### PR TITLE
Change gh issues guide to comin-soon

### DIFF
--- a/_guide-pages/github-issues.html
+++ b/_guide-pages/github-issues.html
@@ -12,7 +12,7 @@ in-this-guide:
   - name: Member Analytics
     link: '#member-analytics'
 card-type: guide-page
-status: active
+status: coming-soon
 display: true
 category: development
 svg: svg/toolkit-default-card-image.svg

--- a/_guide-pages/survey-reporting-dashboard-guide.html
+++ b/_guide-pages/survey-reporting-dashboard-guide.html
@@ -15,7 +15,7 @@ card-type: guide-page
 status: active
 display: true
 category: project management
-svg: svg/survey-reporting-image.svg
+svg: svg/2FA.svg
 alt-text: survey-reporting-image
 provider-link: 'https://www.hackforla.org/guide-pages/survey-reporting-dashboard-guide'
 ---

--- a/_sass/components/toolkit.scss
+++ b/_sass/components/toolkit.scss
@@ -196,11 +196,13 @@
         font-size: 1.5rem;
         margin-bottom: 3rem;
         line-height: 1.75rem;
+        max-height: 2rem;
 
         @media #{$bp-below-mobile} {
             font-size: 1.4rem;
             margin-bottom: 1.5rem;
             line-height: 1.5rem;
+            max-height: fit-content;
         }
     }
 

--- a/toolkit.html
+++ b/toolkit.html
@@ -66,7 +66,7 @@ Here you can find, share, and suggest tools that are of use to the open source c
                     {%- endif -%}
 
                     {%- if item.description -%}
-                    <p class="toolkit-flex-item-p">{{ item.description }}</p>
+                    <p class="toolkit-flex-item-p">{{ item.short-description }}</p>
                     {%- endif -%}
 
                 </div>


### PR DESCRIPTION
Hotfix to change the "Getting the Most Out of GitHub Issues" to coming soon. I had to make some style changes so that the "coming soon" and the description boxes all lined up at the same height. 

An important note: for the hotfix, I changed the image of the "Building a Survey Reporting Dashboard" because the image was causing some really weird bugs when I changed "Getting the Most Out of GitHub Issues" to coming soon (screenshots bellow). It was strange because when I changed the picture of the Survey Reporting guide to the 2FA image, things work as intended. It took me a while to figure out this image was causing an issue. Sundays are the days I try not to code after noon time, so I hope it is understandable that this temp fix of using different svg is preferred for me right now, and I will look more into it as I resume my work on this page. 

# Before
![Screenshot from 2020-09-27 12-16-43](https://user-images.githubusercontent.com/18221058/94374049-67314300-00be-11eb-9cd9-e6043490b41d.png)
# After changing image to 2FA one
![Screenshot from 2020-09-27 12-35-26](https://user-images.githubusercontent.com/18221058/94374051-68627000-00be-11eb-831a-5c846edcf539.png)
