### PR TITLE
Toolkit mvp update

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
   <title>{% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape}}</title>
   <meta name="description"
     content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 400 }}{% else %}{{ site.description }}{% endif %}" />
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | absolute_url }}" />
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
   <link rel="shortcut icon" type="image/x-icon" href="{{ 'favicon.ico' | absolute_url }}" />
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
   <title>{% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape}}</title>
   <meta name="description"
     content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 400 }}{% else %}{{ site.description }}{% endif %}" />
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | absolute_url }}" />
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
   <link rel="shortcut icon" type="image/x-icon" href="{{ 'favicon.ico' | absolute_url }}" />
 

--- a/_includes/svg/toolkit-default-card-image.svg
+++ b/_includes/svg/toolkit-default-card-image.svg
@@ -1,15 +1,5 @@
-<svg viewBox="0 0 414 289" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="414" height="289">
-<path d="M0 16C0 7.16345 7.16344 0 16 0H398C406.837 0 414 7.16344 414 16V288.026H0V16Z" fill="#C4C4C4"/>
-</mask>
-<g mask="url(#mask0)">
-<mask id="mask1" mask-type="alpha" maskUnits="userSpaceOnUse" x="-318" y="4" width="1050" height="280">
-<rect x="-318" y="4.72913" width="1050" height="278.542" fill="#C4C4C4"/>
-</mask>
-<g mask="url(#mask1)">
-<rect x="-318" y="-92.25" width="1050" height="465.938" fill="url(#pattern0)"/>
-</g>
-</g>
+<svg viewBox="0 0 414 280" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<rect x="-318" y="-96.2501" width="1050" height="465.938" fill="url(#pattern0)"/>
 <defs>
 <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
 <use xlink:href="#image0" transform="translate(0 -0.00028169) scale(0.000666667 0.00150235)"/>

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -80,14 +80,21 @@
 }
 
 .suggest-guide-group {
-    display: flex; 
-    flex-wrap: wrap; 
-    justify-content: space-between; 
-    padding-left: 3rem; 
-    padding-right: 3rem; 
+    display: flex;
+    justify-content: space-between;
+    padding-left: 3rem;
+    padding-right: 3rem;
     text-align: center;
+    margin-bottom: 2rem;
+
+    @media only screen and (max-width: 1200px){
+        padding-left: 0rem;
+        padding-right: 0rem;
+    }
 
     @media only screen and (max-width: 600px){
+        padding-left: 3rem; 
+        padding-right: 3rem;
         justify-content: space-evenly;
         flex-direction: column;
     }
@@ -97,10 +104,12 @@
     font-style: normal;
     font-weight: normal;
     font-size: 35px;
-    line-height: 41px;
-    display: flex;
-    align-items: center;
     color: #FFFFFF;
+    margin-bottom: 0;
+
+    @media only screen and (max-width: 600px){
+        margin-bottom: 1rem;
+    }
 }
 
 .toolkit-flex-container {
@@ -109,10 +118,20 @@
     padding-left: 2rem;
     padding-right: 2rem;
 
-    @media only screen and (max-width: 800px) {
+    @media only screen and (max-width: 1200px) {
+        display: grid;
+        grid-gap: 24px;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        padding: 0;
+    }
+
+    @media #{$bp-below-mobile} {
+        display: flex;
+        flex-wrap: wrap;
         align-content: center;
         flex-direction: column;
     }
+
 }
 
 .outer-link {
@@ -126,36 +145,31 @@
     flex-basis: 25%;
     min-width: 33rem;
     padding: 0rem;
+    height: fit-content;
     min-height: 38rem;
-    overflow: hidden;
     margin: 1.2rem 1rem;
     overflow: hidden;
 
     @media only screen and (max-width: 1200px) {
-        flex-basis: 13%; 
-        margin: 1rem;
-    }
-
-    @media only screen and (max-width: 800px) {
-        min-width: 28rem;
+        min-width: auto;
         min-height: auto;
-    }
-
-    @media only screen and (max-width: 600px) {
-        min-height: 30rem;
+        width: 100%;
+        height: 100%;
+        margin: 0;
     }
 
     @media #{$bp-below-mobile} {
-        min-width: auto;
-    }
+        margin-bottom: 1.5rem;
+    }    
 
 }
 
 .toolkit-flex-item-img-container {
-    min-height: 60%;
+    height: 60%;
 
     @media only screen and (max-width: 1000px) {
-        min-height: auto;
+        height: auto;
+        width: 100%;
     }
 }
 
