### PR TITLE
We need to filter out the 'hidden' projects before building our filters.

### DIFF
--- a/_includes/current-projects.html
+++ b/_includes/current-projects.html
@@ -16,7 +16,7 @@
         {% for status in status_list %}
           {% assign projects = site.projects | where: "status", status | sort: "title" %}
           {%- for item in projects -%}
-            {%- if item.hide != true -%}
+            {%- if item.visible == true -%}
               {%- include project-card.html project=item -%}
             {%- endif -%}
           {%- endfor -%}
@@ -25,7 +25,8 @@
     </div>
 </section>
 <script>
-var projectDataFromJekyll = [{%- for project in site.projects -%}
+{% assign visible_projects = site.projects | where: "visible", "true" %}
+var projectDataFromJekyll = [{%- for project in visible_projects -%}
       {
         "id": {{ project.identification | default: 0 }},
         "status": ["{{ project.status }}"]

--- a/_projects/100-automations.md
+++ b/_projects/100-automations.md
@@ -45,5 +45,6 @@ technologies:
 location:
    - Remote
 # partner: N/A
+visible: true
 status: Active
 ---

--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -72,5 +72,6 @@ location:
   - Remote
 
 partner: EmpowerLA
+visible: true
 status: Active
 ---

--- a/_projects/adopt-civic-art.md
+++ b/_projects/adopt-civic-art.md
@@ -11,6 +11,6 @@ location:
   - Downtown LA
   - Remote
 partner: County of Los Angeles
-hide: true
+visible: false
 status: On Hold
 ---

--- a/_projects/ballot-nav.md
+++ b/_projects/ballot-nav.md
@@ -44,5 +44,6 @@ looking:
 location: 
   - Remote
 partner: Code for America, Other Brigades
+visible: true
 status: Active
 ---

--- a/_projects/civic-opportunity-project.md
+++ b/_projects/civic-opportunity-project.md
@@ -36,5 +36,6 @@ location:
   - Remote
 # tools:
 partner: Undisclosed
+visible: true
 status: Active
 ---

--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -68,5 +68,6 @@ location:
   - Downtown LA
   - Remote
 partner: Code for America, Yale OpenLab and many more.
+visible: true
 status: Active
 ---

--- a/_projects/civic-tech-structure.md
+++ b/_projects/civic-tech-structure.md
@@ -63,5 +63,6 @@ technologies:
 location:
   - Remote
 partner: Code for America & its Brigades
+visible: true
 status: Active
 ---

--- a/_projects/criminal-sentencing.md
+++ b/_projects/criminal-sentencing.md
@@ -10,6 +10,6 @@ links:
 location: 
   - Downtown LA
   - Remote
-hide: true
+visible: false
 status: On Hold
 ---

--- a/_projects/curbmap.md
+++ b/_projects/curbmap.md
@@ -18,6 +18,6 @@ looking:
 location: 
   - Downtown LA
   - Remote
-hide: true
+visible: false
 status: On Hold
 ---

--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -42,5 +42,6 @@ location:
   - Remote
 tools: Hotjar, Google Analytics
 partner: City of Santa Monica
+visible: true
 status: Active
 ---

--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -71,5 +71,6 @@ location:
   - Remote
 tools: figma, photoshop, sketch, pencil and paper, phone calls.
 partner: seeking
+visible: true
 status: Active
 ---

--- a/_projects/heart.md
+++ b/_projects/heart.md
@@ -66,6 +66,7 @@ links:
   - name: Wiki
     url: 'https://github.com/hackforla/heart/wiki'
 partner: LA City Attorney’s Homeless Engagement and Response Team
+visible: true
 status: Completed
 ---
 

--- a/_projects/hellogov.md
+++ b/_projects/hellogov.md
@@ -37,5 +37,6 @@ location:
   - Remote
 partner: Digital Defense Fund
 tools: Mongo, Angular, Node, JS
+visible: true
 status: Completed
 ---

--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -61,7 +61,8 @@ technologies:
 location: 
   - Downtown LA
   - Remote
-partner: Safe Place for Youth (SPY)
-status: Active
 tools: Figma, Miro, AWS, Nginx, Terraform, Docker, DynamoDB, Style Components, Zoom, GitHub, Google Drive, Docs, Sheets, Slides
+partner: Safe Place for Youth (SPY)
+visible: true
+status: Active
 ---

--- a/_projects/jobs-for-hope.md
+++ b/_projects/jobs-for-hope.md
@@ -15,5 +15,6 @@ location:
   - Downtown LA
   - Remote
 partner: LA County Homeless Initiative; http://homeless.lacounty.gov
+visible: true
 status: On Hold
 ---

--- a/_projects/light-the-way.md
+++ b/_projects/light-the-way.md
@@ -14,6 +14,6 @@ looking:
 location: 
   - Downtown LA
   - Remote
-hide: true
+visible: false
 status: On Hold
 ---

--- a/_projects/lucky-parking.md
+++ b/_projects/lucky-parking.md
@@ -75,5 +75,6 @@ location:
   - Remote
 partner: Seeking
 tools: Google Colab, AWS
+visible: true
 status: Active
 ---

--- a/_projects/metro-ontime.md
+++ b/_projects/metro-ontime.md
@@ -31,5 +31,6 @@ location:
   - Remote
 partner: LA Metro (https://www.metro.net/)
 tools: Docker, AWS, Observable
+visible: true
 status: Completed
 ---

--- a/_projects/new-schools-today.md
+++ b/_projects/new-schools-today.md
@@ -48,5 +48,6 @@ partner: Seeking
 location:
   - Santa Monica
   - Remote
+visible: true
 status: Active
 ---

--- a/_projects/not-today.md
+++ b/_projects/not-today.md
@@ -29,5 +29,6 @@ location:
   - Santa Monica
   - Remote
 partner: Seeking
+visible: true
 status: On Hold
 ---

--- a/_projects/public-tree-map.md
+++ b/_projects/public-tree-map.md
@@ -53,5 +53,6 @@ location:
   - Remote
 partner: City of Santa Monica
 tools: Zeplin
+visible: true
 status: Active
 ---

--- a/_projects/record-clearance-project.md
+++ b/_projects/record-clearance-project.md
@@ -50,5 +50,6 @@ technologies:
 location:
   - Santa Monica
   - Remote
+visible: true
 status: Active
 ---

--- a/_projects/shared-housing-project.md
+++ b/_projects/shared-housing-project.md
@@ -15,6 +15,6 @@ looking:
 location:
   - Downtown LA
   - Remote
-hide: true
+visible: false
 status: On Hold
 ---

--- a/_projects/spare.md
+++ b/_projects/spare.md
@@ -24,5 +24,6 @@ location:
   - Santa Monica
   - Remote
 partner: Hope of the Valley and hopefully others in the near future.
+visible: true
 status: On Hold
 ---

--- a/_projects/tdm-calculator.md
+++ b/_projects/tdm-calculator.md
@@ -71,5 +71,6 @@ location:
   - Downtown LA
   - Remote
 partner: LA Department of Transportation LADOT (https://ladot.lacity.org/)
+visible: true
 status: Active
 ---

--- a/_projects/undebate.md
+++ b/_projects/undebate.md
@@ -36,5 +36,6 @@ location:
   - Santa Monica
   - Remote
 partner: EnCiv.org, Ballotpedia.org
+visible: true
 status: Active
 ---

--- a/_projects/vrms.md
+++ b/_projects/vrms.md
@@ -62,5 +62,6 @@ technologies:
 location:
   - Remote
 partner: TBD
+visible: true
 status: Active
 ---

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -52,5 +52,6 @@ location:
   - Santa Monica
   - Downtown LA
   - Remote
+visible: true
 status: Active
 ---

--- a/_projects/work-for-la.md
+++ b/_projects/work-for-la.md
@@ -19,6 +19,7 @@ location:
   - Downtown LA
   - Remote
 partner: Department of Personnel
+visible: true
 status: Completed
 completed-contact: WorkForLA@googlegroups.com
 ---

--- a/_projects/writeforall.md
+++ b/_projects/writeforall.md
@@ -43,5 +43,6 @@ location:
   - Downtown LA 
   - Remote
 partner: Seeking
+visible: true
 status: Active
 ---


### PR DESCRIPTION
Because of the way Jekyll's where method works, that's easier if we match something rather than look for 'not' something.
So I replaced "hide: true" with "visible: false"  (and added visible: true to all the visible project cards)

Fixes #657 