### PR TITLE
Sort by project id because we have 2 projects named 'website'

### DIFF
--- a/github-actions/get-project-data.js
+++ b/github-actions/get-project-data.js
@@ -129,7 +129,7 @@ async function main(params) {
       console.log(e)
     });
   function finish(){
-    let output = github.apiData.sort(github.compareValues('name'));
+    let output = github.apiData.sort(github.compareValues('id'));
     console.log(JSON.stringify(output, null, 2));
     fs.writeFileSync('_data/github-data.json', JSON.stringify(output, null, 2));
   }


### PR DESCRIPTION
We are still getting commits every night because the 2 projects named 'website' and not returned in a deterministic order. Change the sort to be by project id so the sort key is guaranteed to be unique.