@@ -169,29 +183,35 @@
 }
 
 .resource-svg-icons {
-    height: 356px;
-    width: 356px;
-    margin: 0rem auto 1rem auto;
-    display: flex;
+    height: 22.5rem;
+    width: 22.5rem;
+    margin: 0 auto;
 
-    @media only screen and (max-width: 800px) {
-        height: 164px;
-        width: 164px;
-        margin-bottom: 3rem;
+    @media only screen and (max-width: 1000px) {
+        height: 15.5rem;
+        width: 15.5rem;
+    }
+
+    @media #{$bp-below-mobile} {
+        height: 14.5rem;
+        width: 14.5rem;
     }
 }
 
 .toolkit-info-container {
-    margin-top: 1rem;
+    margin: 1rem auto;
     padding: 0rem 2rem;
 
     h3 {
         font-weight: normal;
         text-align: left;
         font-size: 1.5rem;
-        margin-bottom: 3rem;
+        margin-bottom: 1.5rem;
         line-height: 1.75rem;
-        max-height: 2rem;
+        height: fit-content;
+
+        @media only screen and (max-width: 1000px) {
+        }
 
         @media #{$bp-below-mobile} {
             font-size: 1.4rem;
@@ -201,19 +221,15 @@
         }
     }
 
-    @media #{$bp-below-mobile} {
-        padding: 2rem;
+    @media only screen and (max-width: 1000px) {
+        margin-bottom: 4rem;
     }
 }
 
 .toolkit-info-container p {
     margin: 1rem auto auto 0rem;
     line-height: 1.1rem;
-
-    @media only screen and (max-width: 500px) {
-        width: 15rem;
-        padding: 0rem !important;
-    }
+    width: 100%;
 }
 
 .not-clickable {
@@ -227,7 +243,7 @@
     font-size: 1.5rem;
     line-height: 1.2rem;
 
-    @media #{$bp-below-mobile} {
+    @media only screen and (max-width: 1000px) {
         font-size: 1.1rem;
     }
 }
@@ -237,5 +253,5 @@
 }
 
 .toolkit-button {
-    margin: 5px 0px;
+    margin: 0;
 }

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -2,28 +2,16 @@
     padding-top: 10rem; 
     padding-bottom: 10rem;
 
-    @media only screen and (max-width: 1200px) {
-        padding-bottom: 3rem;
-    }
-
     &__text-group {
         display: flex; 
         flex-wrap: wrap; 
-        justify-content: space-evenly; 
-        padding-left: 30rem; 
-        padding-right: 30rem; 
+        justify-content: center;
         text-align: center;
-        padding: 1.5rem 22rem;
-
-        @media only screen and (max-width: 1300px){
-            padding-left: 0;
-            padding-right: 0;
-            justify-content: space-evenly;
-        }
+        padding: 1.4rem 0;
 
     }
     
