### PR TITLE
Generalize calendar filter

### DIFF
--- a/components/Calendar.vue
+++ b/components/Calendar.vue
@@ -38,10 +38,7 @@ export default {
         )
         .then(({ data }) => {
           this.calendar = data.items.filter(
-            item =>
-              item.summary &&
-              item.summary !== 'Westside Hack Night' &&
-              item.summary !== 'DTLA Hack Night'
+            item => item.summary && item.summary.indexOf('Hack Night') < 0
           );
         });
     },


### PR DESCRIPTION
This change removes not only regular Hack Night events, but also the canceled events that have been showing up recently.

Closes #10, but I will point out that this change is *slightly* more general than what was called for in that issue. Happy to adjust if needed.