### PR TITLE
Dropdowns Centered

### DIFF
--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -102,6 +102,7 @@
   // NEW MOBILE FRIENDLY RULES
   @media #{$bp-below-tablet} {
     padding: 5px 15px;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
Fix #1107 

Dropdown are now centered according to the Figma Specs

<details>
<summary>Drop Downs Before Fix</summary>

![image](https://user-images.githubusercontent.com/32349001/109880633-2f1dc580-7c45-11eb-973a-871534aca5a0.png)

</details>
<details>
<summary>DropDowns After Fix</summary>

![image](https://user-images.githubusercontent.com/32349001/109880444-ef56de00-7c44-11eb-95f6-6df7c321abaf.png)

</details>

https://www.figma.com/file/0RRPy1Ph7HafI3qOITg0Mr/Hack-for-LA-Website?node-id=62%3A94
