### PR TITLE
Added leadership information for about half of the currently active projects

### DIFF
--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -4,12 +4,43 @@ title: 311 Data
 description: The 311 Data project seeks to empower local Neighborhood Councils to improve the ideation and analysis of their initiatives using the wealth of publicly available 311 data.
 image: /assets/images/projects/311.jpg
 alt: "image of building with windows that look like they spell out 311"
-links: 
+leadership:
+  - name: John Ritchey
+    role: Product Manager
+    links:
+      slack: 'https://app.slack.com/team/UNFV029Q8'
+      github: 'https://github.com/johnr54321'
+    picture: https://avatars.githubusercontent.com/johnr54321
+  - name: Joyce Lee
+    role: UI/UX Lead
+    links:
+      slack: 'https://hackforla.slack.com/team/UQZ71S04A'
+      github: 'https://github.com/itsjoycelee'
+    picture: https://avatars.githubusercontent.com/itsjoycelee
+  - name: Joshua Marx
+    role: Frontend Lead
+    links:
+      slack: 'https://app.slack.com/team/UG4G54YUD'
+      github: 'https://github.com/brodly'
+    picture: https://avatars.githubusercontent.com/brodly
+  - name: Ryan Swan
+    role: Data Science Lead
+    links:
+      slack: 'https://app.slack.com/team/UPB2FHJCX'
+      github: 'https://github.com/ryanmswan'
+    picture: https://avatars.githubusercontent.com/ryanmswan
+  - name: Russell Tan
+    role: Backend Lead
+    links:
+      slack: 'https://app.slack.com/team/UKBN4RB7G'
+      github: 'https://github.com/sellnat77'
+    picture: https://avatars.githubusercontent.com/sellnat77
+links:
   - name: GitHub
     url: 'https://github.com/hackforla/311-data'
   # - name: Site
   #   url: ''
-looking: 
+looking:
   - TBD
 location: Downtown LA
 partner: EmpowerLA

--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -4,15 +4,28 @@ title: Engage
 description: Engage is a civic participation platform. Currently in beta, Engage makes it easier for residents of Santa Monica, CA to offer their feedback on policy issues that City Council is considering. Engage aims to increase access for community stakeholders who are unable to attend public meetings or may otherwise feel unheard by their local government.
 image: /assets/images/projects/engage.jpg
 alt: "'city council closed in session'"
-links: 
+leadership:
+  - name: Teddy Cripeneau
+    role:
+    links:
+      slack:
+      github: 'https://github.com/TeddyCr'
+    picture: https://avatars.githubusercontent.com/TeddyCr
+  - name: Eli Selkin
+    role:
+    links:
+      slack:
+      github: 'https://github.com/eselkin'
+    picture: https://avatars.githubusercontent.com/eselkin
+links:
   - name: GitHub
     url: 'https://github.com/hackla-engage'
   - name: Site
     url: 'https://sm.engage.town'
-looking: 
-  - NLP engineers 
-  - Django developers (API) 
-  - React developers 
+looking:
+  - NLP engineers
+  - Django developers (API)
+  - React developers
   - UX designers
   - anyone else...
 location: Santa Monica

--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -4,16 +4,53 @@ title: Food Oasis
 description: The website is focused on individuals seeking food in Los Angeles who need an up-to-date resource about food pantries and meals. Our mission is to update the existing website, foodoasis.la with a simplified UI and verified data.  Future development goals include creating functionality for referral services that will allow the end user to annotate and update listings through a peer verification system.
 image: /assets/images/projects/food-oasis.jpg
 alt: "'vegatables beats stacked'"
-links: 
+leadership:
+  - name: Jenny Mikesell
+    role: Product Manager
+    links:
+      slack: 'https://app.slack.com/team/UM4FE6ELQ'
+      github: 'https://github.com/jpmikesell'
+    picture: https://avatars.githubusercontent.com/jpmikesell
+  - name: Tina Moh
+    role: UX/Service Lead
+    links:
+      slack: https://app.slack.com/team/UP4AZM459'
+      github: 'https://github.com/tina-moh'
+    picture: https://avatars.githubusercontent.com/tina-moh
+  - name: John Darragh
+    role: Architect
+    links:
+      slack: 'https://app.slack.com/team/UFLDX9V19'
+      github: 'https://github.com/entrotech'
+    picture: https://avatars.githubusercontent.com/entrotech
+  - name: Lucas Homer
+    role: Sr. Developer
+    links:
+      slack: 'https://app.slack.com/team/UMQ5H55TN'
+      github: 'https://github.com/lucas-homer'
+    picture: https://avatars.githubusercontent.com/lucas-homer
+  - name: Gaby Cohen
+    role:
+    links:
+      slack: 'https://app.slack.com/team/UQG8PEXPX'
+      github: 'https://github.com/gcohen02'
+    picture: https://avatars.githubusercontent.com/gcohen02
+  - name: Steven Ettinger
+    role: Blockchain Developer
+    links:
+      slack: 'https://app.slack.com/team/UNFG6M8FN'
+      github: 'https://github.com/disregardfiat'
+    picture: https://avatars.githubusercontent.com/disregardfiat
+links:
   - name: GitHub
     url: 'https://github.com/foodoasisla'
   - name: Site
     url: 'https://foodoasis.la/'
   - name: Read.me
     url: 'https://github.com/hackforla/food-oasis/blob/master/README.md'
