### PR TITLE
Update 100automations with link to their overview

### DIFF
--- a/_projects/100-automations.md
+++ b/_projects/100-automations.md
@@ -44,12 +44,14 @@ leadership:
       github: 'https://github.com/superbunker'
     picture: 'https://avatars.githubusercontent.com/superbunker'
 links:
-  - name: Slack
-    url: 'https://hackforla.slack.com/archives/C018S5TCQE7'
   - name: GitHub
     url: 'https://github.com/100Automations/website'
+  - name: Slack
+    url: 'https://hackforla.slack.com/archives/C018S5TCQE7'
   - name: Readme
     url: 'https://github.com/OpenSourceAutomations/OSA-Website/blob/master/README.md'
+  - name: Overview
+    url: 'https://github.com/100Automations/Website/blob/master/100-Automations-Project-One-Sheet.pdf'
 looking:
   - category: Development
     skill: Anyone who wants to write open source automations


### PR DESCRIPTION
##Action Items
- [x]   Add link to Overview document in card.
- [x]  Confirm that it is showing up at the bottom
- [x]  Add a screenshot to this issue in the comments 
 
![100automations#991](https://user-images.githubusercontent.com/32349001/106711630-ca2f6b00-65c5-11eb-801f-2dd6ab706275.png)

Fixes #991 
