### PR TITLE
fixed issue #83

### DIFF
--- a/_includes/press.html
+++ b/_includes/press.html
@@ -15,7 +15,7 @@
           <div class="news-card-inner">
             <div class="news-body">
               <h4 class="news-title">
-                <a href="{{ item.url }}">{{ item.title }}</a>
+                <a href="{{ item.link_url }}">{{ item.title }}</a>
               </h4>
               <p>{{ item.source }}</p>
             </div>

--- a/_press/cnn.md
+++ b/_press/cnn.md
@@ -1,5 +1,5 @@
 ---
 source: CNN
 title: Why LA’s Tech Community is Trying to Hack Hunger
-url: http://money.cnn.com/2017/04/19/technology/la-food-deserts/
+link_url: http://money.cnn.com/2017/04/19/technology/la-food-deserts/
 ---

--- a/_press/gov_tech.md
+++ b/_press/gov_tech.md
@@ -1,5 +1,5 @@
 ---
 source: GovTech
 title: March 4 Declared “Open Data Day” in Los Angeles
-url: http://www.govtech.com/dc/articles/March-4-Declared-Open-Data-Day-in-Los-Angeles-Cities-Worldwide.html
+link_url: http://www.govtech.com/dc/articles/March-4-Declared-Open-Data-Day-in-Los-Angeles-Cities-Worldwide.html
 ---

--- a/_press/la_times.md
+++ b/_press/la_times.md
@@ -1,5 +1,5 @@
 ---
 source: LA Times
 title: At L.A. 'hackathon,' civic-minded coders aim to put city data to good use
-url: http://www.latimes.com/local/california/la-me-hackathon-20150607-story.html
+link_url: http://www.latimes.com/local/california/la-me-hackathon-20150607-story.html
 ---


### PR DESCRIPTION
fixes issue where links are being defaulted to site.url if you use the keyword "url" as a variable in the markdown frontmatter.