### PR TITLE
Fixes the font for the names on the wins page

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -133,8 +133,6 @@
 	margin-top: 13px;
 }
 .wins-card-team{
-	font-family: Roboto;
-	font-style: normal;
 	font-weight: normal;
 	font-size: 16px;
 	line-height: 18px;

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -127,8 +127,6 @@
 }
 
 .wins-card-name{
-	font-family: Roboto;
-	font-style: normal;
 	font-weight: bold;
 	font-size: 20px;
 	line-height: 22px;


### PR DESCRIPTION
Fixes font issue discussed in meeting. 

Old:
![Screen Shot 2020-12-13 at 11 16 00 AM](https://user-images.githubusercontent.com/53061723/102021425-973ec880-3d34-11eb-94b0-b2687c192baf.png)

new:
![Screen Shot 2020-12-13 at 11 51 15 AM](https://user-images.githubusercontent.com/53061723/102022142-b0964380-3d39-11eb-9ca6-46107c855fde.png)


Thanks @drubgrubby for figuring this out :D