### PR TITLE
Fix provider link for 2FA

### DIFF
--- a/_guide-pages/2FA.html
+++ b/_guide-pages/2FA.html
@@ -13,7 +13,7 @@ display: true
 category: development
 svg: svg/2FA.svg
 alt-text: 2fa-image
-provider-link: '/guide-pages/2FA
+provider-link: '/guide-pages/2FA'
 ---
 
 <div class='content-section'>


### PR DESCRIPTION
Add colon to the end of provider link to remove error that was causing card not to show up on toolkit list.