### PR TITLE
Sort data from GitHub before writing to the file

### DIFF
--- a/github-actions/get-project-data.js
+++ b/github-actions/get-project-data.js
@@ -69,6 +69,29 @@ var github = {
     }).catch(function(err) {
       return err.message;
     });
+  },
+  compareValues: function(key, order = 'asc') {
+    return function innerSort(a, b) {
+      if (!a.hasOwnProperty(key) || !b.hasOwnProperty(key)) {
+        // property doesn't exist on either object
+        return 0;
+      }
+
+      const varA = (typeof a[key] === 'string')
+            ? a[key].toUpperCase() : a[key];
+      const varB = (typeof b[key] === 'string')
+            ? b[key].toUpperCase() : b[key];
+
+      let comparison = 0;
+      if (varA > varB) {
+        comparison = 1;
+      } else if (varA < varB) {
+        comparison = -1;
+      }
+      return (
+        (order === 'desc') ? (comparison * -1) : comparison
+      );
+    };
   }
 }
 
@@ -106,8 +129,9 @@ async function main(params) {
       console.log(e)
     });
   function finish(){
-    console.log(JSON.stringify(github.apiData, null, 2));
-    fs.writeFileSync('_data/github-data.json', JSON.stringify(github.apiData, null, 2));
+    let output = github.apiData.sort(github.compareValues('name'));
+    console.log(JSON.stringify(output, null, 2));
+    fs.writeFileSync('github-actions/github_data.json', JSON.stringify(output, null, 2));
   }
 }
 

--- a/github-actions/get-project-data.js
+++ b/github-actions/get-project-data.js
@@ -131,7 +131,7 @@ async function main(params) {
   function finish(){
     let output = github.apiData.sort(github.compareValues('name'));
     console.log(JSON.stringify(output, null, 2));
-    fs.writeFileSync('github-actions/github_data.json', JSON.stringify(output, null, 2));
+    fs.writeFileSync('_data/github-data.json', JSON.stringify(output, null, 2));
   }
 }
 


### PR DESCRIPTION
It would be nice to minimize the changes in the json file so that the 'git diff' between versions shows you real changes - not just differences in the order in which the endpoints returned data.

This commit adds a sorting function and then uses it to sort the json objects by project name before writing them to the file