### PR TITLE
Add button to getting started page

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -3,6 +3,6 @@
     <h1>You can change LA for the better!</h1>
     <p class="type-featured">Can you design, write, or code? Are you an activist with an idea? You can help Los Angeles
       live up to its potential at Hack for LA. Everyone is welcome!</p>
-    {% include forms/hero-signup.html %}
+      {% comment %} {% include forms/hero-signup.html %} {% endcomment %}
   </div>
 </header>

--- a/_includes/home-getting-started.html
+++ b/_includes/home-getting-started.html
@@ -1,3 +1,3 @@
 <div class='home-getting-started-container content-section section-hack-nights'>
-    <button class='home-getting-started btn btn-primary'>Getting Started</button>
+    <a href='./getting-started-page'><button class='home-getting-started btn btn-primary'>Getting Started</button></a>
 </div>

--- a/_includes/home-getting-started.html
+++ b/_includes/home-getting-started.html
@@ -1,3 +1,3 @@
 <div class='home-getting-started-container content-section section-hack-nights'>
-    <a href='./getting-started-page'><button class='home-getting-started btn btn-primary'>Getting Started</button></a>
+    <a href='./getting-started'><button class='home-getting-started btn btn-primary'>Getting Started</button></a>
 </div>

--- a/_includes/home-getting-started.html
+++ b/_includes/home-getting-started.html
@@ -1,0 +1,3 @@
+<div class='home-getting-started-container content-section section-hack-nights'>
+    <button class='home-getting-started btn btn-primary'>Getting Started</button>
+</div>

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -40,6 +40,7 @@
 @import 'components/press';
 @import 'components/projects';
 @import 'components/social-links';
+@import 'components/home-getting-started';
 
 // /**
 //  * Layouts

--- a/_sass/components/_home-getting-started.scss
+++ b/_sass/components/_home-getting-started.scss
@@ -1,0 +1,10 @@
+.home-getting-started-container {
+    text-align: center;
+}
+
+.home-getting-started {
+    width: 300px;
+    height: 75px;
+    border-radius: 100px;
+    font-size: 25px;
+}

--- a/index.html
+++ b/index.html
@@ -1,8 +1,16 @@
 ---
 ---
-{%- include hero.html -%}
+<!-- {%- include hero.html -%}
 {%- include hack-nights.html -%}
 {%- include calendar.html -%}
+{%- include current-projects.html -%}
+{%- include press.html -%}
+{%- include about.html -%}
+{%- include forms/contact-us.html -%}
+{%- include sponsors.html -%} -->
+
+{%- include hero.html -%}
+{%- include home-getting-started.html -%}
 {%- include current-projects.html -%}
 {%- include press.html -%}
 {%- include about.html -%}

--- a/index.html
+++ b/index.html
@@ -1,18 +1,21 @@
 ---
 ---
-<!-- {%- include hero.html -%}
-{%- include hack-nights.html -%}
-{%- include calendar.html -%}
-{%- include current-projects.html -%}
-{%- include press.html -%}
-{%- include about.html -%}
-{%- include forms/contact-us.html -%}
-{%- include sponsors.html -%} -->
-
-{%- include hero.html -%}
-{%- include home-getting-started.html -%}
-{%- include current-projects.html -%}
-{%- include press.html -%}
-{%- include about.html -%}
-{%- include forms/contact-us.html -%}
-{%- include sponsors.html -%}
+{% assign remote-only = 'true' %}
+{% if remote-only == 'false' %}
+    {%- include hero.html -%}
+    {%- include hack-nights.html -%}
+    {%- include calendar.html -%}
+    {%- include current-projects.html -%}
+    {%- include press.html -%}
+    {%- include about.html -%}
+    {%- include forms/contact-us.html -%}
+    {%- include sponsors.html -%}
+{% else %}
+    {%- include hero.html -%}
+    {%- include home-getting-started.html -%}
+    {%- include current-projects.html -%}
+    {%- include press.html -%}
+    {%- include about.html -%}
+    {%- include forms/contact-us.html -%}
+    {%- include sponsors.html -%}
+{% endif %}


### PR DESCRIPTION
Removes hack nights section, sign up section in hero, and calendar. Adds button under hero section to the getting started page. To toggle between these two differences, set "remote-only" to true or false. The sign up section in the hero will be commented out on both options.
Related issues: 
#368 