### PR TITLE
changed styling so that view more text on the wins cards

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -34,7 +34,7 @@
 }
 
 .wins__card-text {
-	padding-top: 50px;
+	padding-top: 40px;
 	p {
 		margin: 0;
 	}
@@ -93,12 +93,13 @@
 
 //card styling
 .wins-card{
-	padding: 50px;
+	padding: 45px;
 	display: flex;
 	flex-direction: row;
 }
 .wins-card-left{
 	width: 100px;
+	margin-right: 10px;
 	display: flex;
 	align-items: flex-end;
 	flex-direction: column;
@@ -111,7 +112,7 @@
 .wins-card-big-quote{
 	width: 28px;
 	height: 96.05px;
-	margin: 8px;
+	// margin: 8px;
 }
 .wins-card-content{
 	display: flex;
@@ -119,7 +120,7 @@
 	margin-left: 20px;
 	width: 100%;
 	position: relative;
-	height: 225px;
+	height: 233px;
 	overflow: hidden;
 	margin-left: 6px;
 }
@@ -128,16 +129,16 @@
 	font-family: Roboto;
 	font-style: normal;
 	font-weight: bold;
-	font-size: 24px;
-	line-height: 28px;
+	font-size: 20px;
+	line-height: 22px;
 	margin-top: 13px;
 }
 .wins-card-team{
 	font-family: Roboto;
 	font-style: normal;
 	font-weight: normal;
-	font-size: 20px;
-	line-height: 23px;
+	font-size: 16px;
+	line-height: 18px;
 	display: flex;
 	align-items: center;
 }
@@ -158,13 +159,13 @@
 
 @media #{$bp-below-tablet} {
 	.wins-card-content{
-		height: 217px;
+		height: 233px;
 	}
 }
 
 @media #{$bp-below-mobile} {
 	.wins-card-content{
-		height: 209px;
+		height: 215px;
 	}
 	.wins-card{
 		padding: 24px;
@@ -178,7 +179,7 @@
 		border-radius: 100px;
 	}
 	.wins-card-big-quote{
-		margin: 4px;
+		margin: 4px;    
 		height: 60px;
 		width: 18px;
 	}
@@ -204,8 +205,8 @@
 		height: 20px;
 		width: 20px;
 	}
-	.wins-card-info{
-		margin-top: 15px;
+	.wins__card-text{
+		padding-top: 16px;
 	}
 
 	.wins-card-overview{

--- a/wins.html
+++ b/wins.html
@@ -17,8 +17,8 @@ title: Wins
 			<div id="overlay-teams" class="project-inner wins-card-team">Team(s): Blank</div>
 			<div id="overlay-roles" class="project-inner wins-card-team">Role(s): Blank</div>
 			<div class="project-inner wins__card-text">
-				<p id="overlay-info" class="wins-card-info">Blank</p>
 				<p id="overlay-overview">Blank</p>
+				<p id="overlay-info" class="wins-card-info">Blank</p>
 			</div>
 		</div>
 	</div>
@@ -156,10 +156,10 @@ title: Wins
 			//makes the win and info text on the bottom of the card
 				let winDiv = makeElement('div', rightDiv, "project-inner");
 				winDiv.classList.add("wins__card-text");
-				let winElement = makeElement('p', winDiv, "wins-card-info");
-				winElement.innerHTML = formatMessage(card[win]); //win
 				let overviewElement = makeElement('p', winDiv, "wins-card-overview");
 				overviewElement.innerHTML = card[overview];//description
+				let winElement = makeElement('p', winDiv, "wins-card-info");
+				winElement.innerHTML = formatMessage(card[win]); //win
 
 			let innerHeight = Array.from(rightDiv.childNodes).reduce((acc, el) => el.offsetHeight + acc, 0)
 
@@ -213,11 +213,11 @@ title: Wins
 			const overlayRoles = document.querySelector('#overlay-roles');
 			overlayRoles.innerHTML = `Role(s): ${data[i][role]}`;
 
-			const overlayInfo = document.querySelector('#overlay-info');
-			overlayInfo.innerHTML = formatMessage(data[i][win]);
-
 			const overlayOverview = document.querySelector('#overlay-overview');
 			overlayOverview.innerHTML = data[i][overview];
+
+			const overlayInfo = document.querySelector('#overlay-info');
+			overlayInfo.innerHTML = formatMessage(data[i][win]);
 
 			const overlayProjectCard = document.querySelector('#overlay-project-card');
 			overlayProjectCard.parentNode.classList.add("display-initial");


### PR DESCRIPTION
Here are the changes I made real quick. I think it might require a more meaningful fix. Let me know what you think @ExperimentsInHonesty @daniellex0.
I think that the "wins" text (the bolded one), should not be bolded, but when I unbolded it, it looked a bit strange also.
![Screen Shot 2020-12-07 at 2 36 54 PM](https://user-images.githubusercontent.com/53061723/101413835-d3d47500-3899-11eb-8e1f-6960f8034e67.png)
![Screen Shot 2020-12-07 at 2 37 15 PM](https://user-images.githubusercontent.com/53061723/101413837-d505a200-3899-11eb-856c-cd5ca6c7e0bb.png)

And here are the rest of the photos
![screencapture-localhost-4000-wins-2020-12-07-14_10_55](https://user-images.githubusercontent.com/53061723/101413391-0b8eed00-3899-11eb-938d-ecbfe41caae7.png)
![screencapture-localhost-4000-wins-2020-12-07-14_39_19](https://user-images.githubusercontent.com/53061723/101413956-1007d580-389a-11eb-922c-6d52d0eca46f.png)

![screencapture-localhost-4000-wins-2020-12-07-14_12_07](https://user-images.githubusercontent.com/53061723/101413403-0df14700-3899-11eb-9bf7-e708dec93ff9.png)
