### PR TITLE
Make hfla logo link to home

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,11 @@
 <header class="main-header">
   <div class="main-header-content">
-    <div class="branding">
-      <div class="sr-only">Hack for LA</div>
-      {% include svg/logo-hfla.svg %}
-    </div>
+    <a href="/#">
+      <div class="branding">
+        <div class="sr-only">Hack for LA</div>
+        {% include svg/logo-hfla.svg %}
+      </div>
+    </a>
     {% include main-nav.html %} {% include social.html %}
   </div>
 </header>


### PR DESCRIPTION
This will work on the project home page and the regular homepage itself. I avoided adding code to _data/navigation/main and _data/navigation/social (which contains different routes for links) because other code in the project loops over them to create html elements. I wanted to avoid unforeseen changes and create an unwanted html element. However, I did not test it.

I do not think there was an issue for this. This was a dependency for implementing the project home page in issue #157 that came about during a meeting with @ExperimentsInHonesty. 
Related issues:
#157 