-    &__h2 {
+    &__title {
         font-style: normal;
         font-weight: normal;
         font-size: 3.7rem;
@@ -32,13 +20,11 @@
         text-align: center;
     }
 
-    &__h3 {
+    &__banner-item {
         margin-block-end: 0;
         font-weight: 300;
-
-        @media #{$bp-below-mobile} {
-            font-size: .75rem;
-        }
+        font-size: 1.75rem;
+        margin: 0 4.5rem;
     }
     
     &__p {
@@ -50,14 +36,6 @@
         margin: 3rem auto;
         text-align: left;
 
-        @media only screen and (max-width: 1200px){
-            max-width: 70vw;
-        }
-
-        @media only screen and (max-width: 400px){
-            font-size: 1.1rem;
-        }
-
     }
 
     &__hero-image {
@@ -68,10 +46,6 @@
 .toolkit-svg {
     width: 45%;
     height: 60%;
-
-    @media only screen and (max-width: 1200px) {
-        width: 75%;
-    }
 }
 
 .toolkit-background {
@@ -86,30 +60,14 @@
     padding-right: 3rem;
     text-align: center;
     margin-bottom: 2rem;
-
-    @media only screen and (max-width: 1200px){
-        padding-left: 0rem;
-        padding-right: 0rem;
-    }
-
-    @media only screen and (max-width: 600px){
-        padding-left: 3rem; 
-        padding-right: 3rem;
-        justify-content: space-evenly;
-        flex-direction: column;
-    }
 }
 
-.suggest-guide-group h3 {
+.suggest-guide-group h2 {
     font-style: normal;
     font-weight: normal;
     font-size: 35px;
     color: #FFFFFF;
     margin-bottom: 0;
-
-    @media only screen and (max-width: 600px){
-        margin-bottom: 1rem;
-    }
 }
 
 .toolkit-flex-container {
@@ -118,84 +76,35 @@
     padding-left: 2rem;
     padding-right: 2rem;
     align-items: stretch;
-
-    @media only screen and (max-width: 1200px) {
-        display: grid;
-        grid-gap: 24px;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        padding: 0;
-    }
-
-    @media #{$bp-below-mobile} {
-        display: flex;
-        flex-wrap: wrap;
-        align-content: center;
-        flex-direction: column;
-    }
-
 }
 
 .outer-link {
-    width: 30px;
+    width: 1.5rem;
 }
 
 .toolkit-flex-item {
     position: relative;
-    flex-basis: 25%;
+    max-width: 24.5rem;
     padding: 0rem;
     height: auto;
     margin: 1.2rem 1rem;
     overflow: hidden;
 
-    @media only screen and (max-width: 1200px) {
-        min-width: auto;
-        min-height: auto;
-        width: 100%;
-        height: 100%;
-        margin: 0;
-    }
-
-    @media #{$bp-below-mobile} {
-        margin-bottom: 1.5rem;
-    }    
-
-}
-
-.toolkit-flex-item-img-container {
-
-    @media only screen and (max-width: 1000px) {
-        height: auto;
-        width: 100%;
-    }
 }
 
 .toolkit-flex-item-img-container svg {
     width: 100%;
     height: 100%;
-
-    @media only screen and (max-width: 800px) {
-        flex: 1;
-    }
 }
 
 .resource-svg-icons {
-    height: 22.5rem;
-    width: 22.5rem;
+    height: 17.5rem;
+    width: 17.5rem;
     margin: 0 auto;
-
-    @media only screen and (max-width: 1000px) {
-        height: 15.5rem;
-        width: 15.5rem;
-    }
-
-    @media #{$bp-below-mobile} {
-        height: 14.5rem;
-        width: 14.5rem;
-    }
 }
 
 .toolkit-info-container {
-    margin-top: 1rem 0rem;
+    margin: 1rem 0rem 2rem;
     padding: 0rem 2rem;
 
     h3 {
@@ -203,20 +112,6 @@
         text-align: left;
         font-size: 1.125rem;
         height: fit-content;
-
-        @media only screen and (max-width: 1000px) {
-        }
-
-        @media #{$bp-below-mobile} {
-            font-size: 1.4rem;
-            margin-bottom: 1.5rem;
-            line-height: 1.5rem;
-            max-height: fit-content;
-        }
-    }
-
-    @media only screen and (max-width: 1000px) {
-        margin-bottom: 4rem;
     }
 }
 
@@ -236,10 +131,6 @@
     line-height: 1.2rem;
     right: 1rem;
     bottom: 1rem;
-
-    @media only screen and (max-width: 1000px) {
-        font-size: 1.1rem;
-    }
 }
 
 .toolkit__card-list {
@@ -249,3 +140,97 @@
 .toolkit-button {
     margin: 0;
 }
+
+@media #{$bp-below-desktop} {
+
+    .toolkit-header {
+        padding-bottom: 3rem;
+
+        &__text-group {
+            padding-left: 0;
+            padding-right: 0;
+        }
+
+        &__banner-item {
+            font-size: 1.2rem;
+            margin: 0 1.2rem;
+        }
+    }
+
+    .toolkit-svg {
+        width: 75%;
+    }
+
+    .suggest-guide-group {
+        padding-left: 0rem;
+        padding-right: 0rem;
+    }
+
+    .toolkit-flex-container {
+        display: grid;
+        grid-gap: 24px;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        padding: 0;
+    }
+
+    .toolkit-flex-item {
+        margin: 0 auto;
+    }
+
+    .resource-svg-icons {
+        height: 15.5rem;
+        width: 15.5rem;
+    }
+}
+
+@media #{$bp-below-mobile} {
+    .toolkit-header {
+        &__banner-item {
+            font-size: .75rem;
+            margin: 0 1rem;
+        }
+
+        &__p {
+            font-size: 1.1rem;
+        }
+    }
+
+    .toolkit-flex-container {
+        display: flex;
+        flex-wrap: wrap;
+        align-content: center;
+        flex-direction: column;
+    }
+
+    .toolkit-flex-item {
+        margin-bottom: 1.5rem;
+    }
+
+    .resource-svg-icons {
+        height: 14.5rem;
+        width: 14.5rem;
+    }
+
+    .toolkit-info-container {
+        h3 {
+            font-size: 1.4rem;
+            margin-bottom: 1.5rem;
+            line-height: 1.5rem;
+            max-height: fit-content;
+        }
+    }
+
+    .suggest-guide-group {
+        align-items: center;
+        flex-direction: column;
+
+        h2 {
+            margin-bottom: 1rem;
+            font-size: 31px;
+        }
+    }
+
+    .toolkit-button {
+        width: fit-content;
+    }
+}  

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -117,6 +117,7 @@
     flex-wrap: wrap;
     padding-left: 2rem;
     padding-right: 2rem;
