### PR TITLE
Fix buggy header navigation bar

### DIFF
--- a/_includes/hamburger-nav.html
+++ b/_includes/hamburger-nav.html
@@ -7,10 +7,13 @@
 </div>
 
 <script>
+    //Retrieve svg string from _includes
+    const burgerImage = `{% include svg/icon-hamburger-nav.svg %}` ;
+    const burgerImageX = `{% include svg/icon-hamburger-nav-x.svg %}` ;
 
 
   document.querySelector('#burgerImage').addEventListener('click',toggleNavDisplay);
-  window.addEventListener('resize', removeStyleAttrOnResize);
+  window.addEventListener('resize', resetNavBarPropsToDefaultState);
 
   function toggleNavDisplay(){
     swapIcons(this.firstElementChild.id);
@@ -21,11 +24,6 @@
 
 
   function swapIcons(icon_id){
-
-    //Retrieve svg string from _includes
-    const burgerImage = `{% include svg/icon-hamburger-nav.svg %}` ;
-    const burgerImageX = `{% include svg/icon-hamburger-nav-x.svg %}` ;
-
     //Create dictionary for swap
     const hamburger = {
       'hamburger-nav': {"el":burgerImage,'opposite':burgerImageX},
@@ -42,10 +40,14 @@
   }
   
 
-  function removeStyleAttrOnResize(){
+  function resetNavBarPropsToDefaultState(){
     if(document.body.clientWidth>767){
       document.querySelector('#headerNav').removeAttribute("style");
+      document.querySelector(`#burgerImage`).firstElementChild.remove();
+      document.querySelector(`#burgerImage`).insertAdjacentHTML('afterbegin',burgerImage);
+
     }
+
 
   }
 

--- a/_includes/hamburger-nav.html
+++ b/_includes/hamburger-nav.html
@@ -1,91 +1,53 @@
 <div id="swapButton">
   <ul class="inline-list">
     <li>
-      <button onclick="burgerSwap()" id="burgerImage">{% include svg/icon-hamburger-nav.svg %}</button>
-      <button onclick="burgerSwap()" id="burgerImageX">{% include svg/icon-hamburger-nav-x.svg %}</button> 
+      <button id="burgerImage" >{% include svg/icon-hamburger-nav.svg %}</button>
     </li>
   </ul>
 </div>
 
 <script>
 
-  // visibleBurger marks the state of the icon.  if 'true' the burger icon is showing
-  let visibleBurger = true;
 
-  function burgerSwap() {
-    // Initialize
-    let burgerImage = document.getElementById("burgerImage");
-    let burgerImageX = document.getElementById("burgerImageX");
-    let burgerMenu = document.getElementById("headerNav");
+  document.querySelector('#burgerImage').addEventListener('click',toggleNavDisplay);
+  window.addEventListener('resize', removeStyleAttrOnResize);
+
+  function toggleNavDisplay(){
+    swapIcons(this.firstElementChild.id);
+    document.querySelector('#headerNav').style.display == 'flex' ? document.querySelector('#headerNav').style.display = 'none': document.querySelector('#headerNav').style.display = 'flex';
+
     
-    //Test to see the current state of the image
-    if (visibleBurger == true) {
-      // If the burger is showing, swap for the X and show the menu.
-      burgerImage.style.display = "none"; 
-      burgerImageX.style.display = "block";
-      burgerMenu.style.display = "flex";
+  }
 
-      //Change the state marker
-      visibleBurger = false; 
 
-    } else {
-      //If the X and menu is showing, swap for burger and close the menu.
-      burgerImage.style.display = "block"; 
-      burgerImageX.style.display = "none";
-      burgerMenu.style.display = "none"; 
+  function swapIcons(icon_id){
+
+    //Retrieve svg string from _includes
+    const burgerImage = `{% include svg/icon-hamburger-nav.svg %}` ;
+    const burgerImageX = `{% include svg/icon-hamburger-nav-x.svg %}` ;
+
+    //Create dictionary for swap
+    const hamburger = {
+      'hamburger-nav': {"el":burgerImage,'opposite':burgerImageX},
+      'hamburger-nav-x':{'el':burgerImageX,'opposite':burgerImage}
+    }
+
+    //remove existing icon
+    document.querySelector(`#${icon_id}`).remove();
+
+    //insert opposite icon
+    document.querySelector(`#burgerImage`).insertAdjacentHTML('afterbegin',hamburger[icon_id].opposite);
     
-      //Change the state marker
-      visibleBurger = true;
+
+  }
+  
+
+  function removeStyleAttrOnResize(){
+    if(document.body.clientWidth>767){
+      document.querySelector('#headerNav').removeAttribute("style");
     }
-    event.stopPropagation();
-  }
-  // When you click anywhere on the page, other than the menu, if the menu is open, this closes it. 
-  function clickOutsideToClose() {
-    if (visibleBurger == false) {
-      let eventID = event.target.id;
 
-      // If the click is on the navigation menu, it does nothing.  If it is not on the navmenu it runs burgerSwap and closes the menu. 
-      if (eventID != "headerNav") {
-        burgerSwap();
-        event.stopPropagation();
-      }
-    }
   }
 
-  // If this is mobile, it adds event listeners to close the menus. 
-  let windowWidth = window.innerWidth;
-  if (windowWidth < 768) {
-    //Listen for someone clicking a link from the mobile nav.
-    document.getElementById("mobileNavLink").addEventListener("click", burgerSwap);
-
-    //Listen for someone clicking anywhere on the page to close the menus.
-    window.addEventListener("click", clickOutsideToClose);
-  }
-
-  // There was bug where if you go from portrait to landscape on a really tall phone, you lose the navigation links.  
-  // This was caused by hiding the links in portrait and they're still hidden in landscape.  
-  // This code fixes that bug
-  window.addEventListener("orientationchange", handleOrientationChange, true);
-
-  function handleOrientationChange (event) {
-    let windowHeight = window.innerHeight;
-    let windowWidth = window.innerWidth;
-    let burgerMenu = document.getElementById("headerNav");
-    // "if statements" only affect tall phones
-    if(windowHeight >= 768) {
-      // Should display original nav bar for large phones
-      document.getElementById("mobileNavLink").removeEventListener("click", burgerSwap);
-      window.removeEventListener("click", clickOutsideToClose);
-      burgerMenu.style.display = "block";
-    } else if (windowWidth >= 768) {
-      // Reset things to mobile nav bar
-      document.getElementById("mobileNavLink").addEventListener("click", burgerSwap);
-      window.addEventListener("click", clickOutsideToClose);
-      // Trigger burger swap to set things to initial view
-      visibleBurger = false;
-      burgerSwap();
-    }
-    event.stopPropagation();
-  }
 
 </script>

--- a/_includes/svg/icon-hamburger-nav-x.svg
+++ b/_includes/svg/icon-hamburger-nav-x.svg
@@ -1,4 +1,4 @@
-<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg id='hamburger-nav-x' width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M18.6292 6.99756L6.62915 18.9976" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M6.62915 6.99756L18.6292 18.9976" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/_includes/svg/icon-hamburger-nav.svg
+++ b/_includes/svg/icon-hamburger-nav.svg
@@ -1,4 +1,4 @@
-<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg id='hamburger-nav' width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M21.6297 12.2046H3.6297" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M21.6297 6.20459H3.6297" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M21.6297 18.2046H3.6297" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
Fixes #1055 

- Fixes the buggy navigation bar, where it would default to open state in mobile view to now defaulting to being on closed state by default.
- The header navigation bar disappear from page (when the navigation bar is closed by clicking the X icon, and the viewport resize to >= 768px)