### PR TITLE
Code of Conduct

### DIFF
--- a/_layouts/conduct.html
+++ b/_layouts/conduct.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+  {% include head.html %}
+<body>
+  <section id="conduct" class="content-section about">
+      <div class="page-contain">
+    <h2>Hack for LA's Code of Conduct</h2>
+    <p>This document is forked from the <a href="https://github.com/codeforamerica/codeofconduct">The Code for America
+        Code of Conduct</a>.</p>
+    <p>Hack for LA expects that all network activities, events, and digital forums:</p>
+    <ol>
+      <li>Are a safe and respectful environment for all participants.</li>
+      <li>Are a place where people are free to fully express their identities.</li>
+      <li>Presume the value of others. Everyone’s ideas, skills, and contributions have value.</li>
+      <li>Don’t assume everyone has the same context, and encourage questions.</li>
+      <li>Find a way for people to be productive with their skills (technical and not) and energy. Use language such as
+        “yes/and”, not “no/but.”</li>
+      <li>Encourage members and participants to listen as much as they speak.</li>
+      <li>Strive to build tools that are open and free technology for public use. Activities that aim to foster public
+        use, not private gain, are prioritized.</li>
+      <li>Prioritize access for and input from those who are traditionally excluded from the civic process.</li>
+      <li>Work to ensure that the community is well-represented in the planning, design, and implementation of civic
+        tech.
+        This includes encouraging participation from women, minorities, and traditionally marginalized groups.</li>
+      <li>Actively involve community groups and those with subject matter expertise in the decision-making process.</li>
+      <li>Ensure that the relationships and conversations between community members, the local government staff and
+        community partners remain respectful, participatory, and productive.</li>
+      <li>Provide an environment where people are free from discrimination or harassment.</li>
+    </ol>
+    <p>Hack for LA reserves the right to ask anyone in violation of these policies not to participate in Hack for LA
+      network activities, events, and digital forums.</p>
+    <h2>Hack for LA's Anti-Harassment Policy</h2>
+    <p>This anti-harassment policy is based on <a
+        href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy" rel="nofollow">the example
+        policy</a>
+      from the Geek Feminism wiki, created by the Ada Initiative and other volunteers.</p>
+    <p>This policy is based on several other policies, including the Ohio LinuxFest anti-harassment policy, written by
+      Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah
+      Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek
+      Feminism and other groups contributed to this work.</p>
+    <hr>
+    <p>All Hack for LA network activities, events, and digital forums and their staff, presenters, and participants are
+      held to an anti-harassment policy, included below.</p>
+    <p>In addition to governing our own events by this policy, Hack for LA will only lend our brand and fund groups that
+      offer an anti-harassment policy to their attendees. For information on how to offer an anti-harassment policy to
+      your group, <a
+        href="https://docs.google.com/a/codeforamerica.org/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/edit%22"
+        rel="nofollow">see this guide</a>.</p>
+    <p>Hack for LA is dedicated to providing a harassment-free experience for everyone regardless of gender, gender
+      identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion.
+      We
+      do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not
+      appropriate for any Hack for LA event or network activity, including talks. Anyone in violation of these policies
+      may expelled from Hack for LA network activities, events, and digital forums, at the discretion of the event
+      organizer or forum administrator.</p>
+    <p>Harassment includes but is not limited to: offensive verbal or written comments related to gender, gender
+      identity
+      and expression, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in
+      public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained
+      disruption of talks or other events; inappropriate physical contact; unwelcome sexual attention; unwarranted
+      exclusion; and patronizing language or action.</p>
+    <p>If a participant engages in harassing behavior, the organizers may take any action they deem appropriate,
+      including
+      warning the offender or expulsion from Hack for LA network activities, events, and digital forums.</p>
+    <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact
+      a
+      member of the event staff or forum administrator immediately. Event staff or forum administrators will be happy to
+      help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist
+      those
+      experiencing harassment to feel safe for the duration of the event.</p>
+    <p>If you cannot reach an event organizer or forum administrator and/or it is an emergency, please call 911 and/or
+      remove yourself from the situation.</p>
+    <p>You can also contact Hack for LA about harassment at <a href="mailto:info@hackforla.org">info@hackforla.org</a>
+      and
+      feel free to use the email template below. Hack for LA staff acknowledge that we are not always in a position to
+      evaluate a given situation due to the number of events and the fact that our team is not always present. However,
+      we
+      are hopeful that by providing these guidelines we are establishing a community that jointly adheres to these
+      values
+      and can provide an environment that is welcoming to all.</p>
+    <p>We value your attendance and hope that by communicating these expectations widely we can all enjoy a
+      harassment-free environment.</p>
+    <a href="http://hackforla-slack.herokuapp.com" rel="nofollow" class="btn btn-primary">Accept</a>
+    <a href="https://www.hackforla.org/" class="btn btn-primary">Decline</a>
+  </div>
+  </section>
+</body>
+
+</html>

--- a/conduct.md
+++ b/conduct.md
@@ -1,5 +1,4 @@
 ---
-layout: redirect
+layout: conduct
 permalink: /conduct/
-redirect_to: https://github.com/hackforla/codeofconduct
 ---


### PR DESCRIPTION
Fixes #110 

I translated the Code of Conduct repo to HTML. Currently we are using the same CSS from the About component. We may need to update the name of the CSS to reflect the two pages.