### PR TITLE
Fix alt text for .md files that were incorrectly formatted - 625

### DIFF
--- a/_projects/100-automations.md
+++ b/_projects/100-automations.md
@@ -3,9 +3,9 @@ identification: '67671778'
 title: 100 Automations
 description: Hack for LA seeks to reduce repetitive work in our open source projects and for the open source community.  This project will be both a showcase for the automations and/or microservices that we develop, but also a convenient home for those automations, so that they can be found, forked, and contributed to easily.
 image: /assets/images/projects/100automations.png
-alt: "Open Source logo with hackforla logo on the left edge of it."
+alt: "'Open Source logo with hackforla logo on the left edge of it.'"
 image-hero: /assets/images/projects/100automations-hero.png
-alt-hero: "Green gears with a red center on one"
+alt-hero: "'Green gears with a red center on one'"
 leadership:
   - name: Niven Prasad
     role: Product Manager

--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -3,8 +3,9 @@ identification: '190321758'
 title: 311 Data
 description: The 311 Data project seeks to empower local Neighborhood Councils to improve the ideation and analysis of their initiatives using the wealth of publicly available 311 data.
 image: /assets/images/projects/311.jpg
-alt: "image of building with windows that look like they spell out 311"
+alt: "'Image of building with windows that look like they spell out 311.'"
 image-hero: /assets/images/projects/311data-hero.png
+alt-hero: "'Picture of tablet and phone showing 311 data'"
 leadership:
   - name: John Ritchey
     role: Product Manager

--- a/_projects/civic-opportunity-project.md
+++ b/_projects/civic-opportunity-project.md
@@ -3,9 +3,9 @@ identification: '273746448'
 title: Civic Opportunity Project
 description: The mission of the Civic Opportunity project is to develop and curate the journey of all volunteers that we interact with to reach their fullest potential. Relationship bridge-building and workforce readiness development of volunteers is at the core of the Hack for LA brand. We have found that this effort enables and supports the delivery of a consistent pipeline of knowledge worker resources. In turn, our volunteers are more prepared to create products that are impactful in local government and beyond.
 image: /assets/images/projects/civic-opportunity-project.jpg
-alt: "two pairs of hands pointing to a tablet and papers"
+alt: "'Two pairs of hands pointing to a tablet and papers.'"
 image-hero: /assets/images/projects/civic-opportunity-project-hero.png
-alt-hero: "hands pointing to a tablet and papers"
+alt-hero: "'hands pointing to a tablet and papers'"
 leadership:
   - name: Ray Fambro
     role: Product Manager

--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -4,9 +4,9 @@ identification: '241519642'
 title: Civic Tech Index
 description: Our goal of the project is to create a comprehensive, searchable index of all civic tech open source software projects around the world. We have created the framework. Now our next step is to create a website and other marketing tools that will demonstrate the power of the index and will provide instructions for how to tag and share your github repository in 2 min or less.
 image: /assets/images/projects/civic-tech-index.png
-alt: civic tech index logo layered on top of the world map. Paired with a globe icon and a magnifying glass.
+alt: "'Civic tech index logo layered on top of the world map. Paired with a globe icon and a magnifying glass.'"
 image-hero: /assets/images/projects/civic-tech-index-hero.png
-alt-hero: outline of the world map with connectivity dots linking major cities on each continent
+alt-hero: "'outline of the world map with connectivity dots linking major cities on each continent'"
 leadership:
   - name: Bonnie Wolfe
     role: Acting PM (project looking for a new PM)

--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -5,7 +5,7 @@ description: Engage is a civic participation platform. Currently in beta, Engage
 image: /assets/images/projects/engage.jpg
 alt: "'city council closed in session'"
 image-hero: /assets/images/projects/engage-hero.jpg
-alt-hero: "Neon sign for the Santa Monica pier. Palm trees and sunset in the background"
+alt-hero: "'Neon sign for the Santa Monica pier. Palm trees and sunset in the background'"
 leadership:
   - name: Teddy Cripeneau
     role:

--- a/_projects/heart.md
+++ b/_projects/heart.md
@@ -3,9 +3,9 @@ identification: '159286729'
 title: Heart
 description: Heart is a project working directly with the LA City Attorney’s Homeless Engagement and Response Team. The HEART program helps individuals experiencing homelessness resolve eligible traffic and pedestrian infractions and related warrants and fines by engaging with relevant services. Hack for LA is helping them build a database and case management system to streamline their workflow and enable them to scale their program.
 image: /assets/images/projects/heart.png
-alt: "programming code icon that reads helping the homeless with code"
+alt: "'programming code icon that reads helping the homeless with code'"
 image-hero: /assets/images/projects/heart-hero.png
-alt-hero: "a line of tents under a freeway overpass"
+alt-hero: "'a line of tents under a freeway overpass'"
 leadership:
   - name: Marie-Aimee Brajeux
     role: Product Manager

--- a/_projects/hellogov.md
+++ b/_projects/hellogov.md
@@ -5,7 +5,7 @@ description: HelloGOV is helping grassroots organizations connect supporters to 
 image: /assets/images/projects/hellogov.jpg
 alt: "'smartphones using hellogo app'"
 image-hero: /assets/images/projects/hellogov-hero.jpg
