### PR TITLE
Fixed alt attribute in include and changed all md files to single quotes

### DIFF
--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -8,7 +8,7 @@
     {%- else  -%}
     <a href='{{ project.url | replace: ".html", "" }}'>
       <div class="project-tmb">
-        <img src="{{ project.image | absolute_url }}" class="project-tmb-img" alt={{project.alt}}/>
+        <img src="{{ project.image | absolute_url }}" class="project-tmb-img" alt="{{project.alt}}"/>
       </div>
     </a>
     {%- endif -%}

--- a/_projects/100-automations.md
+++ b/_projects/100-automations.md
@@ -3,9 +3,9 @@ identification: '67671778'
 title: 100 Automations
 description: Hack for LA seeks to reduce repetitive work in our open source projects and for the open source community.  This project will be both a showcase for the automations and/or microservices that we develop, but also a convenient home for those automations, so that they can be found, forked, and contributed to easily.
 image: /assets/images/projects/100automations.png
-alt: "Open Source logo with hackforla logo on the left edge of it."
+alt: 'Open Source logo with hackforla logo on the left edge of it.'
 image-hero: /assets/images/projects/100automations-hero.png
-alt-hero: "Green gears with a red center on one"
+alt-hero: 'Green gears with a red center on one'
 leadership:
   - name: Niven Prasad
     role: Product Manager

--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -3,8 +3,9 @@ identification: '190321758'
 title: 311 Data
 description: The 311 Data project seeks to empower local Neighborhood Councils to improve the ideation and analysis of their initiatives using the wealth of publicly available 311 data.
 image: /assets/images/projects/311.jpg
-alt: "image of building with windows that look like they spell out 311"
+alt: 'Image of building with windows that look like they spell out 311.'
 image-hero: /assets/images/projects/311data-hero.png
+alt-hero: 'iPhone and iPad showing app display.'
 leadership:
   - name: John Ritchey
     role: Product Manager

--- a/_projects/adopt-civic-art.md
+++ b/_projects/adopt-civic-art.md
@@ -3,7 +3,7 @@ identification: '84370933'
 title: ArtWatcher
 description: There are thousands of works of public art scattered around the city.  There should be one place to see where they are and how they’re doing. We’re building it.
 image: /assets/images/projects/adopt-civic-art.jpg
-alt: "'adopt civic arts'"
+alt: 'Adopt civic arts.'
 links: 
   - name: GitHub
     url: 'https://github.com/hackforla/adopt-civic-art'

--- a/_projects/civic-opportunity-project.md
+++ b/_projects/civic-opportunity-project.md
@@ -3,9 +3,9 @@ identification: '273746448'
 title: Civic Opportunity Project
 description: The mission of the Civic Opportunity project is to develop and curate the journey of all volunteers that we interact with to reach their fullest potential. Relationship bridge-building and workforce readiness development of volunteers is at the core of the Hack for LA brand. We have found that this effort enables and supports the delivery of a consistent pipeline of knowledge worker resources. In turn, our volunteers are more prepared to create products that are impactful in local government and beyond.
 image: /assets/images/projects/civic-opportunity-project.jpg
-alt: "two pairs of hands pointing to a tablet and papers"
+alt: 'Two pairs of hands pointing to a tablet and papers.'
 image-hero: /assets/images/projects/civic-opportunity-project-hero.png
-alt-hero: "hands pointing to a tablet and papers"
+alt-hero: 'Hands pointing to a tablet and papers.'
 leadership:
   - name: Ray Fambro
     role: Product Manager

--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -4,9 +4,9 @@ identification: '241519642'
 title: Civic Tech Index
 description: Our goal of the project is to create a comprehensive, searchable index of all civic tech open source software projects around the world. We have created the framework. Now our next step is to create a website and other marketing tools that will demonstrate the power of the index and will provide instructions for how to tag and share your github repository in 2 min or less.
 image: /assets/images/projects/civic-tech-index.png
-alt: civic tech index logo layered on top of the world map. Paired with a globe icon and a magnifying glass.
+alt: 'Civic tech index logo layered on top of the world map. Paired with a globe icon and a magnifying glass.'
 image-hero: /assets/images/projects/civic-tech-index-hero.png
