### PR TITLE
OpenGraph tags for project pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ source: .
 
 title: Hack for LA
 email: hello@hackforla.org
-description: Hack for LA's website!
+description: Can you design, write, or code? Are you an activist with an idea? You can help Los Angeles live up to its potential at Hack for LA. Everyone is welcome!
 
 baseurl: ""
 url: https://www.hackforla.org

--- a/_data/navigation/main.yml
+++ b/_data/navigation/main.yml
@@ -1,24 +1,24 @@
 - name: Hack Nights
-  link: "#hack-nights"
+  link: "/#hack-nights"
   list_class_name:
   icon: /svg/icon-hacknights.svg
 
 - name: Projects
-  link: "#projects"
+  link: "/#projects"
   list_class_name:
   icon: /svg/icon-projects.svg
 
 - name: Press
-  link: "#press"
+  link: "/#press"
   list_class_name:
   icon: /svg/icon-press.svg
 
 - name: About
-  link: "#about"
+  link: "/#about"
   list_class_name:
   icon: /svg/icon-about.svg
 
 - name: Contact Us
-  link: "#contact"
+  link: "/#contact"
   list_class_name: hide-mobile
   icon:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,16 +4,13 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge" />
   <meta property="og:url" content="{{ page.url | absolute_url }}" />
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Hack for LA" />
-  <meta property="og:description" content="Can you design, write, or code? Are you an activist with an idea? You can help Los Angeles live up to its potential at Hack for LA. Everyone is welcome!" />
-  <meta property="og:image" content="{{'/assets/images/logos/hfla_fb_logo.png' | absolute_url }}" />
-  {% if page.title %} <meta property="og:title" content="{{page.title}}" /> 
-  {% else %} <meta property="og:title" content="{{site.title}}" /> 
-  {% endif %}
-  
-  <title> {% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape}}</title>
+  <meta property="og:title" content="{% if page.title %}{{ page.title | escape }} by {% endif %}{{ site.title | escape}}" />
+  <meta property="og:description" content="{% if page.description %}{{ page.description | strip_html strip_newlines | truncate: 400 }}{% else %}{{ site.description }}{% endif %}" />
+  <meta property="og:image" content="{% if page.image %}{{ page.image | absolute_url }}{% else%}{{'/assets/images/logos/hfla_fb_logo.png' | absolute_url }}{% endif %}" />
+
+  <title>{% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape}}</title>
   <meta name="description"
-    content="{% if page.excerpt %}{{ page.excerpt | strip_html strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}" />
+    content="{% if page.description %}{{ page.description | strip_html strip_newlines | truncate: 400 }}{% else %}{{ site.description }}{% endif %}" />
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | absolute_url }}" />
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
   <link rel="shortcut icon" type="image/x-icon" href="{{ 'favicon.ico' | absolute_url }}" />

--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -2,7 +2,7 @@
 <li class="project-card">
   <div class="project-card-inner">
     <div class="project-tmb">
-      <img src={{ project.image | absolute_url }} class="project-tmb-img" alt={{project.alt}}/>
+      <img src="{{ project.image | absolute_url }}" class="project-tmb-img" alt={{project.alt}}/>
     </div>
     <div class="project-body">
       <div class='status-indicator {{ "status-" | append: project.status }}'>


### PR DESCRIPTION
Fixes #352 

This is a quick and dirty version reusing project's title, description, and card image for the OpenGraph data.