### PR TITLE
Revise project vertical info to project cards 

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -58,6 +58,6 @@ location:
 tools: Figma, Miro, AWS, Nginx, Terraform, Docker, DynamoDB, Style Components, Zoom, GitHub, Google Drive, Docs, Sheets, Slides
 partner: Safe Place for Youth (SPY), Point Source Youth (PSY)
 visible: true
-vertical: 'Under Development'
+vertical: 'Social Safety Net'
 status: Active
 ---

--- a/_projects/not-today.md
+++ b/_projects/not-today.md
@@ -30,6 +30,6 @@ location:
   - Remote
 partner: Seeking
 visible: true
-vertical: 'Under Development'
+vertical: 'Social Safety Net'
 status: On Hold
 ---


### PR DESCRIPTION
Fixes #896 

Changed "vertical: 'Under Development' " to "vertical: 'Social Safety Net' " in not-today.md and home-unite-us.md. 