### PR TITLE
Security fix for one of the dependencies we use for our GH actions

### DIFF
--- a/github-actions/package-lock.json
+++ b/github-actions/package-lock.json
@@ -20,9 +20,9 @@
         }
       },
       "@actions/http-client": {
-        "version": "1.0.6",
-        "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.6.tgz",
-        "integrity": "sha512-LGmio4w98UyGX33b/W6V6Nx/sQHRXZ859YlMkn36wPsXPB82u8xTVlA/Dq2DXrm6lEq9RVmisRJa1c+HETAIJA==",
+        "version": "1.0.8",
+        "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
+        "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
         "requires": {
           "tunnel": "0.0.6"
         }

--- a/github-actions/package.json
+++ b/github-actions/package.json
@@ -6,6 +6,7 @@
     "dependencies": {
       "@actions/core": "^1.2.0",
       "@actions/github": "^2.0.0",
+      "@actions/http-client": ">=1.0.8",
       "request": "2.88.0",
       "request-promise": "4.2.5"
     },
@@ -16,4 +17,4 @@
     "keywords": [],
     "author": "",
     "license": "ISC"
-  }
+}


### PR DESCRIPTION
Security alert: https://github.com/hackforla/website/network/alert/github-actions/package-lock.json/@actions%2Fhttp-client/open

Worked on my test repository cnk/actions-test