### PR TITLE
Update styling for toolkit header.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
   <title>{% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape}}</title>
   <meta name="description"
     content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 400 }}{% else %}{{ site.description }}{% endif %}" />
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | absolute_url }}" />
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
   <link rel="shortcut icon" type="image/x-icon" href="{{ 'favicon.ico' | absolute_url }}" />
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
   <title>{% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape}}</title>
   <meta name="description"
     content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 400 }}{% else %}{{ site.description }}{% endif %}" />
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | absolute_url }}" />
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
   <link rel="shortcut icon" type="image/x-icon" href="{{ 'favicon.ico' | absolute_url }}" />
 

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -44,6 +44,7 @@
 .suggest-guide-group {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     padding-left: 3rem;
     padding-right: 3rem;
     text-align: center;
@@ -227,7 +228,6 @@
     }
 
     .suggest-guide-group {
-        align-items: center;
         flex-direction: column;
 
         h2 {

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -26,6 +26,7 @@
     }
 
     &__hero-image {
+        margin: 33px 0px;
         max-width: 100%;
     }
 }

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -1,6 +1,4 @@
 .toolkit-header {
-    padding-top: 10rem; 
-    padding-bottom: 10rem;
 
     &__text-group {
         display: flex; 
@@ -10,31 +8,20 @@
         padding: 1.4rem 0;
 
     }
-    
-    &__title {
-        font-style: normal;
-        font-weight: normal;
-        font-size: 3.7rem;
-        line-height: 4.3rem;
-        align-items: center;
-        text-align: center;
-    }
 
     &__banner-item {
         margin-block-end: 0;
         font-weight: 300;
-        font-size: 1.75rem;
+        font-size: 1.5rem;
         margin: 0 4.5rem;
     }
     
     &__p {
-        font-style: normal;
-        font-weight: normal;
-        font-size: 1.7rem;
-        line-height: 2rem;
-        max-width: 60vw;
-        margin: 3rem auto;
+        font-size: 27px;
+        max-width: 895px;
         text-align: left;
+        padding: 30px;
+        margin: 12px auto;
 
     }
 
@@ -65,7 +52,7 @@
 .suggest-guide-group h2 {
     font-style: normal;
     font-weight: normal;
-    font-size: 35px;
+    font-size: 1.75rem;
     color: #FFFFFF;
     margin-bottom: 0;
 }
@@ -244,7 +231,6 @@
 
         h2 {
             margin-bottom: 1rem;
-            font-size: 31px;
         }
     }
 

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -146,7 +146,6 @@
 @media #{$bp-below-desktop} {
 
     .toolkit-header {
-        padding-bottom: 3rem;
 
         &__text-group {
             justify-content: space-evenly;
@@ -189,6 +188,7 @@
 
 @media #{$bp-below-mobile} {
     .toolkit-header {
+        padding-bottom: 3rem;
 
         &__banner-item {
             font-size: .65rem;

--- a/toolkit.html
+++ b/toolkit.html
@@ -3,7 +3,7 @@ layout: default
 title: Toolkit
 --- 
 <div class="toolkit-header header-container">
-    <h1 class="toolkit-header__title">Our Toolkit</h1>
+    <h1>Our Toolkit</h1>
     <p class="toolkit-header__p">Toolkit implies that there is one set of tools that is perfect for the job you are tackling!
 What you will find here are tools we have found to be effective. Think of this as the most awesome collective tool shed!
 Here you can find, share, and suggest tools that are of use to the open source civic tech software community.</p>


### PR DESCRIPTION
Fixes #780 

I'll be specific in what I did to match/respond to the specificity of the directions.
- Made title of page exact same as getting started by removing toolkit page specific class (now it just takes styling rules from h1 tag just like getting started page).
- Made font size, max width, padding, and margin of header paragraph the same exact values as the getting started header paragraph. Only tangible difference between the two pages for this part is the text align (I kept it left for the toolkit as that was the original request). I didn't make a generic class for partly that reason and partly that I did not have the time for it today. And I also didn't know if I should start that process.
- Reduced the space on the top and bottom of the header. Not the same values as recommended in the figma, but it is the same as the getting started page (which I felt like was the goal of the issue). They are both computed to 40px away from the nav bar and the following section (content for the getting started page, category banner for toolkit page).
- "Guides We Made These!" and "External Resources" font size changed to 1.75rem (which equates to the request 28px). I kept this in rem because the toolkit used much more `rem` units than `px` units, and I wanted to keep that theme as much as possible. I kept the `px` units in the header paragraph so it can match the getting started class definition more closely, and the componentization/genericizing of the 2 classes more apparent.
- Made Category banner 1.5rem as requested (which equates to 24px)

On iPhone 6/7/8 landscape (and other width lengths around that), it looks like the title of the page is the same font as the paragraph. However, it is the same behavior on the getting started. I posted a screenshot in it just in case it was considered an important thing to consider.

I did not post many screenshots and finished this issue in a bit of a hurry. So if you wanted to have an in depth look please clone the branch to local and self test. If more screenshots or changes are desired, I can add those tomorrow. I opened this pr just in case this issue was urgent and needed at least something.

**Edit**: I also realized that I didn't make the computed px distance between the header paragraph and the page title/page image 70px as requested. However, again, it is the same as the getting started page. Also, a difference between the getting started page is that on mobile the font of the paragraph does get smaller. So there is at least one difference in behavior.

# Screenshots
## Desktop
![desktop](https://user-images.githubusercontent.com/18221058/96324416-a6c0c000-0fd6-11eb-9ee2-9a15dcde5ada.png)
## iPhone 6/7/8 Vertical
![iphone678top](https://user-images.githubusercontent.com/18221058/96324429-b8a26300-0fd6-11eb-9c79-1d9c04be195c.png)
![iphone678bottom](https://user-images.githubusercontent.com/18221058/96324433-bb04bd00-0fd6-11eb-9bc8-aa168643a0e4.png)
## iPhone 6/7/8 Landscape
![iphone678landscapetop](https://user-images.githubusercontent.com/18221058/96324464-dc65a900-0fd6-11eb-819b-e2de00745994.png)
![iphone678landscapemiddle](https://user-images.githubusercontent.com/18221058/96324468-e091c680-0fd6-11eb-8a55-5f47a7ad5a09.png)
![iphone678landscapebottom](https://user-images.githubusercontent.com/18221058/96324471-e25b8a00-0fd6-11eb-8bf1-d12c13c98ca5.png)
