### PR TITLE
media query for font-size change in mobile view #1045

### DIFF
--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -6,6 +6,10 @@
   padding: 30px;
   margin: 12px auto;
   font-family: "Roboto"sans-serif;
+
+  @media #{$bp-below-mobile} {
+    font-size: 18px;
+  }
 }
 
 .getting-started-page {


### PR DESCRIPTION
**before:**
<img width="366" alt="HeaderFontSize-GettingStarted-Before" src="https://user-images.githubusercontent.com/67438372/112067860-02fbb300-8b26-11eb-9635-ff914dd53e5e.png">


**after:**
<img width="375" alt="HeaderFontSize-GettingStarted-After" src="https://user-images.githubusercontent.com/67438372/112067880-0c851b00-8b26-11eb-910c-a45666dbed25.png">

Fixes #1045