### PR TITLE
centered toolkit page guide cards and left aligned extra cards

### DIFF
--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -99,12 +99,12 @@
 }
 
 .toolkit-flex-container {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, max-content));
     padding-left: 2rem;
     padding-right: 2rem;
     align-items: stretch;
-    justify-content: start;
+    justify-content: center;
 }
 
 .outer-link {


### PR DESCRIPTION
Fixed #1168

Current Toolkit Page Guide Cards are centered and extra Guide Cards aligned left

https://user-images.githubusercontent.com/68657634/111221665-07f5bb00-8598-11eb-9407-78b4ebc08821.mov
