### PR TITLE
Fix scss variable for absolute_url

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -2,6 +2,6 @@
 ---
 
 // define the absolute_url for use in image includes
-$absolute_url: "{{ absolute_url }}";
+$absolute_url: "{{ site.url }}";
 
-@import 'main';
+@import "main";


### PR DESCRIPTION
I tested this on my gh-pages build and it worked when using `site.url`. 
I also assume that `absolute_url` filter will only work when piped with a value (no proof). 

Closes #88.