### PR TITLE
Change link name for "Test Site" for Food Oasis

### DIFF
--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -50,8 +50,8 @@ links:
     url: 'https://github.com/hackforla/food-oasis/blob/master/README.md'
   - name: Slack
     url: 'https://hackforla.slack.com/archives/C6JBH478W'
-  - name: Testing site
-    url: 'http://food-oasis.herokuapp.com/' 
+  - name: Test Site
+    url: 'http://food-oasis.herokuapp.com/'
 looking:
   - Project Management
   - Junior Python developers (2)


### PR DESCRIPTION
There isn't an issue for this but I noticed it while correcting link name