### PR TITLE
Improvements to hack night description; "meetups" in main nav

### DIFF
--- a/_includes/hack-nights.html
+++ b/_includes/hack-nights.html
@@ -1,11 +1,11 @@
 <section id="hack-nights" class="content-section section-hack-nights">
     <div class="page-contain">
-        <h2>Meetups - Every Monday &amp; Tuesday</h2>
+        <h2>Hack Nights - Every Monday &amp; Tuesday</h2>
         <p>We host weekly Meetups in Downtown Los Angeles and Santa Monica. At these events, we help groups of
             volunteers organize themselves into project teams to build technology addressing the LA region’s biggest civic issues. </p>
         <p>Come to a meetup to:</p>
             <ul>
-                <li>Meet project team members and learn about projects from live human beings. (Project team members also coordinate their work on our <a href="https://www.hackforlat.org/slack">Slack</a> team &ndash; which is a great place to start if you're not able to get to the next meetup.)</li>
+                <li>Meet project team members and learn about projects from live human beings. (Project team members also coordinate their work on our <a href="https://www.hackforla.org/slack">Slack</a> team &ndash; which is a great place to start if you're not able to get to the next meetup.)</li>
                 <li>Learn! Hone a new skill on a real-world project, or attend one of our tech talks.</li>
                 <li>Join an inclusive, diverse community who are driven to make LA better. Just like you!</li>
             </ul>

--- a/_includes/hack-nights.html
+++ b/_includes/hack-nights.html
@@ -1,10 +1,15 @@
 <section id="hack-nights" class="content-section section-hack-nights">
     <div class="page-contain">
-        <h2>Hack Nights - Every Monday &amp; Tuesday</h2>
-        <p>We host weekly Hack Nights in Downtown Los Angeles and Santa Monica. At these events, we organize groups of
-            volunteers to build technology addressing the LA region’s biggest civic issues. Each night offers an
-            inclusive, diverse community, and everyone is welcome. Join an existing project team or pitch your own civic
-            issue.</p>
+        <h2>Meetups - Every Monday &amp; Tuesday</h2>
+        <p>We host weekly Meetups in Downtown Los Angeles and Santa Monica. At these events, we help groups of
+            volunteers organize themselves into project teams to build technology addressing the LA region’s biggest civic issues. </p>
+        <p>Come to a meetup to:</p>
+            <ul>
+                <li>Meet project team members and learn about projects from live human beings. (Project team members also coordinate their work on our <a href="https://www.hackforlat.org/slack">Slack</a> team &ndash; which is a great place to start if you're not able to get to the next meetup.)</li>
+                <li>Learn! Hone a new skill on a real-world project, or attend one of our tech talks.</li>
+                <li>Join an inclusive, diverse community who are driven to make LA better. Just like you!</li>
+            </ul>
+        <p>Everyone is welcome. Show up and we will find a way for you to be useful, no matter what skills you have.</p>
         <div class="locations">
             {%- assign hacknights = site.hack-nights | sort: 'ordinal' -%}
             {%- for item in hacknights -%}


### PR DESCRIPTION
I felt "Hack nights" verbiage was too prominent, given our many discussions about the word "hack" being a confusing description of what we do. So...
- I added more description (hopefully more welcoming) to the "Meetups" section at the top of the site
- I replaced "Hack nights" in the section heading for hack night info with "Meetups"
- (I incorrectly stated before that I changed the main nav - that's not in here.)

**Best make sure I edited the right file :)**