### PR TITLE
(I didn't) Change page-card class name 

### DIFF
--- a/_sass/elements/_cards.scss
+++ b/_sass/elements/_cards.scss
@@ -1,4 +1,9 @@
-// This was originally created for the about-us page which has a separate column for sticky nav
+/* This was originally created for the about-us page which has a separate column for sticky nav 
+It is, however, not actually being used on that page so that there isn't a problem when we change
+the .page-card class as part of the standardization process. I have commented it out so there is no
+confusion...about this.  */
+
+/*
 .page-card {
     background: #fff;
     border: 0 solid rgba(51, 51, 51, 0.06);
@@ -17,6 +22,7 @@
         padding: 40px;
     }
 }
+*/
 
 .small-card {
     height: 180px;


### PR DESCRIPTION
Fixes #976 

I had already used a different class name on the about us page to avoid having a problem when we standardized the card class names.  I had left the page-card class behind on _cards.scss in case it was useful as part of the standardization process.  At @daniellex0 's request, the class has been commented out. 