-alt-hero: "Sky blue background"
+alt-hero: "'Sky blue background'"
 leadership:
   - name: Kate Rose
     links:

--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -3,9 +3,9 @@ identification: '228981080'
 title: Home Unite Us
 description: We're working with community non-profits who have a Host Home initiative to develop a workflow management tool to make the process scaleable (across all providers), reduce institutional bias, and effectively capture data. <br /><br />Host Home programs are centered around housing young people, 18 - 25 years old. Their approach focuses on low-cost, community-driven intervention by matching a willing host with a guest or group of guests, providing a stable housing environment for youths who are experiencing homelessness and seeking stable housing.
 image: /assets/images/projects/home-unite-us.png
-alt: 'Cartoon picture of person'
+alt: "'Cartoon picture of person'"
 image-hero: /assets/images/projects/home-unite-us-hero.png
-alt-hero: 'Cartoon picture of person and a plus sign and a house all in a row'
+alt-hero: "'Cartoon picture of person and a plus sign and a house all in a row'"
 leadership:
   - name: Timothy Malstead
     role: Front End Web Developer Lead (on loan to Food Oasis project)

--- a/_projects/jobs-for-hope.md
+++ b/_projects/jobs-for-hope.md
@@ -5,7 +5,7 @@ description: We compiled job listings from 60+ different non-profit organization
 image: /assets/images/projects/jobs-for-hope.png
 alt: "'LA county homelessness initiative logo'"
 image-hero: /assets/images/projects/jobs-for-hope-hero.png
-alt-hero: "Purple background"
+alt-hero: "'Purple background'"
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/jobs-for-hope'

--- a/_projects/lucky-parking.md
+++ b/_projects/lucky-parking.md
@@ -3,9 +3,9 @@ identification: '216854923'
 title: Lucky Parking
 description: A platform looking for nearby street parking with least possibility of getting citation
 image: /assets/images/projects/lucky-parking.png
-alt: "Lucky Parking Logo"
+alt: "'Lucky Parking Logo'"
 image-hero: /assets/images/projects/lucky-parking-hero.png
-alt-hero: "Lucky Parking Logo overlaid on a parking lot with a yellow Volkswagon"
+alt-hero: "'Lucky Parking Logo overlaid on a parking lot with a yellow Volkswagon'"
 leadership:
   - name: Rong Xue
     role: Product Owner

--- a/_projects/metro-ontime.md
+++ b/_projects/metro-ontime.md
@@ -5,7 +5,7 @@ description: Trailstats LA tracks LA Metro trains and generates punctuality repo
 image: /assets/images/projects/metro-ontime.png
 alt: "'metro ontime'"
 image-hero: /assets/images/projects/metro-ontime-hero.png
-alt-hero: "Line graph of arrival times vs schedule for the Green Line train"
+alt-hero: "'Line graph of arrival times vs schedule for the Green Line train'"
 leadership:
   - name: Cameron Sexton
     role: Product Owner/Lead Developer

--- a/_projects/not-today.md
+++ b/_projects/not-today.md
@@ -3,9 +3,9 @@ identification: '202051333'
 title: Not Today - Self-Defense Against Suicidal Thoughts
 description:  Not Today is an app intended to help people wait out periods of suicidal thinking without acting on their thoughts.
 image: /assets/images/projects/not-today.png
-alt: 'person being supported by another.  Art by c.w. moss'
+alt: "'person being supported by another.  Art by c.w. moss'"
 image-hero: /assets/images/projects/not-today-hero.png
-alt-hero: "Blue background"
+alt-hero: "'Blue background'"
 leadership:
   - name: Mya Stark
     role: Product Owner & SME

--- a/_projects/public-tree-map.md
+++ b/_projects/public-tree-map.md
@@ -3,9 +3,9 @@ identification: '128148093'
 title: Public Tree Map
 description: Public Tree Map helps connect people to Santa Monica's urban forest. The map includes information about each of the 35,000 trees (and vacant tree sites) in Santa Monica's publicly-owned urban forest (compiled from open datasets, digitized city records, and federal ecosystem services values), as well as tools for users to share favorite trees. To reflect tree plantings and removals, the map updates every day.
 image: /assets/images/projects/public-tree-map.png
-alt: 'public tree map grid'
+alt: "'public tree map grid'"
 image-hero: /assets/images/projects/public-tree-map-hero.jpeg
-alt-hero: 'Coral tree - Dave Baiocchi www.studiobaiocchi.com'
+alt-hero: "'Coral tree - Dave Baiocchi www.studiobaiocchi.com'"
 leadership:
   - name: Emily F.
     role: Product Owner

--- a/_projects/shared-housing-project.md
+++ b/_projects/shared-housing-project.md
@@ -5,7 +5,7 @@ description: The shared housing team works on creating an efficient & effective 
 image: /assets/images/projects/shared-housing-project.jpg
 alt: "'linked arms'"
 image-hero: /assets/images/projects/shared-housing-project-hero.png
