### PR TITLE
Add "identification" field to relevant projects

### DIFF
--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -1,4 +1,5 @@
 ---
+identification: '190321758'
 title: 311 Data
 description: The 311 Data project seeks to empower local Neighborhood Councils to improve the ideation and analysis of their initiatives using the wealth of publicly available 311 data.
 image: /assets/images/projects/311.jpg

--- a/_projects/adopt-civic-art.md
+++ b/_projects/adopt-civic-art.md
@@ -1,4 +1,5 @@
 ---
+identification: '84370933'
 title: ArtWatcher
 description: There are thousands of works of public art scattered around the city.  There should be one place to see where they are and how they’re doing. We’re building it.
 image: /assets/images/projects/adopt-civic-art.jpg

--- a/_projects/criminal-sentencing.md
+++ b/_projects/criminal-sentencing.md
@@ -1,4 +1,5 @@
 ---
+identification: '157484926'
 title: Los Angeles Criminal Sentencing Project
 description: Our project's goal is to make all criminal sentences administered in LA county into an open dataset. There is a lot of data about when and where crimes are committed - but none about what sentences are passed down in LA County.
 image: /assets/images/projects/criminal-sentencing.jpg

--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -1,4 +1,5 @@
 ---
+identification: '138791772'
 title: Engage
 description: Engage is a civic participation platform. Currently in beta, Engage makes it easier for residents of Santa Monica, CA to offer their feedback on policy issues that City Council is considering. Engage aims to increase access for community stakeholders who are unable to attend public meetings or may otherwise feel unheard by their local government.
 image: /assets/images/projects/engage.jpg

--- a/_projects/equity-language.md
+++ b/_projects/equity-language.md
@@ -1,4 +1,5 @@
 ---
+identification: '238357606'
 title: Equity Language
 description: Equity is a priority in the City of Los Angeles and we want to improve the language used in websites to be more inclusive (of all communities) while also educating the public about exclusionary language.
 image: /assets/images/projects/equity-language.png

--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -1,4 +1,5 @@
 ---
+identification: '215666884'
 title: Food Oasis
 description: The website is focused on individuals seeking food in Los Angeles who need an up-to-date resource about food pantries and meals. Our mission is to update the existing website, foodoasis.la with a simplified UI and verified data.  Future development goals include creating functionality for referral services that will allow the end user to annotate and update listings through a peer verification system.
 image: /assets/images/projects/food-oasis.jpg

--- a/_projects/heart.md
+++ b/_projects/heart.md
@@ -1,4 +1,5 @@
 ---
+identification: '159286729'
 title: Heart
 description: Heart is a project working directly with the LA City Attorney’s Homeless Engagement and Response Team. The HEART program helps homeless individuals resolve eligible traffic and pedestrian infractions and related warrants and fines by engaging with relevant services. Hack for LA is helping them build a database and case management system to streamline their workflow and enable them to scale their program.
 image: /assets/images/projects/heart.png

--- a/_projects/hellogov.md
+++ b/_projects/hellogov.md
@@ -1,4 +1,5 @@
 ---
+identification: '76137532'
 title: HelloGOV
 description: HelloGOV is helping reproductive rights advocacy organizations connect supporters to their state assembly and state senate representatives for call campaigns. The HelloGOV webapp generates a campaign shortlink that can be used in texts, social posts, and more.
 image: /assets/images/projects/hellogov.jpg

--- a/_projects/jobs-for-hope.md
+++ b/_projects/jobs-for-hope.md
@@ -1,4 +1,5 @@
 ---
+identification: '140512203'
 title: Jobs for Hope
 description: We compiled job listings from 60+ different non-profit organization websites for the LA County Homeless Initiative and consolidated them into a single database so that it is easier for job-seekers to search and filter for jobs.
 image: /assets/images/projects/jobs-for-hope.png

--- a/_projects/metro-ontime.md
+++ b/_projects/metro-ontime.md
@@ -1,4 +1,5 @@
 ---
