### PR TITLE
Update Getting Started Page

### DIFF
--- a/_sass/components/getting-started-page.scss
+++ b/_sass/components/getting-started-page.scss
@@ -30,6 +30,10 @@
     margin-left: 21px;
 }
 
+.getting-started-guide-content-section h4 {
+    margin-block-end: 16px;
+}
+
 .zoom-pictures {
     display: flex;
     justify-content: space-evenly;

--- a/getting-started.html
+++ b/getting-started.html
@@ -14,22 +14,28 @@ layout: default
         <div class='getting-started-guide-content-section'>
             <h4 style='color:#333'>Onboarding Video</h4>
             <ol>
-                <li>Watch our <a target='_blank' href='https://undebate-cc.herokuapp.com/hackforla-projects'>Onboading Video</a> where you will hear a brief introduction to Code for America and Hack for LA, meet members of our active projects, and hear about the intended impact and roles these projects are seeking to fill.</li>
-                <li>Read the Hack for LA <a target='_blank' href='https://www.hackforla.org/conduct'>Code of Conduct.</a></li>
-                <li>Complete our <a target='_blank' href='https://docs.google.com/forms/d/e/1FAIpQLScXnJSyCXgO_RCAuCyOkG4sqGILpAepTlJ0HOaK4H_ccEVmNw/viewform'>Remote Onboarding Survey</a>.</li>
+                <p>Watch our <a target='_blank' href='https://undebate-cc.herokuapp.com/hackforla-projects'>Onboading Video</a> where you will hear a brief introduction to Code for America and Hack for LA, meet members of our active projects, and hear about the intended impact and roles these projects are seeking to fill.</p>
             </ol>
-            <h4 style='color:#333'>Slack</h4>
+            <h4 style='color:#333'>Code of Conduct</h4>
             <ol>
-                <li>Self-invite to the Hack for LA <a target='_blank' href='https://www.hackforla.org/slack/'>Slack</a>.</li>
+                <p>Read the Hack for LA <a target='_blank' href='https://www.hackforla.org/conduct'>Code of Conduct</a>.</p>
             </ol>
-            <h4 style='color:#333'>Projects</h4>
+            <h4 style='color:#333'>Help Us Improve</h4>
             <ol>
-                <li>Review the projects listed in the <a target='_blank' href='/#projects'>projects section</a> to determine which one you would like to know more about.</li>
-                <li>Check the <a href='./project-meetings'>team meeting overview</a>, to see if the team you are interested in meets at a time that fits into your schedule.</li>
+                <p>Complete our <a target='_blank' href='https://docs.google.com/forms/d/e/1FAIpQLScXnJSyCXgO_RCAuCyOkG4sqGILpAepTlJ0HOaK4H_ccEVmNw/viewform'>Remote Onboarding Survey</a>.</p>
+            </ol>
+            <h4 style='color:#333'>Join Us on Slack</h4>
+            <ol>
+                <p>Self-invite to the Hack for LA <a target='_blank' href='https://www.hackforla.org/slack/'>Slack</a>.</p>
+            </ol>
+            <h4 style='color:#333'>Pick a Project</h4>
+            <ol>
+                <li>Review the projects listed in the <a target='_blank' href='/#projects'>projects section</a> to determine which one you would like to know more about. If you still don’t know what project you want to join, please attend one of our <a target='_blank' href='http://Meetup.com/hackforla/events'>onboarding sessions</a>.</li>
+                <li>Check the <a target='_blank' href='./project-meetings'>team meeting overview</a>, to see if the team you are interested in meets at a time that fits into your schedule.</li>
                 <li>Click to the project’s home page.</li>
                 <ol>
                     <li>Locate and review the project-specific getting started guide.</li>
-                    <li>Locate and join the project’s Slack channel and reach out to the project lead listed on the project homepage.</li>
+                    <li>Locate and join the project’s Slack channel and post your interest in joining the team, in the channel.</li>
                 </ol>
             </ol>
         </div>
@@ -41,10 +47,9 @@ layout: default
         <div class='getting-started-guide-content-section'>
             <h4 style='color:#333'>Online Onboarding</h4>
             <ol>
-                <li>Attend a Hack for LA Remote Onboarding session via Zoom.  Our next one can be found here: <a target='_blank' href='http://bit.ly/HackforLA-onboard'> Hack for LA Remote Onboarding</a></li>
-                <p>If you don’t have a Zoom account, sign up for a free <a target='_blank' href='https://zoom.us/signup'></a>Zoom account</a>.</p>
-                <li>Ask questions in the Zoom chat, or raise your hand to signal the host.</li>
-                <p><br>To raise your hand in Zoom: (1) Click the Participants button found in the control panel at the bottom of the Zoom window (2) Click “Raise Hand” found at the bottom of the chat window that appears.</p>
+                <p>Attend a Hack for LA Remote Onboarding session via Zoom. Our next one can be found here: <a target='_blank' href='http://Meetup.com/hackforla/events'> Meetup.com/hackforla/events</a></p>
+                <p>If you don’t have a Zoom account, sign up for a free Zoom account. Ask questions in the Zoom chat, or raise your hand to signal the host.</p>
+                <p><i>To raise your hand in Zoom: (1) Click the Participants button found in the control panel at the bottom of the Zoom window (2) Click “Raise Hand” found at the bottom of the chat window that appears</i>.</p>
                 <div class='zoom-pictures'>
                     <img class='zoom-img' src='{{ "assets/images/getting-started/getting-started-zoom1.png" | absolute_url}}'>
                     <img class='zoom-img' src='{{ "assets/images/getting-started/getting-started-zoom2.png" | absolute_url}}'>
@@ -57,11 +62,11 @@ layout: default
     <div class='getting-started-page-card'>
         <h3 style='color:#333'>Once you have joined a team!</h3>
         <div class='getting-started-guide-content-section'>
-            <p>Once you have joined a team you will need to do the following:</p>
+            <p>Once you have joined a team, please do the following:</p>
             <ol>
                 <li>Send the project lead your Gmail email address so you can be added to the Google project drive.</li>
                 <li>After you get access to the Google drive, fill out the team’s roster.</li>
-                <li>GitHub setup: If you do not already have a GitHub account, you will need to sign up for a <a target='_blank' href='https://www.github.com/signup'>GitHub account</a>. If you are not a coder, don’t worry!  There is still lots for you to do. We use GitHub’s Lean workflow tool (the project boards) and their Wiki functionality to organize our projects and share non-code artifacts we create.</li>
+                <li>GitHub setup: If you do not already have a GitHub account, you will need to sign up for a <a target='_blank' href='https://www.github.com/signup'>GitHub account</a>. If you are not a coder, don’t worry! There is still lots for you to do. We use GitHub’s Lean workflow tool (the project boards) and its Wiki functionality to organize our projects and share non-code artifacts we create.</li>
                 <ol>
                     <li>Set up <a target='_blank' href='https://github.com/hackforla/governance/issues/20'>two-factor authentication.</a></li>
                     <li>Mark your Hack for LA <a target='_blank' href='https://help.github.com/en/articles/publicizing-or-hiding-organization-membership#changing-the-visibility-of-your-organization-membership'>organization membership</a> public.</li>


### PR DESCRIPTION
Add updates on content and update spacing. Another thing that is changed is that the link to the project meetings schedule page opens in a new window instead of navigating the current window. The reason for this is because I forgot if the original functionality was intentional or not, and when I asked Harish he went with opening in a new tab. Opening in a new tab makes it consistent with the rest of the links, but let me know if this should be reverted.
![Screenshot from 2020-03-30 19-34-15](https://user-images.githubusercontent.com/18221058/77980955-868d1600-72bd-11ea-9953-340d9339dc15.png)
![Screenshot from 2020-03-30 19-34-21](https://user-images.githubusercontent.com/18221058/77980956-8725ac80-72bd-11ea-991a-8a6c3e947540.png)
![Screenshot from 2020-03-30 19-34-27](https://user-images.githubusercontent.com/18221058/77980957-8725ac80-72bd-11ea-86a5-50ac2bf1d7c8.png)
![Screenshot from 2020-03-30 19-34-32](https://user-images.githubusercontent.com/18221058/77980959-87be4300-72bd-11ea-816b-2f935f5eabd7.png)



