### PR TITLE
Revert "Getting Started Page: Make width auto on mobile for images"

### DIFF
--- a/_sass/components/getting-started-page.scss
+++ b/_sass/components/getting-started-page.scss
@@ -35,12 +35,3 @@
     justify-content: space-evenly;
     flex-wrap: wrap
 }
-
-.zoom-img {
-    width: 320px;
-
-    // NEW MOBILE FRIENDLY RULES
-    @media #{$bp-below-mobile} {
-        width: auto;
-    }
-}

--- a/getting-started.html
+++ b/getting-started.html
@@ -45,8 +45,8 @@ layout: default
                 <li>Ask questions in the Zoom chat, or raise your hand to signal the host.</li>
                 <p><br>To raise your hand in Zoom: (1) Click the Participants button found in the control panel at the bottom of the Zoom window (2) Click “Raise Hand” found at the bottom of the chat window that appears.</p>
                 <div class='zoom-pictures'>
-                    <img class='zoom-img' src='assets/images/getting-started-zoom1.png'>
-                    <img class='zoom-img' src='assets/images/getting-started-zoom2.png'>
+                    <img src='assets/images/getting-started-zoom1.png' width='320'>
+                    <img src='assets/images/getting-started-zoom2.png' width='320'>
                 </div>
             </ol>
         </div>


### PR DESCRIPTION
Reverts hackforla/website#378

The hotfix did not work. The emulator on dev tools shows a better looking version than on actual mobile devices (even when emulating the same device), so it is hard to test without merging. For now, I am just going to try to remove the images on mobile.