-alt-hero: outline of the world map with connectivity dots linking major cities on each continent
+alt-hero: 'Outline of the world map with connectivity dots linking major cities on each continent.'
 leadership:
   - name: Bonnie Wolfe
     role: Acting PM (project looking for a new PM)

--- a/_projects/criminal-sentencing.md
+++ b/_projects/criminal-sentencing.md
@@ -3,7 +3,7 @@ identification: '157484926'
 title: Los Angeles Criminal Sentencing Project
 description: Our project's goal is to make all criminal sentences administered in LA county into an open dataset. There is a lot of data about when and where crimes are committed - but none about what sentences are passed down in LA County.
 image: /assets/images/projects/criminal-sentencing.jpg
-alt: "'gavel'"
+alt: 'Gavel'
 links: 
   - name: GitHub
     url: "https://github.com/timdef/criminal-sentencing" 

--- a/_projects/curbmap.md
+++ b/_projects/curbmap.md
@@ -2,7 +2,7 @@
 title: curbmap
 description: We are building a platform to engage the community to map and update the city's parking restrictions. Simultaneously we want to create an app that is easy for all people (community members, visitors, etc.) to use to see the landscape of parking around themselves. We want to help you avoid endlessly searching for parking in all the wrong places and reduce your risk of getting tickets.
 image: /assets/images/projects/curbmap.jpg
-alt: "'parking sign'"
+alt: 'Parking sign'
 links:
   - name: GitHub
     url: 'https://github.com/curbmap'

--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -3,9 +3,9 @@ identification: '138791772'
 title: Engage
 description: Engage is a civic participation platform. Currently in beta, Engage makes it easier for residents of Santa Monica, CA to offer their feedback on policy issues that City Council is considering. Engage aims to increase access for community stakeholders who are unable to attend public meetings or may otherwise feel unheard by their local government.
 image: /assets/images/projects/engage.jpg
-alt: "'city council closed in session'"
+alt: 'City council closed in session.'
 image-hero: /assets/images/projects/engage-hero.jpg
-alt-hero: "Neon sign for the Santa Monica pier. Palm trees and sunset in the background"
+alt-hero: 'Neon sign for the Santa Monica pier. Palm trees and sunset in the background.'
 leadership:
   - name: Teddy Cripeneau
     role:

--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -3,9 +3,9 @@ identification: "215666884"
 title: Food Oasis
 description: The website is focused on individuals seeking food in Los Angeles who need an up-to-date resource about food pantries and meals. Our mission is to update the existing website, foodoasis.la with a simplified UI and verified data.  Future development goals include creating functionality for referral services that will allow the end user to annotate and update listings through a peer verification system.
 image: /assets/images/projects/food-oasis.jpg
-alt: "'vegatables beats stacked'"
+alt: 'Vegatables beats stacked'
 image-hero: /assets/images/projects/food-oasis-hero.jpg
-alt-hero: "'Food Oasis hero'"
+alt-hero: 'Food Oasis hero'
 leadership:
   - name: Jenny Mikesell
     role: Product Manager

--- a/_projects/heart.md
+++ b/_projects/heart.md
@@ -3,9 +3,9 @@ identification: '159286729'
 title: Heart
 description: Heart is a project working directly with the LA City Attorney’s Homeless Engagement and Response Team. The HEART program helps individuals experiencing homelessness resolve eligible traffic and pedestrian infractions and related warrants and fines by engaging with relevant services. Hack for LA is helping them build a database and case management system to streamline their workflow and enable them to scale their program.
 image: /assets/images/projects/heart.png
-alt: "programming code icon that reads helping the homeless with code"
+alt: 'Programming code icon that reads helping the homeless with code.'
 image-hero: /assets/images/projects/heart-hero.png
-alt-hero: "a line of tents under a freeway overpass"
+alt-hero: 'A line of tents under a freeway overpass.'
 leadership:
   - name: Marie-Aimee Brajeux
     role: Product Manager

--- a/_projects/hellogov.md
+++ b/_projects/hellogov.md
@@ -3,9 +3,9 @@ identification: '76137532'
 title: HelloGOV
 description: HelloGOV is helping grassroots organizations connect supporters to their state assembly and state senate representatives for call campaigns to advocate on the legislation that matters most to their work. The HelloGOV webapp generates a campaign shortlink that can be used in texts, social posts, and more.
 image: /assets/images/projects/hellogov.jpg
