### PR TITLE
Adds project 'status' category to project-specific markdown page

### DIFF
--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -11,4 +11,5 @@ links:
 looking: TBD
 location: Downtown LA
 partner: EmpowerLA
+status: Active
 ---

--- a/_projects/adopt-civic-art.md
+++ b/_projects/adopt-civic-art.md
@@ -11,4 +11,5 @@ links:
 # looking: 
 location: Downtown LA
 partner: County of Los Angeles
+status: On Hold
 ---

--- a/_projects/criminal-sentencing.md
+++ b/_projects/criminal-sentencing.md
@@ -11,4 +11,5 @@ links:
 # looking: Great communicators and researchers!
 location: Downtown LA
 # partner: 
+status: On Hold
 ---

--- a/_projects/curbmap.md
+++ b/_projects/curbmap.md
@@ -12,4 +12,5 @@ looking: UX designers, UX researchers, UI designers
 location: Downtown LA
 hide: true
 # partner: 
+status: On Hold
 ---

--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -12,4 +12,5 @@ looking: NLP engineers, Django developers (API), React developers, UX designers,
       anyone else...
 location: Santa Monica
 partner: City of Santa Monica
+status: Active
 ---

--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -11,4 +11,5 @@ links:
 # looking: 
 # location: 
 partner: Youth Policy Institute
+status: Rebooting
 ---

--- a/_projects/heart.md
+++ b/_projects/heart.md
@@ -10,5 +10,6 @@ links:
     url: 'https://hackforla.slack.com/messages/CDWKEBYBB'
 looking: experienced full-stack developer, node.js, react
 partner: LA City Attorney’s Homeless Engagement and Response Team
+status: Active
 ---
 

--- a/_projects/hellogov.md
+++ b/_projects/hellogov.md
@@ -11,4 +11,5 @@ links:
 looking: Angular skills or willing to learn, Node, JS, visual designers, dev-ops.
 location: Santa Monica
 partner: Digital Defense Fund
+status: Active
 ---

--- a/_projects/jobs-for-hope.md
+++ b/_projects/jobs-for-hope.md
@@ -11,4 +11,5 @@ links:
 # looking: No one currently
 location: Downtown LA
 partner: LA County Homeless Initiative; http://homeless.lacounty.gov
+status: Active
 ---

--- a/_projects/light-the-way.md
+++ b/_projects/light-the-way.md
@@ -12,4 +12,5 @@ looking: Front-end Developers, UX Designers
 location: Downtown LA
 hide: true
 # partner: 
+status: On Hold
 ---

--- a/_projects/metro-ontime.md
+++ b/_projects/metro-ontime.md
@@ -11,6 +11,7 @@ links:
 looking: Frontend Developers (React, D3), Backend Developers (Python, Pandas)
 location: Downtown LA
 partner: LA Metro (https://www.metro.net/)
+status: Active
 ---
 
 

--- a/_projects/not-today.md
+++ b/_projects/not-today.md
@@ -11,4 +11,5 @@ links:
 looking: Flutter, Mobile Development UI/UX, Empathy and sensitivity with subject material and end users.
 location: Santa Monica
 partner: Seeking
+status: Active
 ---

--- a/_projects/public-tree-map.md
+++ b/_projects/public-tree-map.md
@@ -15,4 +15,5 @@ links:
 looking: Front-end web development (JS, leaflet), project management, appreciation for trees.
 location: Santa Monica
 partner: City of Santa Monica
+status: Active
 ---

--- a/_projects/shared-housing-project.md
+++ b/_projects/shared-housing-project.md
@@ -11,4 +11,5 @@ links:
 looking: project management, product management, design-thinking, user research, user interviews, UX design, UI design, front & back-end web development, scrum / agile project management & product delivery
 location: Downtown LA
 # partner:
+status: Active
 ---

--- a/_projects/spare.md
+++ b/_projects/spare.md
@@ -11,4 +11,5 @@ links:
 looking: Front-end development, Back-end development, Product Management, and Marketing.
 location: Santa Monica
 partner: Hope of the Valley and hopefully others in the near future.
+status: On Hold
 ---

--- a/_projects/tdm-calculator.md
+++ b/_projects/tdm-calculator.md
@@ -11,4 +11,5 @@ links:
 # looking: 
 location: Downtown LA
 partner: LA Department of Transportation LADOT (https://ladot.lacity.org/)
+status: On Hold
 ---

--- a/_projects/work-for-la.md
+++ b/_projects/work-for-la.md
@@ -11,4 +11,5 @@ links:
 looking: UX, Writers, Designers
 location: Downtown LA
 partner: Department of Personnel
+status: Completed
 ---


### PR DESCRIPTION
Addresses action item #1 in Issue #160: "Add status to Project Cards (also a task for Issue #159 )"