-alt-hero: "Light-gray background"
+alt-hero: "'Light-gray background'"
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/shared-housing'

--- a/_projects/spare.md
+++ b/_projects/spare.md
@@ -5,7 +5,7 @@ description: A fun new project project that connects people in need of clothing 
 image: /assets/images/projects/spare.png
 alt: "'a logo that reads what can you spare'"
 image-hero: /assets/images/projects/spare-hero.png
-alt-hero: "Gray background"
+alt-hero: "'Gray background'"
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/spare'

--- a/_projects/tdm-calculator.md
+++ b/_projects/tdm-calculator.md
@@ -5,6 +5,7 @@ description: We’re building a TDM web calculator for LADOT. It scores proposed
 image: /assets/images/projects/tdm-calculator.jpg
 alt: "'LA TDM Calculator Landing Page (Mock Up)'"
 image-hero: /assets/images/projects/TDM-calculator-hero.png
+alt-hero: "'Los Angeles downtown skyline at dusk with cranes on top of some buildings'"
 leadership:
   - name: Bonnie Wolfe
     role: Product Owner

--- a/_projects/undebate.md
+++ b/_projects/undebate.md
@@ -3,9 +3,9 @@ identification: '221070186'
 title: Undebate
 description: Not debates, but recorded online video Q&A with candidates so voters can quickly can get to know them, for every candidate, for every election, across the US.
 image: /assets/images/projects/undebate.jpg
-alt: "Undebate with moderator and 7 participants"
+alt: "'Undebate with moderator and 7 participants'"
 image-hero: /assets/images/projects/undebate-hero.jpg
-alt-hero: "Silhouette of three people sitting in chairs. Two of them have empty speach bubbles over their heads."
+alt-hero: "'Silhouette of three people sitting in chairs. Two of them have empty speach bubbles over their heads.'"
 leadership:
   - name: David Fridley
     role: Tech Lead

--- a/_projects/vrms.md
+++ b/_projects/vrms.md
@@ -3,9 +3,9 @@ identification: '226157870'
 title: VRMS
 description: VRMS is a tool used for the engagement, support, and retention of a network of volunteers.
 image: /assets/images/projects/vrms.png
-alt: "VRMS homepage showing the check-in buttons"
+alt: "'VRMS homepage showing the check-in buttons'"
 image-hero: /assets/images/projects/vrms-hero.png
-alt-hero: "City of LA skyline"
+alt-hero: "'City of LA skyline'"
 leadership:
   - name: Matt Tapper
     role: Tech Team Lead

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -3,7 +3,7 @@ identification: '130000551'
 title: Hackforla.org Website
 description: The hackforla.org website is our organization's way of communicating with new volunteers, stakeholders, and donors. This project is a good place to start for new volunteers looking to polish their git protocol skills (branches, separation of concerns, etc.). We are currently in a redesign phase, using CI/CD in the run up to demoing the new version at Code for America's Summit 2020 in Washington, D.C.
 image: /assets/images/projects/website.png
-alt: "wireframe sample from new website"
+alt: "'wireframe sample from new website'"
 leadership:
   - name: Kegan Maher
     role: Technical Architect

--- a/_projects/writeforall.md
+++ b/_projects/writeforall.md
@@ -5,7 +5,7 @@ description: We want to improve the language used in websites to be
   more inclusive (of all communities) while also educating the public
   about exclusionary language. @writeforallorg&#8482;
 image: /assets/images/projects/writeforall.png
-alt: "'A a rainbow document searcher icon , the words 'Write for All TM', and a rainbow-like border'"
+alt: "'A a rainbow document searcher icon , the words Write for All TM, and a rainbow-like border'"
 image-hero: /assets/images/projects/writeforall-hero.png
 alt-hero: "'A large rainbow-colored background with a rainbow document searcher icon in the middle'"
 leadership:

--- a/_projects/writeforall.md
+++ b/_projects/writeforall.md
@@ -5,9 +5,9 @@ description: We want to improve the language used in websites to be
   more inclusive (of all communities) while also educating the public
   about exclusionary language. @writeforallorg&#8482;
 image: /assets/images/projects/writeforall.png
-alt: "A a rainbow document searcher icon , the words 'Write for All TM', and a rainbow-like border"
+alt: "'A a rainbow document searcher icon , the words 'Write for All TM', and a rainbow-like border'"
 image-hero: /assets/images/projects/writeforall-hero.png
-alt-hero: "A large rainbow-colored background with a rainbow document searcher icon in the middle"
+alt-hero: "'A large rainbow-colored background with a rainbow document searcher icon in the middle'"
 leadership:
   - name: Joel Parker Henderson
     role: Project Architect


### PR DESCRIPTION
Fixes #625 

- Corrected image alt attribute so that all cards show alt text in correct format. 
- I noticed that 311 and tdm-calculator didn't have an alt-hero attribute, so I added them. 

Note: I noticed that the main pages for each card, where the hero-image is displayed, do not display the alt-hero text.  I ran grep on the directory and didn't see the text alt-hero anywhere other than on the .md files, so perhaps this is known or intentional.  Just mentioning it in case...