### PR TITLE
Fixed 'See our Locations dropdown bug'

### DIFF
--- a/events.html
+++ b/events.html
@@ -373,10 +373,10 @@ title: Hack Nights
 
   showLocations.addEventListener("click", function () {
     this.classList.toggle("active");
-    if (showingLocations.style.display == "none") {
-      showingLocations.style.display = "block";
-    } else {
+    if (showingLocations.style.display == "block") {
       showingLocations.style.display = "none";
+    } else {
+      showingLocations.style.display = "block";
     }
   });
 


### PR DESCRIPTION
I noticed an issue on the 'Events' page (3 actually), so I fixed one of them, which was that on the bottom, when the width is less than 768px, you need to double-click to see the contents pop out