### PR TITLE
Project page getting started link 664

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -101,7 +101,7 @@ layout: default
     <div id="getting-started-section" class='project-page-card'>
         <ul class="resource-list unstyled-list">
             <!-- Hfla Start Guide -->
-            {%- include resource-card.html name='Getting Started' url='https://github.com/hackforla/getting-started' -%}
+            {%- include resource-card.html name='Getting Started' url='https://www.hackforla.org/getting-started' -%}
 
             {% assign hasGettingStarted = false %}
 


### PR DESCRIPTION
Fixes #664 

Updated  _layouts/project.html so the getting started link goes to https://www.hackforla.org/getting-started rather than the github getting started page. 