### PR TITLE
Performance Update

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,5 +17,4 @@
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | absolute_url }}" />
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
   <link rel="shortcut icon" type="image/x-icon" href="{{ 'favicon.ico' | absolute_url }}" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.js"></script>
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,7 @@
       {{ content }}
     </main>
     {%- include footer.html -%}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.js"></script>
     <script src="{{ '/assets/js/api-actionnetwork.js' | absolute_url }}"></script>
     <script src="{{ '/assets/js/api-calendar.js' | absolute_url }}"></script>
   </div>


### PR DESCRIPTION
closing issue#117

I removed the babel import from the head html and moved it to the bottom of the body in default. There are no async tags, so babel should be imported before either js file runs. Tested locally on Chromium and Firefox.

Before:
![Screenshot from 2019-06-05 19-44-50](https://user-images.githubusercontent.com/25378061/59003592-7b677780-87cb-11e9-9057-ed0f15f7de0a.png)
After:
![Screenshot from 2019-06-05 19-45-51](https://user-images.githubusercontent.com/25378061/59003600-7f939500-87cb-11e9-89a7-87f46ee397e8.png)
