### PR TITLE
Add hotfix for languages on project home pages.

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -215,8 +215,8 @@ layout: default
 <!--Script for adding languages to "Languages" Section-->
 <script>
     let languagesSection = document.getElementById('languages');
-    if(project != null && project.languages.data.length > 0){
-        let languages = project.languages.data.join(', ');
+    if(project != null && project.languages.length > 0){
+        let languages = project.languages.join(', ');
         let languagesParagraph = document.createElement('p');
         languagesParagraph.style.display = 'inline';
         let languagesText = document.createTextNode(languages);


### PR DESCRIPTION
Related to #831 (not sure if this is the final fix yet, but it works and it's not hacky)

Temp fix for now so the languages can be displayed right now. Will look into it to see if it is necessary/preferred for there to be a `data` field in the languages data (as opposed to leaving the github-data.json file as is without the `data` field in the languages data). 