### PR TITLE
Remove link to a project page for projects with project-homepage: false

### DIFF
--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -10,7 +10,11 @@
       <div class='status-indicator {{ "status-" | append: project.status }}'>
         <h5 class='status-text'>{{ project.status }}</h5>
       </div>
+      {%- if project.project-homepage == false -%}
+      <h4 class="project-title project-title-no-page">{{ project.title }}</h4>
+      {%- else  -%}
       <a href='{{ project.url | replace: ".html", "" }}'><h4 class="project-title">{{ project.title }}</h4></a>
+      {%- endif -%}
       <p class="project-description">{{ project.description }}</p>
 
       {%- if project.links -%}

--- a/_projects/work-for-la.md
+++ b/_projects/work-for-la.md
@@ -15,4 +15,5 @@ looking:
 location: Downtown LA
 partner: Department of Personnel
 status: Completed
+project-homepage: false
 ---

--- a/_sass/components/_projects.scss
+++ b/_sass/components/_projects.scss
@@ -39,6 +39,10 @@
   }
 }
 
+.project-title-no-page {
+  color: $color-black;
+}
+
 .project-tmb-img {
   display: block;
   width: 100%;


### PR DESCRIPTION
Fixes #402
 - Added logic in _includes/project-card.html to remove the link to a project page for projects with property project-homepage: false
Currently, only Work for LA project has this property
 - Title color for the projects with project-homepage: false set to black 
 - Edited template of a project.md file to have property project-homepage