### PR TITLE
Schedule Fixes

### DIFF
--- a/project-meetings.html
+++ b/project-meetings.html
@@ -10,7 +10,7 @@ layout: default
             <ul class='schedule-list'>
                 <li><p class='time-slot-text'>5:30-10:30 pm <a href='/projects/lucky-parking'>Lucky Parking</a></p></li>
                 <li><p class='time-slot-text'>6:30-8:30 pm <a href='/projects/hellogov'>HelloGov</a></p></li>
-                <li><p class='time-slot-text'>6:30-6:40 <a href='/projects/not-today'>Not Today</a> (updates)</p></li>
+                <li><p class='time-slot-text'>6:30-6:40 pm <a href='/projects/not-today'>Not Today</a> (updates)</p></li>
                 <li><p class='time-slot-text'>6:30-8:30 pm <a href='/projects/new-schools-today'>New Schools Today</a></p></li>
                 <li><p class='time-slot-text'>6:30-8:45 pm <a href='/projects/record-clearance-project'>Record Clearance</a></p></li>
                 <li><p class='time-slot-text'>6:30-TBD pm <a href='/projects/public-tree-map'>Public Tree map</a></p></li>
@@ -28,7 +28,7 @@ layout: default
         <div>
             <ul class='schedule-list'>
                 <li><p class='time-slot-text'>6:30-9:00 pm <a href='/projects/undebate'>Undebate</a></p></li>
-                <li><p class='time-slot-text'>6-6:45pm IT + hosting + operations working group</p></li>
+                <li><p class='time-slot-text'>6:00-6:45 pm IT + hosting + operations working group</p></li>
                 <li><p class='time-slot-text'>6:00-7:00 pm <a href='/projects/engage'>Engage</a></p></li>
                 <li><p class='time-slot-text'>7:00-9:00 pm <a href='/projects/equity-language'>Equity Language</a></p></li>
                 <li><p class='time-slot-text'>7:00-8:30 pm <a href='/projects/tdm-calculator'>TDM Calculator</a></p></li>
@@ -51,7 +51,7 @@ layout: default
         <h3 class='day-header'>Saturday</h3>
         <div>
             <ul class='schedule-list'>
-                <li><p class='time-slot-text'>10:00-12:00 am <a href='/projects/tdm-calculator'>TDM Calculator</a></p></li>
+                <li><p class='time-slot-text'>10:00-12:00 pm <a href='/projects/tdm-calculator'>TDM Calculator</a></p></li>
                 <li><p class='time-slot-text'>12:00-2:00 pm Host Homes</p></li>
                 <li><p class='time-slot-text'>2:00-4:00 pm <a href='/projects/new-schools-today'>New Schools Today</a></p></li>
             </ul>
@@ -59,7 +59,7 @@ layout: default
         <h3 class='day-header'>Sunday</h3>
         <div>
             <ul class='schedule-list'>
-                <li><p class='time-slot-text'>10:00-12:00 am <a href='/projects/website'>Hack for LA website</a></p></li>
+                <li><p class='time-slot-text'>10:00-12:00 pm <a href='/projects/website'>Hack for LA website</a></p></li>
                 <li><p class='time-slot-text'>12:00-2:00 pm Hack for LA marketing team</p></li>
                 <li><p class='time-slot-text'>2:00-4:00 pm CivicTechIndex</p></li>
             </ul>


### PR DESCRIPTION
Add pm to Not Today (was originally 6:30-6:40, now 6:30-6:40 pm) time and change from am to pm on TDM and Website projects that ended at 12pm instead of 12am. Add consistent spacing in time slot for IT + hosting + operations working group project.