-alt: "'smartphones using hellogo app'"
+alt: 'Smartphones using hellogo app'
 image-hero: /assets/images/projects/hellogov-hero.jpg
-alt-hero: "Sky blue background"
+alt-hero: 'Sky blue background'
 leadership:
   - name: Kate Rose
     links:

--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -5,7 +5,7 @@ description: We're working with community non-profits who have a Host Home initi
 image: /assets/images/projects/home-unite-us.png
 alt: 'Cartoon picture of person'
 image-hero: /assets/images/projects/home-unite-us-hero.png
-alt-hero: 'Cartoon picture of person and a plus sign and a house all in a row'
+alt-hero: 'Cartoon picture of person and a plus sign and a house all in a row.'
 leadership:
   - name: Timothy Malstead
     role: Front End Web Developer Lead (on loan to Food Oasis project)

--- a/_projects/jobs-for-hope.md
+++ b/_projects/jobs-for-hope.md
@@ -3,9 +3,9 @@ identification: '140512203'
 title: Jobs for Hope
 description: We compiled job listings from 60+ different non-profit organization websites for the LA County Homeless Initiative and consolidated them into a single database so that it is easier for job-seekers to search and filter for jobs.
 image: /assets/images/projects/jobs-for-hope.png
-alt: "'LA county homelessness initiative logo'"
+alt: 'LA county homelessness initiative logo.'
 image-hero: /assets/images/projects/jobs-for-hope-hero.png
-alt-hero: "Purple background"
+alt-hero: 'Purple background'
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/jobs-for-hope'

--- a/_projects/light-the-way.md
+++ b/_projects/light-the-way.md
@@ -2,7 +2,7 @@
 title: Light The Way
 description: Ahead of you, to guide you - Los Angeles' Best Veteran Resources.  Prevetted By Vets, For Vets.
 image: /assets/images/projects/light-the-way.jpg
-alt: "'Veteran returned from service to civilian life'"
+alt: 'Veteran returned from service to civilian life.'
 links: 
   - name: Site
     url: 'https://lighttheway.herokuapp.com/'

--- a/_projects/lucky-parking.md
+++ b/_projects/lucky-parking.md
@@ -3,9 +3,9 @@ identification: '216854923'
 title: Lucky Parking
 description: A platform looking for nearby street parking with least possibility of getting citation
 image: /assets/images/projects/lucky-parking.png
-alt: "Lucky Parking Logo"
+alt: 'Lucky Parking Logo'
 image-hero: /assets/images/projects/lucky-parking-hero.png
-alt-hero: "Lucky Parking Logo overlaid on a parking lot with a yellow Volkswagon"
+alt-hero: 'Lucky Parking Logo overlaid on a parking lot with a yellow Volkswagon.'
 leadership:
   - name: Rong Xue
     role: Product Owner

--- a/_projects/metro-ontime.md
+++ b/_projects/metro-ontime.md
@@ -3,9 +3,9 @@ identification: '155295655'
 title: Railstats LA
 description: Trailstats LA tracks LA Metro trains and generates punctuality reports. Our website enables both Metro officials and the public to easily review up-to-date statistics for LA's 6 train lines.
 image: /assets/images/projects/metro-ontime.png
-alt: "'metro ontime'"
+alt: 'metro ontime'
 image-hero: /assets/images/projects/metro-ontime-hero.png
-alt-hero: "Line graph of arrival times vs schedule for the Green Line train"
+alt-hero: 'Line graph of arrival times vs schedule for the Green Line train.'
 leadership:
   - name: Cameron Sexton
     role: Product Owner/Lead Developer

--- a/_projects/new-schools-today.md
+++ b/_projects/new-schools-today.md
@@ -3,7 +3,7 @@ identification: '222602391'
 title: New Schools Today
 description: We’re building a platform for students across LA County to create more accessible school-related apps and web apps. Our desired impact is to make students feel more welcomed and included in their community through an online academic environment created by peers, for peers
 image: /assets/images/projects/new-schools-today.jpg
-alt: 'Team working during meeting.'
+alt: 'Team working a during meeting.'
 image-hero: /assets/images/projects/new-schools-today-hero.jpg
 alt-hero: 'Team working during a meeting.'
 leadership:

