### PR TITLE
times SHOULD  be right order now

### DIFF
--- a/events/right-col-content.html
+++ b/events/right-col-content.html
@@ -153,7 +153,7 @@
             hours = "00";
         }
         
-        if (modifier === "PM" || 'pm') {
+        if (modifier.toLowerCase() === 'pm') {
             hours = parseInt(hours, 10) + 12;
         }
         return parseInt(`${hours}${minutes}`);


### PR DESCRIPTION
Fixes #1207 

- Fixes an issue where the times displayed in the events page where arranging in the wrong order due to an if condition always being true.