### PR TITLE
Only apply background color to dashboardEmbed div

### DIFF
--- a/_sass/components/_dashboard.scss
+++ b/_sass/components/_dashboard.scss
@@ -23,6 +23,6 @@ iframe{
     margin: 0 auto 0 auto;
 }
 
-#app{
+.dashboardEmbed {
     background-color: #020d2d;
 }


### PR DESCRIPTION
#app was too broad and was adding background color to ALL pages - including the homepage regions that were not setting their own bgcolor

Fixes #660 