### PR TITLE
Change Code For America link hotfix

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -6,7 +6,7 @@
     </h2>
     <p>
       We bring together civic-minded volunteers to build digital products, programs and services with community partners and local 
-      government to address issues in our LA region. Hack for LA is a project of <a href="https://www.codeforamerica.com" rel="noopener" target="_blank">Code for America</a> and is it's 
+      government to address issues in our LA region. Hack for LA is a project of <a href="https://www.codeforamerica.org" rel="noopener" target="_blank">Code for America</a> and is it's 
       official Los Angeles chapter. 
     </p>
   </div>


### PR DESCRIPTION
Change Code For America link in about section to use .org instead of .com so that it can work.