### PR TITLE
Updated Railstats Project Profile with no link in partner field

### DIFF
--- a/_projects/metro-ontime.md
+++ b/_projects/metro-ontime.md
@@ -1,7 +1,7 @@
 ---
 identification: '155295655'
 title: Railstats LA
-description: Trailstats LA tracks LA Metro trains and generates punctuality reports. Our website enables both Metro officials and the public to easily review up-to-date statistics for LA's 6 train lines.
+description: Railstats LA tracks LA Metro trains and generates punctuality reports. Our website enables both Metro officials and the public to easily review up-to-date statistics for LA's 6 train lines.
 image: /assets/images/projects/metro-ontime.png
 alt: 'metro ontime'
 image-hero: /assets/images/projects/metro-ontime-hero.png
@@ -29,7 +29,7 @@ links:
 location:
   - Downtown LA
   - Remote
-partner: LA Metro (https://www.metro.net/)
+partner: LA Metro
 tools: Docker, AWS, Observable
 visible: true
 vertical: 'Environment'


### PR DESCRIPTION
Fixes #1102.
Removed partner link from Railstats project profile. Also made changes to apparent typo in project description.
Here is screenshot of fixes:
![image](https://user-images.githubusercontent.com/10714770/113066962-51393380-9170-11eb-964d-10169721b150.png)

Here is screenshot of typo on current Hack for LA website:
![image](https://user-images.githubusercontent.com/10714770/113067154-aecd8000-9170-11eb-99d8-08d648fca692.png)