### PR TITLE
Remove images on Getting Started page on mobile

### DIFF
--- a/_sass/components/getting-started-page.scss
+++ b/_sass/components/getting-started-page.scss
@@ -35,3 +35,12 @@
     justify-content: space-evenly;
     flex-wrap: wrap
 }
+
+.zoom-img {
+    width: 320px;
+
+    // NEW MOBILE FRIENDLY RULES
+    @media #{$bp-below-mobile} {
+        width: auto;
+    }
+}

--- a/_sass/components/getting-started-page.scss
+++ b/_sass/components/getting-started-page.scss
@@ -33,7 +33,12 @@
 .zoom-pictures {
     display: flex;
     justify-content: space-evenly;
-    flex-wrap: wrap
+    flex-wrap: wrap;
+
+    // NEW MOBILE FRIENDLY RULES
+    @media #{$bp-below-mobile} {
+        display: none;
+    }
 }
 
 .zoom-img {

--- a/getting-started.html
+++ b/getting-started.html
@@ -45,8 +45,8 @@ layout: default
                 <li>Ask questions in the Zoom chat, or raise your hand to signal the host.</li>
                 <p><br>To raise your hand in Zoom: (1) Click the Participants button found in the control panel at the bottom of the Zoom window (2) Click “Raise Hand” found at the bottom of the chat window that appears.</p>
                 <div class='zoom-pictures'>
-                    <img src='assets/images/getting-started-zoom1.png' width='320'>
-                    <img src='assets/images/getting-started-zoom2.png' width='320'>
+                    <img class='zoom-img' src='assets/images/getting-started-zoom1.png'>
+                    <img class='zoom-img' src='assets/images/getting-started-zoom2.png'>
                 </div>
             </ol>
         </div>


### PR DESCRIPTION
The images were distorted and I could not figure out why. Using an emulator through Chrome dev tools did not reflect actual mobile devices (even when emulating the same device). So the only way to test changes was to push and merge to the master branch (which could take an unpredictable amount of merges and reverts). For now, I decided to just remove them on mobile.