### PR TITLE
Add functionality to GitHub Actions script so that:

### DIFF
--- a/github-actions/get-project-data.js
+++ b/github-actions/get-project-data.js
@@ -21,12 +21,47 @@ var github = {
           id: project.id,
           name: project.name,
           languages: { url: project.languages_url, data: [] },
-          contributors: { url: project.contributors_url, data: [] }
+          contributors: { url: [project.contributors_url], data: [] },
+          repoEndpoint: project.url
         });
       });
     }).catch(function(err) {
       return err.message;
     });
+  },
+  getUntaggedRepos: function(ids) {
+    // Check for repos not under hackforla but that we have the id for
+    let extraRepos = [];
+    for(id of ids){
+      // Check if id is in github-data-json
+      let found = false;
+      for(project of github.apiData){
+        if (project.id == id) found = true;
+      }
+      if (found) continue;
+      extraRepos.push(
+        request({
+          "method": "GET",
+          "uri": `https://api.github.com/repositories/${id}`,
+          "json": true,
+          "headers": {
+            "Authorization": "token " + github.token,
+            "User-Agent": "Hack For LA"
+          }
+        }).then(function(body){
+          github.apiData.push({
+            id: body.id,
+            name: body.name,
+            languages: { url: body.languages_url, data: [] },
+            contributors: { url: [body.contributors_url], data: [] },
+            repoEndpoint: body.url
+          });
+        }).catch(function(err){
+          return err.message;
+        })
+      );
+      return Promise.all(extraRepos);
+    }
   },
   getLanguageInfo: function(url) {
     return request({
@@ -62,7 +97,8 @@ var github = {
           "id": user.id,
           "github_url": user.html_url,
           "avatar_url": user.avatar_url,
-          "gravatar_id": user.gravatar_id
+          "gravatar_id": user.gravatar_id,
+          "contributions": user.contributions
         });
       });
       return Promise.resolve(contributors);
@@ -92,6 +128,43 @@ var github = {
         (order === 'desc') ? (comparison * -1) : comparison
       );
     };
+  },
+  getMoreContributorLinks: function(url) {
+    // Check if repo belongs to a different org than hfla. If it does, return the contributor links of all repos in that org
+    return request({
+      "method": "GET",
+      "uri": url,
+      "json": true,
+      "headers": {
+        "Authorization": "token " + github.token,
+        "User-Agent": "Hack For LA"
+      }
+    }).then(function(body) {
+      if(!body.organization || body.organization.login == 'hackforla') return [];
+      return github.getReposFromOrg(body.organization.repos_url);
+    }).catch(function(err) {
+      return err.message;
+    });
+  },
+  getReposFromOrg: function(url) {
+    // Helper method for getMoreContributorLinks that returns the contributor links of repos from a organization url
+    return request({
+      "method": "GET",
+      "uri": url,
+      "json": true,
+      "headers": {
+        "Authorization": "token" + github.token,
+        "User-Agent": "Hack For LA"
+      }
+    }).then(function(body) {
+      let repos = [];
+      for(repo of body) {
+        repos.push(repo.contributors_url);
+      }
+      return repos;
+    }).catch(function(err) {
+      return err.message;
+    });
   }
 }
 
