### PR TITLE
Get rid of hack nights in nav

### DIFF
--- a/_data/navigation/main.yml
+++ b/_data/navigation/main.yml
@@ -1,7 +1,7 @@
-- name: Hack Nights
-  link: "/#hack-nights"
-  list_class_name:
-  icon: /svg/icon-hacknights.svg
+# - name: Hack Nights
+#   link: "/#hack-nights"
+#   list_class_name:
+#   icon: /svg/icon-hacknights.svg
 
 - name: Projects
   link: "/#projects"


### PR DESCRIPTION
Currently the hack nights section is not being shown as hack nights are not active. Therefore when someone clicks "Hack Nights" on the nav they aren't taken anywhere, and it seems like a bug.

For the time being "Hack Nights" should be commented out, until we bring hack nights back