### PR TITLE
Add access to project home page through current projects page.

### DIFF
--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -1,14 +1,16 @@
 {% assign project = include.project %}
 <li class="project-card">
   <div class="project-card-inner">
-    <div class="project-tmb">
-      <img src="{{ project.image | absolute_url }}" class="project-tmb-img" alt={{project.alt}}/>
-    </div>
+    <a href='{{ project.url }}'>
+      <div class="project-tmb">
+        <img src="{{ project.image | absolute_url }}" class="project-tmb-img" alt={{project.alt}}/>
+      </div>
+    </a>
     <div class="project-body">
       <div class='status-indicator {{ "status-" | append: project.status }}'>
         <h5 class='status-text'>{{ project.status }}</h5>
       </div>
-      <h4 class="project-title">{{ project.title }}</h4>
+      <a href="{{ project.url }}"><h4 class="project-title">{{ project.title }}</h4></a>
       <p class="project-description">{{ project.description }}</p>
 
       {%- if project.links -%}


### PR DESCRIPTION
***Creating this ahead of time even though there is no related issue.*** I did this because I wanted to give the option in the scenario that if wanted the pages to go live, there will be a pull request waiting to integrate the functionality.

Adds access to project home page through current project page. Does this by making project pictures and project titles clickable links to their respective pages.