+    align-items: stretch;
 
     @media only screen and (max-width: 1200px) {
         display: grid;
@@ -140,13 +141,9 @@
 
 .toolkit-flex-item {
     position: relative;
-    display: flex;
-    flex-direction: column;
     flex-basis: 25%;
-    min-width: 33rem;
     padding: 0rem;
-    height: fit-content;
-    min-height: 38rem;
+    height: auto;
     margin: 1.2rem 1rem;
     overflow: hidden;
 
@@ -165,7 +162,6 @@
 }
 
 .toolkit-flex-item-img-container {
-    height: 60%;
 
     @media only screen and (max-width: 1000px) {
         height: auto;
@@ -199,15 +195,13 @@
 }
 
 .toolkit-info-container {
-    margin: 1rem auto;
+    margin-top: 1rem 0rem;
     padding: 0rem 2rem;
 
     h3 {
         font-weight: normal;
         text-align: left;
-        font-size: 1.5rem;
-        margin-bottom: 1.5rem;
-        line-height: 1.75rem;
+        font-size: 1.125rem;
         height: fit-content;
 
         @media only screen and (max-width: 1000px) {
@@ -238,10 +232,10 @@
 
 .toolkit-flex-item-status {
     position: absolute;
-    bottom: 1rem;
-    right: 1rem;
-    font-size: 1.5rem;
+    font-size: 1.125rem;
     line-height: 1.2rem;
+    right: 1rem;
+    bottom: 1rem;
 
     @media only screen and (max-width: 1000px) {
         font-size: 1.1rem;

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -126,7 +126,7 @@
     flex-basis: 25%;
     min-width: 33rem;
     padding: 0rem;
-    min-height: 39rem;
+    min-height: 38rem;
     overflow: hidden;
     margin: 1.2rem 1rem;
     overflow: hidden;
@@ -182,7 +182,8 @@
 }
 
 .toolkit-info-container {
-    padding: 1rem 2rem 5rem 2rem;
+    margin-top: 1rem;
+    padding: 0rem 2rem;
 
     h3 {
         font-weight: normal;

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -143,32 +143,20 @@
     }
 }
 
-.resource-container {
-    display: flex;
-    flex-wrap: wrap;
-    padding: 1.4rem;
-
-    @media only screen and (max-width: 800px) {
-        justify-content: center;
-    }
-
-}
-
 .outer-link {
     width: 30px;
-    display: flex;
-    align-self: flex-end;
 }
 
 .toolkit-flex-item {
-    flex-basis: 25%;
-    padding-left: 0rem;
-    padding-right: 0rem;
-    padding-top: 0rem;
-    margin: 1.2rem 1rem;
     position: relative;
+    display: flex;
+    flex-direction: column;
+    flex-basis: 25%;
     min-width: 33rem;
-    padding-bottom: 0;
+    padding: 0rem;
+    min-height: 40rem;
+    overflow: hidden;
+    margin: 1.2rem 1rem;
     overflow: hidden;
 
     @media only screen and (max-width: 1200px) {
@@ -178,6 +166,7 @@
 
     @media only screen and (max-width: 800px) {
         min-width: 28rem;
+        min-height: auto;
     }
 
     @media only screen and (max-width: 600px) {
@@ -200,6 +189,7 @@
 
 .toolkit-info-container {
     padding: 1rem 2rem 5rem 2rem;
+    min-height: 15rem;
 
     h3 {
         font-size: 1.5rem;
@@ -267,18 +257,12 @@
     color: black !important;
 }
 
-.toolkit-status-text {
-    display: flex;
-    flex-direction: row-reverse;
+.toolkit-flex-item-status {
     align-self: flex-end;
-    right: 100%;
-    font-style: normal;
-    font-weight: normal;
     font-size: 1.5rem;
     line-height: 1.2rem;
-    color: #333333;
-    padding-right: 1rem;
-    padding-bottom: 1rem;
+    margin-right: 1rem;
+    margin-bottom: 1rem;
 
     @media #{$bp-below-mobile} {
         font-size: 1.1rem;
@@ -290,37 +274,6 @@
     max-width: 13rem;
     max-height: 25rem;
     margin: auto;
-}
-
-.toolkit-flex-item-resource {
-    display: flex;
-    position: relative;
-    flex-basis: 23%;
-    flex-direction: column;
-    min-height: 40rem;
-    padding: 1.5rem;
-    margin: 1.2rem !important;
-    justify-content: center;
-
-    min-width: 33em;
-    flex-grow: 0;
-
-    @media only screen and (max-width: 800px) {
-        min-height: 30rem;
-    }
-
-    // @media only screen and (max-width: 800px) {
-    //     min-height: 30rem;
-    // }
-
-    @media only screen and (max-width: 600px) {
-        min-width: 28rem;
-    }
-
-    @media #{$bp-below-mobile} {
-        min-width: auto;
-    }
-
 }
 
 .toolkit-resource-header {

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -79,34 +79,6 @@
     padding: 2rem;
 }
 
-.toolkit-section-container-h5 {
-    text-align: left;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 30px;
-    display: flex;
-    align-items: center;
-}
-
-.toolkit-section-container-li {
-    text-align: left;
-}
-
-.toolkit-resources-h5 {
-    padding-top: 2rem;
-    text-align: left;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 3.7rem;
-    line-height: 35px;
-    display: flex;
-    align-items: center;
-}
-
-.toolkit-resources-li {
-    text-align: left;
-}
-
 .suggest-guide-group {
     display: flex; 
     flex-wrap: wrap; 
@@ -154,7 +126,7 @@
     flex-basis: 25%;
     min-width: 33rem;
     padding: 0rem;
-    min-height: 40rem;
+    min-height: 39rem;
     overflow: hidden;
     margin: 1.2rem 1rem;
     overflow: hidden;
@@ -179,19 +151,42 @@
 
 }
 
-.toolkit-image-container {
-    min-height: 23.5rem;
+.toolkit-flex-item-img-container {
+    min-height: 60%;
 
     @media only screen and (max-width: 1000px) {
         min-height: auto;
     }
 }
 
+.toolkit-flex-item-img-container svg {
+    width: 100%;
+    height: 100%;
+
+    @media only screen and (max-width: 800px) {
+        flex: 1;
+    }
+}
+
+.resource-svg-icons {
+    height: 356px;
+    width: 356px;
+    margin: 0rem auto 1rem auto;
+    display: flex;
+
+    @media only screen and (max-width: 800px) {
+        height: 164px;
+        width: 164px;
+        margin-bottom: 3rem;
+    }
+}
+
 .toolkit-info-container {
     padding: 1rem 2rem 5rem 2rem;
-    min-height: 15rem;
 
     h3 {
+        font-weight: normal;
+        text-align: left;
         font-size: 1.5rem;
         margin-bottom: 3rem;
         line-height: 1.75rem;
@@ -210,45 +205,12 @@
     }
 }
 
-
-.toolkit-image-container svg {
-    width: 100%;
-
-    @media only screen and (max-width: 800px) {
-        flex: 1;
-    }
-}
-
-.toolkit-flex-item-header {
-    font-style: normal;
-    font-weight: normal;
-    font-size: 1.3rem;
-    line-height: 1.2rem;
-    text-align: left;
-    color: #FA114F;
-
-    @media only screen and (max-width: 500px) {
-        font-size: 1rem;
-    }
-}
-
-.toolkit-section-container p {
+.toolkit-info-container p {
     margin: 1rem auto auto 0rem;
+    line-height: 1.1rem;
 
     @media only screen and (max-width: 500px) {
         width: 15rem;
-    }
-}
-
-.toolkit-flex-item-p {
-    font-style: normal;
-    font-weight: normal;
-    font-size: 1rem;
-    text-align: left !important;
-    line-height: 1.1rem;
-    position: inherit;
-
-    @media #{$bp-below-mobile} {
         padding: 0rem !important;
     }
 }
@@ -258,66 +220,19 @@
 }
 
 .toolkit-flex-item-status {
-    align-self: flex-end;
+    position: absolute;
+    bottom: 1rem;
+    right: 1rem;
     font-size: 1.5rem;
     line-height: 1.2rem;
-    margin-right: 1rem;
-    margin-bottom: 1rem;
 
     @media #{$bp-below-mobile} {
         font-size: 1.1rem;
     }
 }
 
-.toolkit-image {
-    display: inline-block;
-    max-width: 13rem;
-    max-height: 25rem;
-    margin: auto;
-}
-
-.toolkit-resource-header {
-    font-style: normal;
-    font-weight: normal;
-    font-size: 1.5rem;
-    line-height: 1.5rem;
-    text-decoration-line: underline;
-    width: fit-content; //ADDED THIS LINE
-    /* Accent Color */
-    color: #FA114F;
-
-    @media #{$bp-below-mobile} {
-        margin-bottom: .95rem;
-    }
-}
-
-.toolkit-resource-text {
-    font-style: normal;
-    font-weight: normal;
-    font-size: 1rem;
-    text-align: left !important;
-    
-    color: #333333;
-}
-
-.toolkit__external-resources {
-    padding-top: 10rem;
-}
-
-.svg-container {
-    height: 356px;
-    width: 356px;
-    margin: 0rem auto 1rem auto;
-    display: flex;
-
-    @media only screen and (max-width: 800px) {
-        height: 164px;
-        width: 164px;
-        margin-bottom: 3rem;
-    }
-}
-.svg-container svg{
-    width: 100%;
+.toolkit__card-list {
+    margin-bottom: 10rem;
 }
 
 .toolkit-button {

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -169,6 +169,7 @@
     position: relative;
     min-width: 33rem;
     padding-bottom: 0;
+    overflow: hidden;
 
     @media only screen and (max-width: 1200px) {
         flex-basis: 13%; 
@@ -187,6 +188,14 @@
         min-width: auto;
     }
 
+}
+
+.toolkit-image-container {
+    min-height: 23.5rem;
+
+    @media only screen and (max-width: 1000px) {
+        min-height: auto;
+    }
 }
 
 .toolkit-info-container {
@@ -213,11 +222,10 @@
 
 
 .toolkit-image-container svg {
-    width: 100% !important;
+    width: 100%;
 
     @media only screen and (max-width: 800px) {
         flex: 1;
-        width: 100%;
     }
 }
 

--- a/toolkit.html
+++ b/toolkit.html
@@ -19,7 +19,7 @@ Here you can find, share, and suggest tools that are of use to the open source c
 </div>
 
 <div class="toolkit-background content-section">
-    <div class="toolkit__guides-section">
+    <div class="toolkit__card-list">
         <div class="suggest-guide-group"><h3>Guides (We Made These!)</h3><button class="toolkit-button btn btn-primary">Suggest a guide</button></div>
 
     <div class="toolkit-flex-container">
@@ -28,21 +28,21 @@ Here you can find, share, and suggest tools that are of use to the open source c
         {%- for item in site.guide-pages -%}
         {%- if item.status == 'active' -%}
 
-            <div class="toolkit-flex-item section-container toolkit-section-container">
+            <div class="toolkit-flex-item section-container">
             
                 {%- if item.svg -%}
-                <div class="toolkit-image-container">
+                <div class="toolkit-flex-item-img-container">
                     {% include {{ item.svg }} %}
                 </div>
                 {%- endif -%}
 
                 <div class="toolkit-info-container">
                     {%- if item.title -%}
-                    <h3 class="toolkit-flex-item-header"><a href={{ item.provider-link }}>{{ item.title }}</a></h3>
+                    <h3><a href={{ item.provider-link }}>{{ item.title }}</a></h3>
                     {%- endif -%}
 
                     {%- if item.short-description -%}
-                    <p class="toolkit-flex-item-p">{{ item.short-description }}</p>
+                    <p>{{ item.short-description }}</p>
                     {%- endif -%}
                 </div>
                     
@@ -52,21 +52,21 @@ Here you can find, share, and suggest tools that are of use to the open source c
 
         {%- for item in site.guide-pages -%}
         {%- if item.status == 'coming-soon' -%}
-            <div class="toolkit-flex-item section-container toolkit-section-container">
+            <div class="toolkit-flex-item section-container">
             
                 {%- if item.svg -%}
-                <div class="toolkit-image-container">
+                <div class="toolkit-flex-item-img-container">
                     {% include {{ item.svg }} %}
                 </div>
                 {%- endif -%}
 
                 <div class="toolkit-info-container">
                     {%- if item.title -%}
-                    <h3 class="toolkit-flex-item-header not-clickable">{{ item.title }}</h3>
+                    <h3 class="not-clickable">{{ item.title }}</h3>
                     {%- endif -%}
 
                     {%- if item.description -%}
-                    <p class="toolkit-flex-item-p">{{ item.short-description }}</p>
+                    <p>{{ item.short-description }}</p>
                     {%- endif -%}
 
                 </div>
@@ -80,24 +80,24 @@ Here you can find, share, and suggest tools that are of use to the open source c
 
     </div>
 
-    <div class="toolkit__external-resources">
+    <div class="toolkit__card-list">
         <div class="suggest-guide-group"><h3>External Resources</h3><button class="toolkit-button btn btn-primary">Suggest a resource</button></div>
 
         <div class="toolkit-flex-container">
             <!-- Searching through toolkitResources collection -->
             {%- for item in site.toolkitResources -%}
             {%- if item.display ==  true -%}
-            <div class="toolkit-flex-item section-container toolkit-section-container">
+            <div class="toolkit-flex-item section-container">
 
                 {%- if item.svg -%}
-                <div class="svg-container">
+                <div class="toolkit-flex-item-img-container resource-svg-icons">
                     {% include {{ item.svg }} %}
                 </div>
                 {%- endif -%}
-                
+
                 <div class="toolkit-info-container">
-                    <h3 class="toolkit-resource-header"><a href="{{item.provider-link}}" target="_blank">{{ item.title }}</a></h3>
-                    <p class="toolkit-resource-text">{{ item.description }}</p>
+                    <h3><a href="{{item.provider-link}}" target="_blank">{{ item.title }}</a></h3>
+                    <p>{{ item.description }}</p>
                 </div>
                 <a href="{{item.provider-link}}" class="toolkit-flex-item-status outer-link" target="_blank">
                     {% include {{ item.link-svg }} %}

--- a/toolkit.html
+++ b/toolkit.html
@@ -71,7 +71,7 @@ Here you can find, share, and suggest tools that are of use to the open source c
 
                 </div>
                 {%- if item.status == 'coming-soon' -%}
-                    <span class="toolkit-status-text">coming soon</span>
+                    <span class="toolkit-flex-item-status">coming soon</span>
                 {%- endif -%}
             </div>
         {%- endif -%}
@@ -83,25 +83,25 @@ Here you can find, share, and suggest tools that are of use to the open source c
     <div class="toolkit__external-resources">
         <div class="suggest-guide-group"><h3>External Resources</h3><button class="toolkit-button btn btn-primary">Suggest a resource</button></div>
 
-        <div class="resource-container">
+        <div class="toolkit-flex-container">
             <!-- Searching through toolkitResources collection -->
             {%- for item in site.toolkitResources -%}
             {%- if item.display ==  true -%}
-            <div class="toolkit-flex-item-resource section-container toolkit-section-container">
+            <div class="toolkit-flex-item section-container toolkit-section-container">
 
                 {%- if item.svg -%}
                 <div class="svg-container">
                     {% include {{ item.svg }} %}
                 </div>
                 {%- endif -%}
-
-                {%- if item.title -%}
-                <h3 class="toolkit-resource-header"><a href="{{item.provider-link}}" target="_blank">{{ item.title }}</a></h3>
-                <p class="toolkit-resource-text">{{ item.description }}</p>
-                <a href="{{item.provider-link}}" class="outer-link" target="_blank">
+                
+                <div class="toolkit-info-container">
+                    <h3 class="toolkit-resource-header"><a href="{{item.provider-link}}" target="_blank">{{ item.title }}</a></h3>
+                    <p class="toolkit-resource-text">{{ item.description }}</p>
+                </div>
+                <a href="{{item.provider-link}}" class="toolkit-flex-item-status outer-link" target="_blank">
                     {% include {{ item.link-svg }} %}
                 </a>
-                {%- endif -%}
             </div>
             {%- endif -%}
             {%- endfor -%}

--- a/toolkit.html
+++ b/toolkit.html
@@ -108,3 +108,15 @@ Here you can find, share, and suggest tools that are of use to the open source c
         </div>
     </div>
 </div>    
+
+<script>
+// Expand height of cards that have a status text
+// let statusElements = document.getElementsByClassName("toolkit-flex-item-status");
+// for(let i = 0; i < statusElements.length; i++){
+//     let parent = statusElements[i].parentElement;
+//     let parentHeight = parent.offsetHeight;
+//     console.log(`parentHeight = ${parentHeight}`);
+//     parent.style.height = (parentHeight + statusElements[i].offsetHeight) + "px";
+//     console.log(`parentHeight = ${parent.offsetHeight}`);
+// }    
+</script>

--- a/toolkit.html
+++ b/toolkit.html
@@ -3,7 +3,7 @@ layout: default
 title: Toolkit
 --- 
 <div class="toolkit-header header-container">
-    <h2 class="toolkit-header__h2">Our Toolkit</h2>
+    <h1 class="toolkit-header__title">Our Toolkit</h1>
     <p class="toolkit-header__p">Toolkit implies that there is one set of tools that is perfect for the job you are tackling!
 What you will find here are tools we have found to be effective. Think of this as the most awesome collective tool shed!
 Here you can find, share, and suggest tools that are of use to the open source civic tech software community.</p>
@@ -13,14 +13,14 @@ Here you can find, share, and suggest tools that are of use to the open source c
 </div>
 
 <div class="toolkit-header__text-group">
-    <h3 class="toolkit-header__h3">Development</h3>
-    <h3 class="toolkit-header__h3">Design</h3>
-    <h3 class="toolkit-header__h3">Project Management</h3>
+    <p class="toolkit-header__banner-item">Development</p>
+    <p class="toolkit-header__banner-item">Design</p>
+    <p class="toolkit-header__banner-item">Project Management</p>
 </div>
 
 <div class="toolkit-background content-section">
     <div class="toolkit__card-list">
-        <div class="suggest-guide-group"><h3>Guides (We Made These!)</h3><button class="toolkit-button btn btn-primary">Suggest a guide</button></div>
+        <div class="suggest-guide-group"><h2>Guides (We Made These!)</h2><button class="toolkit-button btn btn-primary">Suggest a guide</button></div>
 
     <div class="toolkit-flex-container">
         <!-- Searching through toolkitPages collection -->
@@ -81,7 +81,7 @@ Here you can find, share, and suggest tools that are of use to the open source c
     </div>
 
     <div class="toolkit__card-list">
-        <div class="suggest-guide-group"><h3>External Resources</h3><button class="toolkit-button btn btn-primary">Suggest a resource</button></div>
+        <div class="suggest-guide-group"><h2>External Resources</h2><button class="toolkit-button btn btn-primary">Suggest a resource</button></div>
 
         <div class="toolkit-flex-container">
             <!-- Searching through toolkitResources collection -->
@@ -110,13 +110,11 @@ Here you can find, share, and suggest tools that are of use to the open source c
 </div>    
 
 <script>
-// Expand height of cards that have a status text
-// let statusElements = document.getElementsByClassName("toolkit-flex-item-status");
-// for(let i = 0; i < statusElements.length; i++){
-//     let parent = statusElements[i].parentElement;
-//     let parentHeight = parent.offsetHeight;
-//     console.log(`parentHeight = ${parentHeight}`);
-//     parent.style.height = (parentHeight + statusElements[i].offsetHeight) + "px";
-//     console.log(`parentHeight = ${parent.offsetHeight}`);
-// }    
+// Add margin to the bottom of cards with status text
+let statusElements = document.getElementsByClassName("toolkit-flex-item-status");
+for(let i = 0; i < statusElements.length; i++){
+    let parent = statusElements[i].parentElement;
+    let infoContainer = parent.getElementsByClassName("toolkit-info-container");
+    infoContainer[0].style["margin-bottom"] = "3.5rem";
+}
 </script>


### PR DESCRIPTION
Related to #751 
MVP update for toolkit. I'm not sure why there is a change to the svg file. I think that might have happened when I downloaded it from the figma. Either way, it displays nicely still and doesn't change anything functionally and it doesn't appear to remove any important meta information. So I think it is ok to merge. Here is a summary of the some of the bigger changes I can remember: 
- Restructured scss by screen width to make it easier to edit the page.
- Restructured classes used by components to make it easier to edit page.
- Reorder headers to descending order for accessibility

There are 2 small issues that I posted screenshots of at the very bottom. In my opinion, they are minor (iPhone 5 zoom logo on landscape is large compared to the size of the card and iPad pro width still tries to left justify cards).

# Screenshots
## Desktop
![desktop](https://user-images.githubusercontent.com/18221058/95528460-0c84ca80-098d-11eb-93b3-2848cc24753c.png)
## iPad
![ipad](https://user-images.githubusercontent.com/18221058/95528473-11e21500-098d-11eb-8968-c3e8e7a9c79a.png)
## iPhone 6/7/8 Vertical
![iphone678](https://user-images.githubusercontent.com/18221058/95528483-19092300-098d-11eb-9e63-c0b51697c534.png)
## iPhone 6/7/8 Landscape
![iphone678mobile](https://user-images.githubusercontent.com/18221058/95528501-232b2180-098d-11eb-8f57-1713f7bdf4d9.png)

# Not ideal
## iPhone 5 landscape large zoom logo
![Screenshot from 2020-10-08 17-35-24](https://user-images.githubusercontent.com/18221058/95528522-33430100-098d-11eb-8bb0-e90d117a55df.png)
## iPad Pro width still left justifies cards
![Screenshot from 2020-10-08 17-35-50](https://user-images.githubusercontent.com/18221058/95528536-3d64ff80-098d-11eb-9645-81b206b8b37a.png)
