### PR TITLE
Add Project Meetings Page

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -42,6 +42,7 @@
 @import 'components/social-links';
 @import 'components/home-getting-started';
 @import 'components/getting-started-page.scss';
+@import 'components/project-meetings.scss';
 
 // /**
 //  * Layouts

--- a/_sass/components/project-meetings.scss
+++ b/_sass/components/project-meetings.scss
@@ -1,0 +1,61 @@
+.calendar-started-page {
+    margin-top: 29px;
+    background: #030d2d;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.calendar-page-card {
+    background: #fff;
+    border: 0 solid rgba(51,51,51,0.06);
+    border-radius: 16px;
+    box-shadow: 0 0 8px 0 rgba(51,51,51,0.2);
+    overflow: hidden;
+    max-width: 896px;
+    width: 100%;
+    margin-bottom: 0;
+    padding: 30px;
+    height: fit-content;
+    margin: 12px auto;
+
+    // NEW MOBILE FRIENDLY RULES
+    @media #{$bp-below-mobile} {
+        padding: 30px 15px;
+    }
+}
+
+.schedule-list {
+    list-style: none;
+    li:before {
+      content: "\2022";
+      color: #fa114f;
+      font-weight: bold;
+      font-size: 28px;
+      display: inline-block;
+      width: 0.60em;
+      margin-left: -0.6em;
+      vertical-align: middle;
+    }
+}
+
+.time-slot-text {
+    vertical-align: text-top;
+    display: inline-block;
+    margin-block-end: 0;
+}
+
+.day-header {
+    margin-block-end: 0.25em;
+}
+
+.team-meetings-title {
+    color: #fff;
+
+    // NEW MOBILE FRIENDLY RULES
+    @media #{$bp-below-mobile} {
+        margin-top: 60px;
+      }
+}

--- a/getting-started.html
+++ b/getting-started.html
@@ -25,6 +25,7 @@ layout: default
             <h4 style='color:#333'>Projects</h4>
             <ol>
                 <li>Review the projects listed in the <a target='_blank' href='/#projects'>projects section</a> to determine which one you would like to know more about.</li>
+                <li>Check the <a href='./project-meetings'>team meeting overview</a>, to see if the team you are interested in meets at a time that fits into your schedule.</li>
                 <li>Click to the project’s home page.</li>
                 <ol>
                     <li>Locate and review the project-specific getting started guide.</li>

--- a/project-meetings.html
+++ b/project-meetings.html
@@ -1,0 +1,66 @@
+---
+layout: default
+---
+<div class='content-section getting-started-page'>
+    <h1 class='team-meetings-title'>Project Team Meetings</h1>
+    <div class='calendar-page-card'>
+        <h3 class='day-header'>Monday</h3>
+        <div>
+            <ul class='schedule-list'>
+                <li><p class='time-slot-text'>5:30-10:30 pm <a href='/projects/lucky-parking'>Lucky Parking</a></p></li>
+                <li><p class='time-slot-text'>6:30-8:30 pm <a href='/projects/hellogov'>HelloGov</a></p></li>
+                <li><p class='time-slot-text'>6:30-6:40 <a href='/projects/not-today'>Not Today</a> (updates)</p></li>
+                <li><p class='time-slot-text'>6:30-8:30 pm <a href='/projects/new-schools-today'>New Schools Today</a></p></li>
+                <li><p class='time-slot-text'>6:30-TBD pm <a href='/projects/public-tree-map'>Public Tree map</a></p></li>
+                <li><p class='time-slot-text'>7:00-9:00 pm <a href='/projects/vrms'>VRMS</a></p></li>
+            </ul>
+        </div>
+        <h3 class='day-header'>Tuesday</h3>
+        <div>
+            <ul class='schedule-list'>
+                <li><p class='time-slot-text'>6:30-7:30 pm <a href='/projects/food-oasis'>Food Oasis</a></p></li>
+                <li><p class='time-slot-text'>7:00-9:00 pm <a href='/projects/311-data'>311 Data</a> team meeting</p></li>
+            </ul>
+        </div>
+        <h3 class='day-header'>Wednesday</h3>
+        <div>
+            <ul class='schedule-list'>
+                <li><p class='time-slot-text'>6:30-9:00 pm <a href='/projects/undebate'>Undebate</a></p></li>
+                <li><p class='time-slot-text'>6-6:45pm IT + hosting + operations working group</p></li>
+                <li><p class='time-slot-text'>6:00-7:00 pm <a href='/projects/engage'>Engage</a></p></li>
+                <li><p class='time-slot-text'>7:00-9:00 pm <a href='/projects/equity-language'>Equity Language</a></p></li>
+                <li><p class='time-slot-text'>7:00-8:30 pm <a href='/projects/tdm-calculator'>TDM Calculator</a></p></li>
+            </ul>
+        </div>
+        <h3 class='day-header'>Thursday</h3>
+        <div>
+            <ul class='schedule-list'>
+                <li><p class='time-slot-text'>7:00-8:00 pm <a href='/projects/311-data'>311 Data</a> management meeting</p></li>
+                <li><p class='time-slot-text'>8:00-10:00 pm CivicTechIndex</p></li>
+                <li><p class='time-slot-text'>8:00-9:00 pm <a href='/projects/food-oasis'>Food Oasis</a></p></li>
+            </ul>
+        </div>
+        <h3 class='day-header'>Friday</h3>
+        <div>
+            <ul class='schedule-list'>
+                <li>No Scheduled Meetings</li>
+            </ul>
+        </div>
+        <h3 class='day-header'>Saturday</h3>
+        <div>
+            <ul class='schedule-list'>
+                <li><p class='time-slot-text'>10:00-12:00 am <a href='/projects/tdm-calculator'>TDM Calculator</a></p></li>
+                <li><p class='time-slot-text'>12:00-2:00 pm Host Homes</p></li>
+                <li><p class='time-slot-text'>2:00-4:00 pm <a href='/projects/new-schools-today'>New Schools Today</a></p></li>
+            </ul>
+        </div>
+        <h3 class='day-header'>Sunday</h3>
+        <div>
+            <ul class='schedule-list'>
+                <li><p class='time-slot-text'>10:00-12:00 am <a href='/projects/website'>Hack for LA website</a></p></li>
+                <li><p class='time-slot-text'>12:00-2:00 pm Hack for LA marketing team</p></li>
+                <li><p class='time-slot-text'>2:00-4:00 pm CivicTechIndex</p></li>
+            </ul>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Fixes #390 

Adds Project Meeting Page that is accessible through the getting started page. This pull request adds a link in the Getting Started page under the "Projects" section called "team meeting overview". This link allows access to the page.

![Screenshot from 2020-03-25 22-50-53](https://user-images.githubusercontent.com/18221058/77615208-fc733500-6eeb-11ea-963b-c489b87ff573.png)
![Peek 2020-03-25 22-51](https://user-images.githubusercontent.com/18221058/77615216-009f5280-6eec-11ea-8c0a-72634fa1d08f.gif)
