### PR TITLE
Jobs For Hope Url Change

### DIFF
--- a/_projects/jobs-for-hope.md
+++ b/_projects/jobs-for-hope.md
@@ -7,7 +7,7 @@ links:
   - name: Github
     url: 'https://github.com/hackforla/jobs-for-hope'
   - name: Site
-    url: 'https://jobsforhope.digitalservice.la/'
+    url: 'https://jobs-for-hope.herokuapp.com/'
 # looking: No one currently
 location: Downtown LA
 partner: LA County Homeless Initiative; http://homeless.lacounty.gov


### PR DESCRIPTION
Fixes #127 
Updated the URL for Jobs for Hope to point to the deployed app.