### PR TITLE
Make the About Us "Partners" section spacing look closer to the Figma mockup

### DIFF
--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -301,11 +301,12 @@ a.anchor {
 }
 
 .flex-container-row--partners {
-  justify-content: space-evenly;
+  justify-content: space-between;
   margin-top: 25px;
   
   & .partner-logo{
-    width: 120px;
+		width: 100px;
+		margin: 12px 15px;
   }
 }
 

--- a/about.html
+++ b/about.html
@@ -351,6 +351,9 @@ title: About
                         <a href="https://www.pointsourceyouth.org/" target="_blank" rel="noopener noreferrer">
                             <img class="partner-logo" src="assets/images/about/partners/point-source-youth.svg">
                         </a>
+                        <a href="https://www.lacityattorney.org/" target="_blank" rel="noopener noreferrer">
+                            <img class="partner-logo" src="assets/images/about/partners/la-city-attorney.png">
+                        </a>
                         <a href="https://ladot.lacity.org/" target="_blank" rel="noopener noreferrer">
                             <img class="partner-logo" src="assets/images/about/partners/la-dot.png">
                         </a>
@@ -371,9 +374,6 @@ title: About
                         </a>
                         <a href="https://law.ggu.edu/" target="_blank" rel="noopener noreferrer">
                             <img class="partner-logo" src="assets/images/about/partners/ggu-school-of-law.png">
-                        </a>
-                        <a href="https://www.lacityattorney.org/" target="_blank" rel="noopener noreferrer">
-                            <img class="partner-logo" src="assets/images/about/partners/la-city-attorney.png">
                         </a>
                         <a href="https://da.lacounty.gov/" target="_blank" rel="noopener noreferrer">
                             <img class="partner-logo" src="assets/images/about/partners/da-county-of-la.png">


### PR DESCRIPTION
fixes #1128 

- Adjusted styling of partner logos to look closer to the design on the [Figma mockup](https://www.figma.com/file/0RRPy1Ph7HafI3qOITg0Mr/Hack-for-LA-Website?node-id=1803%3A13692)
- Moved the District Attorney logo further away from the City Attorney logo (so their size difference isn't as apparent)

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/42260999/109739288-3f1ea200-7b7e-11eb-9c0b-5f03b2c9f787.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/42260999/109739245-2adaa500-7b7e-11eb-9b93-cfbe66212d83.png)

</details>