-looking: 
-  - Project Management 
-  - Junior Python developers (2) 
+looking:
+  - Project Management
+  - Junior Python developers (2)
   - documentarian (UX) - specifically someone to help with the wiki for onboarding and communicating to stake holders what the project is about
 location: Downtown LA
 tools: figma, photoshop, sketch, pencil and paper, phone calls.

--- a/_projects/metro-ontime.md
+++ b/_projects/metro-ontime.md
@@ -4,7 +4,14 @@ title: Railstats LA
 description: Trailstats LA tracks LA Metro trains and generates punctuality reports. Our website enables both Metro officials and the public to easily review up-to-date statistics for LA's 6 train lines.
 image: /assets/images/projects/metro-time.jpg
 alt: "'metro ontime'"
-links: 
+leadership:
+  - name: Cameron Sexton
+    role: Product Owner/Lead Developer
+    links:
+      slack: 'https://app.slack.com/team/UBENYBXGV'
+      github: 'https://github.com/ctsexton'
+    picture: https://avatars.githubusercontent.com/ctsexton
+links:
   - name: GitHub
     url: 'https://github.com/metro-ontime'
   - name: Site
@@ -13,8 +20,8 @@ links:
     url: 'https://www.metro.net/'
   - name: Observable
     url: 'https://observablehq.com/@ctsexton/railstats-marey-diagram'
-looking: 
-  - Application Developers (Javascript, Node, React, D3) 
+looking:
+  - Application Developers (Javascript, Node, React, D3)
   - Data Engineers (Python, Pandas, GIS)
 partner: LA Metro (https://www.metro.net/)
 location: Downtown LA

--- a/_projects/tdm-calculator.md
+++ b/_projects/tdm-calculator.md
@@ -4,12 +4,37 @@ title: LA TDM Calculator
 description: We’re building a TDM web calculator for LADOT. It scores proposed real estate developments in real-time and aims to discourage exceeding parking requirements to reduce the occurrence of single-occupancy trips to new developments.
 image: /assets/images/projects/tdm-calculator.jpg
 alt: "'LA TDM Calculator Landing Page (Mock Up)'"
-links: 
+leadership:
+  - name: Kevin Howley
+    role: Project Manager
+    links:
+      slack: 'https://app.slack.com/team/UL53VUVPZ'
+      github: 'https://github.com/kphowley'
+    picture: https://avatars.githubusercontent.com/kphowley
+  - name: John Darragh
+    role: Architect
+    links:
+      slack: 'https://app.slack.com/team/UFLDX9V19'
+      github: 'https://github.com/entrotech'
+    picture: https://avatars.githubusercontent.com/entrotech
+  - name: Fang Liu
+    role: Backend Lead
+    links:
+      slack: 'https://hackforla.slack.com/team/UCE01B4AX'
+      github: 'https://github.com/fyliu'
+    picture: https://avatars.githubusercontent.com/fyliu
+  - name: Nicole Doan
+    role: Backend UI/UX Lead
+    links:
+      slack: 'https://hackforla.slack.com/team/UBPKHJJVC'
+      github: 'https://github.com/nekobox'
+    picture: https://avatars.githubusercontent.com/nekobox
+links:
   - name: GitHub
     url: 'https://github.com/orgs/hackforla/teams/tdm-calculator'
   #- name: Site
   #  url: 'https://www.google.com/'
-# looking: 
+# looking:
 location: Downtown LA
 partner: LA Department of Transportation LADOT (https://ladot.lacity.org/)
 status: Active

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -4,13 +4,36 @@ title: hackforla.org website
 description: The hackforla.org website is our organization's way of communicating with new volunteers, stakeholders, and donors. This project is a good place to start for new volunteers looking to polish their git protocol skills (branches, separation of concerns, etc.). We are currently in a redesign phase, using CI/CD in the run up to demoing the new version at Code for America's Summit 2020 in Washington, D.C.
 image: /assets/images/projects/website.png
 alt: "wireframe sample from new website"
+leadership:
+  - name: Bonnie Wolfe
+    role: Product Owner & Tech Lead
+    links:
+      slack: 'https://hackforla.slack.com/team/UE1UG1YFP'
+      github: 'https://github.com/ExperimentsInHonesty'
+    picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
+  - name: Harish Lingam
+    role: Product Manager
+    links:
+      slack: 'https://hackforla.slack.com/team/ULYUA6MNF'
+      github: 'https://github.com/harishlingam'
+    picture: https://avatars.githubusercontent.com/harishlingam
+  - name: Kian Badie
+    role: Frontend Lead
+    links:
+      slack: 'https://hackforla.slack.com/team/ULYUA6MNF'
+      github: 'https://github.com/KianBadie'
+    picture: https://avatars.githubusercontent.com/KianBadie
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/website'
   - name: Site
     url: 'https://www.hackforla.org'
-looking: UI (wireframes), Photoshop, junior JavaScript developers, anyone wanting to learn how to do Git commits in a collaborative work environment
+looking:
+  - UI (wireframes)
+  - Photoshop
+  - Junior JavaScript developers
+  - anyone wanting to learn how to do Git commits in a collaborative work environment
 location: Santa Monica, Downtown and Remote
-partner: N/A
+# partner: N/A
 status: Active
 ---


### PR DESCRIPTION
When this is merged the following urls will have leadership information: 

https://www.hackforla.org/projects/311-data.html
https://www.hackforla.org/projects/engage.html
https://www.hackforla.org/projects/food-oasis.html
https://www.hackforla.org/projects/metro-ontime.html
https://www.hackforla.org/projects/tdm-calculator.html
https://www.hackforla.org/projects/website.html