--- a/_projects/new-schools-today.md
+++ b/_projects/new-schools-today.md
@@ -3,9 +3,9 @@ identification: '222602391'
 title: New Schools Today
 description: We’re building a platform for students across LA County to create more accessible school-related apps and web apps. Our desired impact is to make students feel more welcomed and included in their community through an online academic environment created by peers, for peers
 image: /assets/images/projects/new-schools-today.jpg
-alt: "'Team working during meeting'"
+alt: 'Team working during meeting.'
 image-hero: /assets/images/projects/new-schools-today-hero.jpg
-alt-hero: "'Team working during meeting'"
+alt-hero: 'Team working during a meeting.'
 leadership:
   - name: Ben Swerdlow
     role: Tech Team Lead

--- a/_projects/not-today.md
+++ b/_projects/not-today.md
@@ -5,7 +5,7 @@ description:  Not Today is an app intended to help people wait out periods of su
 image: /assets/images/projects/not-today.png
 alt: 'person being supported by another.  Art by c.w. moss'
 image-hero: /assets/images/projects/not-today-hero.png
-alt-hero: "Blue background"
+alt-hero: 'Blue background'
 leadership:
   - name: Mya Stark
     role: Product Owner & SME

--- a/_projects/record-clearance-project.md
+++ b/_projects/record-clearance-project.md
@@ -3,9 +3,9 @@ identification: '218391110'
 title: Record Clearance Project
 description: Record Clearance helps people in California with non-violent criminal records accomplish record clearance, expungement or reduction as a result of Prop 47 & Prop 64. The main features include building trust, educating the public about the program and informing those who are eligible for this program.
 image: /assets/images/projects/record-clearance.jpg
-alt: "'record clearance project'"
+alt: 'Record clearance project'
 image-hero: /assets/images/projects/record-clearance-hero.png
-alt: "'record clearance hero'"
+alt: 'Record clearance hero'
 leadership:
   - name: Angelina Molina
     role: Project Lead

--- a/_projects/shared-housing-project.md
+++ b/_projects/shared-housing-project.md
@@ -3,9 +3,9 @@ identification: '188127288'
 title: Shared Housing Project
 description: The shared housing team works on creating an efficient & effective solution for matching multiple individuals who experience homelessness as potential co-tenants, and placing the matched individuals in suitable shared housing units.
 image: /assets/images/projects/shared-housing-project.jpg
-alt: "'linked arms'"
+alt: 'Linked arms'
 image-hero: /assets/images/projects/shared-housing-project-hero.png
-alt-hero: "Light-gray background"
+alt-hero: 'Light-gray background'
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/shared-housing'

--- a/_projects/spare.md
+++ b/_projects/spare.md
@@ -3,9 +3,9 @@ identification: '127079094'
 title: Spare
 description: A fun new project project that connects people in need of clothing and other essentials with people in the community who have things to spare. It's kind of like one on one Goodwill. The main objective is to foster interactions between the housed and unhoused. The donation is the mechanism for building these connections throughout our community.
 image: /assets/images/projects/spare.png
-alt: "'a logo that reads what can you spare'"
+alt: 'A logo that reads what can you spare'
 image-hero: /assets/images/projects/spare-hero.png
-alt-hero: "Gray background"
+alt-hero: 'Gray background'
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/spare'

--- a/_projects/tdm-calculator.md
+++ b/_projects/tdm-calculator.md
@@ -3,8 +3,9 @@ identification: '197452459'
 title: LA TDM Calculator
 description: We’re building a TDM web calculator for LADOT. It scores proposed real estate developments in real-time and aims to discourage exceeding parking requirements to reduce the occurrence of single-occupancy trips to new developments.
 image: /assets/images/projects/tdm-calculator.jpg
-alt: "'LA TDM Calculator Landing Page (Mock Up)'"
+alt: 'LA TDM Calculator Landing Page (Mock Up)'
 image-hero: /assets/images/projects/TDM-calculator-hero.png
+alt-hero: 'Los Angeles skyline at dusk, complete with cranes on top of buildings and golden smog.'
 leadership:
   - name: Bonnie Wolfe
     role: Product Owner

