### PR TITLE
Fix github link under leadership section

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -117,7 +117,7 @@ layout: default
             <div class='resource-list'>
                 {% for item in page.leadership %}
                     <div class='leader-card'>
-                        <a href='{{ item.links.GitHub }}' target='_blank' title='GitHub Profile'><img class='leader-img' src='{{ item.picture }}'/></a>
+                        <a href='{{ item.links.github }}' target='_blank' title='GitHub Profile'><img class='leader-img' src='{{ item.picture }}'/></a>
                         <div class='leader-description'>
                             <p style='margin-block-end: 0.25em;'><strong>Name: </strong><a href='{{ item.links.slack }}' target='_blank' title='Slack Direct Message'>{{ item.name }}</a></p>
                             <p style='margin-block-end: 0.25em;'><strong>Role: </strong>{{ item.role }}</p>


### PR DESCRIPTION
Clicking on the image of a leadership team member opens the project page in another tab, but supposed to open the member's GitHub profile. This pr fixed a link to the member's GitHub page. Now when the image under the leadership section is clicked, a user can see leadership team member's GitHub profile, as expected. @cnk Can you please check if everything is OK?