@@ -99,34 +172,92 @@ async function main(params) {
   console.log('In the async function main');
   github.token = params.token;
 
+
+  untaggedRepos = [79977929];
   await github.getAllTaggedRepos();
+  await github.getUntaggedRepos(untaggedRepos);
   let lps = [], ldone = false
-  let cps = [], cdone = false
+  let cps = []
+  let clps = [], cdone = false // Clps represents Contributor Links Promises, which is the array of promises that will result in arrays of contributor links for projects under a different org. cdone represents the whole process of getting contributors being done
   for (i = 0; i < github.apiData.length; i++) {
     lps.push(github.getLanguageInfo(github.apiData[i].languages.url));
-    cps.push(github.getContributorsInfo(github.apiData[i].contributors.url));
+    clps.push(github.getMoreContributorLinks(github.apiData[i].repoEndpoint)); // Fetch all possible contributor links first before fetching contributor data
   }
+  // Get language data
   Promise.all(lps)
     .then(function(ls) {
       for (i = 0; i < ls.length; i++) {
         github.apiData[i].languages.data = ls[i]
       }
       ldone = true
-      if (cdone) finish()
+      if (cdone) {
+        console.log('Calling finish in languages work');
+        finish();
+      }
     })
     .catch(function(e) {
       console.log(e)
     });
-  Promise.all(cps)
-    .then(function(cs) {
-      for (i = 0; i < cs.length; i++) {
-        github.apiData[i].contributors.data = cs[i]
+  // Get all contributors data
+  Promise.all(clps)
+    .then(function(cls) {
+      // Add contribtuor links and remove duplicates
+      for (i = 0; i < clps.length; i++) {
+        github.apiData[i].contributors.url = github.apiData[i].contributors.url.concat(cls[i]);
+        github.apiData[i].contributors.url = github.apiData[i].contributors.url.filter(function(link, index, array){
+          return array.indexOf(link) == index;
+        });
       }
-      cdone = true
-      if (ldone) finish()
+      // Get contributors data from each link
+      for(i = 0; i < github.apiData.length; i++) {
+        let data = [] // Array to hold contributors data for each repo in project [i]
+        for(link of github.apiData[i].contributors.url) {
+          data.push(github.getContributorsInfo(link));
+        }
+        cps.push(data);
+      }
+      // cps now holds and array of arrays that hold promises. We need to resolve each array of promises
+      let contribuorsPromises = []; // Will result an array of promises representing the end of reolving the nested array of promises listed above. When this array of promises are resolved, then all the data is fetched and usable.
+      for(i = 0; i < cps.length; i++) {
+        // The reason to use a self-executing function with parameter i is that the contained promise won't have knowledge about i without it. We need i in order to know what project in github.apiData we are working with.
+        (function(i) {
+          let contributorsPromise = Promise.all(cps[i])
+            .then(function(cs) {
+              // We start off with an array of contributor arrays, so we flatten them into one
+              let contributors = cs.flat();
+              // Combine contributions from contributors that come up multiple times and keep track of their contributions
+              for(z = 0; z < contributors.length - 1; z++) {
+                let j = z + 1;
+                while(j < contributors.length) {
+                  if(contributors[z].id == contributors[j].id) {
+                    contributors[z].contributions += contributors[j].contributions;
+                    contributors.splice(j, 1);
+                  } else {
+                    j++;
+                  }
+                }
+              }
+              contributors.sort(github.compareValues('contributions', order = 'desc'));
+              github.apiData[i].contributors.data = contributors;
+            }).catch(function(err) {
+              return err.message;
+            });
+          // Push the current Promise.all() that is working on the current contributors to the overall promise array
+          contribuorsPromises.push(contributorsPromise);
+        })(i);
+      }
+      // When we return this promise, the next then() statement will wait for the array of promises to be resolved
+      return Promise.all(contribuorsPromises);
+    })
+    .then(function(promises) {
+      cdone = true;
+      if (ldone) {
+        console.log('Calling finish in Contributors work');
+        finish();
+      }
     })
     .catch(function(e) {
-      console.log(e)
+      return e.message;
     });
   function finish(){
     let output = github.apiData.sort(github.compareValues('id'));


### PR DESCRIPTION
1. Get more contributors if repo we track is under a different org.
2. Get repos from a hard coded array of ids that are not currently tagged hack-for-la.

Fixes #458 

Couple important notes/things I wanted to bring up: 
- Right now, the script is hardcoding the project id that is not tagged under "hack-for-la". In the future, we can parse the _projects directory using javascript to get the project ids we need. 
- Getting the untagged repos by id is using an endpoint that has no documentation on the GitHub API docs. I made some comments about it [here](https://github.com/hackforla/website/issues/458#issuecomment-628394547). Is that something that we want to discuss? Are we ok with that?
- The way I tried to test that it was indeed getting all the contributors was by manually adding the contributors from the Public Tree Map org and seeing if it matched up with the results from the script. It did, but I didn't test it with others. Not sure how to validate the data. I was thinking of making a script that added up the contributors and then I would compare that scripts results to this scripts results. But then I thought "isn't this current script doing what that validator script is going to do?" But I guess the validation script would have less going on in terms of code/functionality and if we get the same results it would provide some more confidence that the results from this script are correct.. If it would be better to make that, please let me know.