### PR TITLE
Logo adjustment for tablet

### DIFF
--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -80,6 +80,21 @@
   background-color: $color-red;
 }
 
+@media only screen and (max-width: 1028px) {
+
+  // style the HfLA logo for tablet and mobile
+  // It's not one of the standard numbers because
+  // this is where the text started to get covered up
+  // by the logo
+  .main-header .branding {
+    position: absolute;
+    top: -13px;
+    left: -18px;
+    height: 50px;
+    width: 95px;
+  }
+}
+
 @media #{$bp-below-tablet} {
   // HFLA logo setting for mobile
   .main-header {
@@ -95,14 +110,5 @@
     height: 30px;
     margin-top: 6px;
     line-height: 0;
-  }
-
-  // style the HFLA logo for mobile
-  .main-header .branding {
-    position: absolute;
-    top: -13px;
-    left: -18px;
-    height: 50px;
-    width: 95px;
   }
 }


### PR DESCRIPTION
Fixes #717 

Currently, when scaled to tablet, the logo covers some of the text or images when you click the navigation links: 

![Screen Shot 2020-12-04 at 2 46 48 PM](https://user-images.githubusercontent.com/68244054/101223025-e18ebe00-363f-11eb-84e4-85ea86c6da57.png)

This PR makes the logo smaller for tablet so that this is no longer the case:

![Screen Shot 2020-12-04 at 2 47 09 PM](https://user-images.githubusercontent.com/68244054/101223062-f53a2480-363f-11eb-9159-13bf069e2041.png)