+identification: '155295655'
 title: Railstats LA
 description: Trailstats LA tracks LA Metro trains and generates punctuality reports. Our website enables both Metro officials and the public to easily review up-to-date statistics for LA's 6 train lines.
 image: /assets/images/projects/metro-time.jpg

--- a/_projects/not-today.md
+++ b/_projects/not-today.md
@@ -1,4 +1,5 @@
 ---
+identification: '202051333'
 title: Not Today - Self-Defense Against Suicidal Thoughts
 description: NotToday is a mobile app for people who suffer from chronic suicidal ideation (thoughts). It allows people to time-shift their desire to live across suicidal/non-suicidal dissociated mental states.
 image: /assets/images/projects/not-today.png

--- a/_projects/public-tree-map.md
+++ b/_projects/public-tree-map.md
@@ -1,4 +1,5 @@
 ---
+identification: '128148093'
 title: Public Tree Map
 description: Public Tree Map documents all ~36,000 public trees in Santa Monica's urban forest. The map includes contextual information compiled from open datasets and digitized city records. To reflect tree plantings and removals, the map updates every day.
 image: /assets/images/projects/public-tree-map.png

--- a/_projects/record-clearance-project.md
+++ b/_projects/record-clearance-project.md
@@ -1,4 +1,5 @@
 ---
+identification: '218391110'
 title: Record Clearance Project
 description: Record Clearance helps people in California with non-violent criminal records accomplish record clearance, expungement or reduction as a result of Prop 47 & Prop 64. The main features include building trust, educating the public about the program and informing those who are eligible for this program.
 image: /assets/images/projects/record-clearance.jpg

--- a/_projects/shared-housing-project.md
+++ b/_projects/shared-housing-project.md
@@ -1,4 +1,5 @@
 ---
+identification: '188127288'
 title: Shared Housing Project
 description: The shared housing team works on creating an efficient & effective solution for matching multiple individuals who experience homelessness as potential co-tenants, and placing the matched individuals in suitable shared housing units.
 image: /assets/images/projects/shared-housing-project.jpg

--- a/_projects/spare.md
+++ b/_projects/spare.md
@@ -1,4 +1,5 @@
 ---
+identification: '127079094'
 title: Spare
 description: A fun new project project that connects people in need of clothing and other essentials with people in the community who have things to spare. It's kind of like one on one Goodwill. The main objective is to foster interactions between the housed and unhoused. The donation is the mechanism for building these connections throughout our community.
 image: /assets/images/projects/spare.png

--- a/_projects/tdm-calculator.md
+++ b/_projects/tdm-calculator.md
@@ -1,4 +1,5 @@
 ---
+identification: '197452459'
 title: LA TDM Calculator
 description: We’re building a TDM web calculator for LADOT. It scores proposed real estate developments in real-time and aims to discourage exceeding parking requirements to reduce the occurrence of single-occupancy trips to new developments.
 image: /assets/images/projects/tdm-calculator.jpg

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -1,4 +1,5 @@
 ---
+identification: '130000551'
 title: hackforla.org website
 description: The hackforla.org website is our organization's way of communicating with new volunteers, stakeholders, and donors. This project is a good place to start for new volunteers looking to polish their git protocol skills (branches, separation of concerns, etc.). We are currently in a redesign phase, using CI/CD in the run up to demoing the new version at Code for America's Summit 2020 in Washington, D.C.
 image: /assets/images/projects/website.png


### PR DESCRIPTION
Add "identification" fields to every project that comes up in github data. Field is not added to those projects that are not in the data. To see where I am getting these id's from, here is a [link](https://github.com/KianBadie/website/blob/github-actions/_data/github-data.json) to a file I have with some github data where you can find the field. The website will be pulling this data on a regular schedule in the future (see [this](https://github.com/hackforla/website/pull/330) pull request for more information on that). This field was needed so that the data we get from github can be identified and used in our website.

Since this issue was raised and made pretty quickly, there is currently no issue relating to this.
Related issues: 
#193 
#157  

Future pull request will need to be made for projects that still need to add/will add their github repository to hackforla using the appropriate tags on their repository.