### PR TITLE
Sort project cards by title

### DIFF
--- a/_includes/current-projects.html
+++ b/_includes/current-projects.html
@@ -5,7 +5,7 @@
     <ul class="project-list unstyled-list">
       {% assign status_list = "Active, Rebooting, Completed, On Hold" | split: ", " %}
       {% for status in status_list %}
-        {% assign projects = site.projects | sample: site.projects.size - 1 | where: "status", status %}
+        {% assign projects = site.projects | where: "status", status | sort: "title" %}
         {%- for item in projects -%}
           {%- if item.hide != true -%}
             {%- include project-card.html project=item -%}


### PR DESCRIPTION
Removed 'sample' which was randomizing the project cards within a status. I explicitly sort by title here because the default sort by filename isn't right for projects that have been renamed.

Fixes #413 