### PR TITLE
logos have been centered

### DIFF
--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -45,9 +45,11 @@
     img {
       display: block;
       height: 50px;
+      margin: 10px 80px;
 
       @media #{$bp-mobile-up} {
         height: 70px;
+        margin: 10px;
       }
     }
   }

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -32,6 +32,7 @@
       &:link,
       &:visited {
         color: $color-black;
+        margin: -4px;
       }
 
       &:hover,
@@ -43,7 +44,7 @@
   }
 
   .branding {
-    @include position(absolute, -20px null null -20px);
+    @include position(absolute, -23px null null -23px);
 
     @media #{$bp-tablet-up} {
       left: -20px;

--- a/_sass/components/_hero.scss
+++ b/_sass/components/_hero.scss
@@ -4,7 +4,7 @@
   background-size: cover;
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 140vh;
   justify-content: flex-end;
   max-height: 700px;
   min-height: 100vh;
@@ -39,7 +39,7 @@
 
 .hero-inner {
   color: $color-white;
-  margin: 60px auto 40px;
+  margin: 60px auto 0px;
   max-width: $max-content-width;
   position: relative;
   z-index: 2;

--- a/_sass/elements/_lists.scss
+++ b/_sass/elements/_lists.scss
@@ -11,7 +11,7 @@
 
   > li {
     display: inline-block;
-    margin-right: 32px;
+    margin-right: 15px;
 
     &:last-child {
       margin-right: 0;


### PR DESCRIPTION
this fixes #367 I centered the 4 logos on the footer of the page and move the hack for LA logo to cover the small white part of the top left corner. 