### PR TITLE
1107 events page  center dropdowns

### DIFF
--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -62,6 +62,10 @@
     width: 90%;
   }
   
+  @media #{$bp-below-mobile}{
+    width: 95%;
+  }
+
   & > .column-card-lg--events {
     background: #fff;
     border: 0 solid rgba(51, 51, 51, 0.06);
@@ -86,7 +90,8 @@
     // NEW MOBILE FRIENDLY RULES
     @media #{$bp-below-tablet} {
       padding: 5px 15px;
-  
+      max-width: 100%;
+
       &:first-child, &:last-child{
         margin-left: auto;
         margin-right: auto;

--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -53,11 +53,47 @@
 
 .flex-page-card {
   display: flex;
+  justify-content: center;
+  margin-left: 45px;
+  margin-right: 45px;
 
   @media #{$bp-below-tablet} {
     flex-direction: column;
-    width: 100%;
+    width: 90%;
   }
+  
+  & > .column-card-lg--events {
+    background: #fff;
+    border: 0 solid rgba(51, 51, 51, 0.06);
+    border-radius: 20px;
+    box-shadow: 0 0 8px 0 rgba(51, 51, 51, 0.2);
+    overflow: hidden;
+    max-width: 489px;
+    width: 100%;
+    padding: 32px;
+    margin-top: 8px;
+    margin-bottom: 8px;
+    font-family: "Roboto" sans-serif;
+    
+    &:first-child{
+      margin-right: 8px;
+    }
+  
+    &:last-child{
+      margin-left: 8px;
+    }
+  
+    // NEW MOBILE FRIENDLY RULES
+    @media #{$bp-below-tablet} {
+      padding: 5px 15px;
+  
+      &:first-child, &:last-child{
+        margin-left: auto;
+        margin-right: auto;
+      }
+    }
+  }
+
 }
 
 #head-content::before {
@@ -86,23 +122,6 @@
   height: 134px;
   text-align: center;
   max-width: 150px;
-}
-.column-card-lg--events {
-  background: #fff;
-  border: 0 solid rgba(51, 51, 51, 0.06);
-  border-radius: 20px;
-  box-shadow: 0 0 8px 0 rgba(51, 51, 51, 0.2);
-  overflow: hidden;
-  max-width: 489px;
-  margin-bottom: 0;
-  padding: 32px;
-  margin: 8px;
-  font-family: "Roboto" sans-serif;
-
-  // NEW MOBILE FRIENDLY RULES
-  @media #{$bp-below-tablet} {
-    padding: 5px 15px;
-  }
 }
 
 .getting-started-mobile-page {


### PR DESCRIPTION
fixes #1159 

- Centered Dropdowns on Events Page
 
<details>
<summary>Before</summary>

<img width="700px" src="https://user-images.githubusercontent.com/42260999/109888095-c8de7600-7c37-11eb-933f-21e9fa89db1c.png">

</details>

<details>

<summary>After</summary>

<img width="700px" src="https://user-images.githubusercontent.com/42260999/109888133-dac01900-7c37-11eb-8581-4e662737b78e.png">

</details>

- Noticed "Event" cards don't align with "Our Location" cards at certain breakpoints and had extra margining. Tweaked styling so they align better.
<details>
<summary>Before</summary>

<img width="700px" src="https://user-images.githubusercontent.com/42260999/109888728-d7795d00-7c38-11eb-90c1-becb9dfd3206.jpg">

<img width="700px" src="https://user-images.githubusercontent.com/42260999/109889036-72723700-7c39-11eb-89f8-4d89986a946b.jpg">

</details>

<details>

<summary>After</summary>

<img width="700px" src="https://user-images.githubusercontent.com/42260999/109888922-4060d500-7c39-11eb-8754-b8630adfe3f5.png">

</details>

- Nested `.column-card-lg--events` into `.flex-page-card` in `_events.scss` for easier understanding in styling hierarchy.