--- a/_projects/undebate.md
+++ b/_projects/undebate.md
@@ -3,9 +3,9 @@ identification: '221070186'
 title: Undebate
 description: Not debates, but recorded online video Q&A with candidates so voters can quickly can get to know them, for every candidate, for every election, across the US.
 image: /assets/images/projects/undebate.jpg
-alt: "Undebate with moderator and 7 participants"
+alt: 'Undebate with moderator and 7 participants.'
 image-hero: /assets/images/projects/undebate-hero.jpg
-alt-hero: "Silhouette of three people sitting in chairs. Two of them have empty speach bubbles over their heads."
+alt-hero: 'Silhouette of three people sitting in chairs. Two of them have empty speach bubbles over their heads.'
 leadership:
   - name: David Fridley
     role: Tech Lead

--- a/_projects/vrms.md
+++ b/_projects/vrms.md
@@ -3,9 +3,9 @@ identification: '226157870'
 title: VRMS
 description: VRMS is a tool used for the engagement, support, and retention of a network of volunteers.
 image: /assets/images/projects/vrms.png
-alt: "VRMS homepage showing the check-in buttons"
+alt: 'VRMS homepage showing the check-in buttons.'
 image-hero: /assets/images/projects/vrms-hero.png
-alt-hero: "City of LA skyline"
+alt-hero: 'City of LA skyline.'
 leadership:
   - name: Matt Tapper
     role: Tech Team Lead

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -3,7 +3,7 @@ identification: '130000551'
 title: Hackforla.org Website
 description: The hackforla.org website is our organization's way of communicating with new volunteers, stakeholders, and donors. This project is a good place to start for new volunteers looking to polish their git protocol skills (branches, separation of concerns, etc.). We are currently in a redesign phase, using CI/CD in the run up to demoing the new version at Code for America's Summit 2020 in Washington, D.C.
 image: /assets/images/projects/website.png
-alt: "wireframe sample from new website"
+alt: 'Wireframe sample from new website.'
 leadership:
   - name: Kegan Maher
     role: Technical Architect

--- a/_projects/work-for-la.md
+++ b/_projects/work-for-la.md
@@ -3,7 +3,7 @@ identification: '79977929'
 title: Work for LA
 description: Applying for work should be simple—but the application process for the City of LA is confusing and cumbersome. We’re going to make it easier to find the job of your dreams.
 image: /assets/images/projects/work-for-la.jpg
-alt: "'Los Angeles City Hall building'"
+alt: 'Los Angeles City Hall building'
 leadership:
   - name: Hunter Owens
     role: Data Scientist

--- a/_projects/writeforall.md
+++ b/_projects/writeforall.md
@@ -5,9 +5,9 @@ description: We want to improve the language used in websites to be
   more inclusive (of all communities) while also educating the public
   about exclusionary language. @writeforallorg&#8482;
 image: /assets/images/projects/writeforall.png
-alt: "A a rainbow document searcher icon , the words 'Write for All TM', and a rainbow-like border"
+alt: 'A a rainbow document searcher icon, the words Write for All TM, and a rainbow-like border.'
 image-hero: /assets/images/projects/writeforall-hero.png
-alt-hero: "A large rainbow-colored background with a rainbow document searcher icon in the middle"
+alt-hero: 'A large rainbow-colored background with a rainbow document searcher icon in the middle.'
 leadership:
   - name: Joel Parker Henderson
     role: Project Architect

--- a/_projects/writeforall.md
+++ b/_projects/writeforall.md
@@ -5,7 +5,7 @@ description: We want to improve the language used in websites to be
   more inclusive (of all communities) while also educating the public
   about exclusionary language. @writeforallorg&#8482;
 image: /assets/images/projects/writeforall.png
-alt: 'A a rainbow document searcher icon, the words Write for All TM, and a rainbow-like border.'
+alt: 'A rainbow document searcher icon, the words &quot;Write for All TM&quot;, and a rainbow-like border.'
 image-hero: /assets/images/projects/writeforall-hero.png
 alt-hero: 'A large rainbow-colored background with a rainbow document searcher icon in the middle.'
 leadership:


### PR DESCRIPTION
Fixes #625

Kian suggested a better fix, so...
- Changed the include file to better display alt attribute
- Changed all (but one) .md file so that the alt and alt-hero attributes were consistent with a single quotation mark. 
- Added alt-hero attribute to 311 and tdm-calculator because they didn't have it. 
