### PR TITLE
Fixed broken getting started link in events page

### DIFF
--- a/_data/internal/events.yml
+++ b/_data/internal/events.yml
@@ -1,9 +1,12 @@
 - name: Onboarding
-  text: If you are new to the community, join us for Onboarding Night! We offer Guided Onboarding on alternating Mondays and Tuesdays on our <a target='_blank' href='getting-started'>Getting Started</a> page.
+  text: If you are new to the community, join us for Onboarding Night! We offer Guided Onboarding on alternating Mondays and Tuesdays on our <a target='_blank' href='https://www.hackforla.org/getting-started'>Getting Started</a> page.
   link: '../assets/images/getting-started/step1.png'
 - name: Workshops
   text: We host workshops on a range of topics, from development best practices to project management methodologies. Please check back for the current workshop schedule.
   link: '../assets/images/hack-nights/building.png'
+- name: Happy Hour
+  text: Bars and cafes are shut down, but that doesn’t mean we can’t enjoy each other’s company! Grab your beverage of choice and socialize with fellow hackers following some organizational announcements.
+  link: ../assets/images/hack-nights/happy-hour.png
 - name: Happy Hour
   text: Bars and cafes are shut down, but that doesn’t mean we can’t enjoy each other’s company! Grab your beverage of choice and socialize with fellow hackers following some organizational announcements.
   link: ../assets/images/hack-nights/happy-hour.png

--- a/_data/internal/events.yml
+++ b/_data/internal/events.yml
@@ -7,6 +7,3 @@
 - name: Happy Hour
   text: Bars and cafes are shut down, but that doesn’t mean we can’t enjoy each other’s company! Grab your beverage of choice and socialize with fellow hackers following some organizational announcements.
   link: ../assets/images/hack-nights/happy-hour.png
-- name: Happy Hour
-  text: Bars and cafes are shut down, but that doesn’t mean we can’t enjoy each other’s company! Grab your beverage of choice and socialize with fellow hackers following some organizational announcements.
-  link: ../assets/images/hack-nights/happy-hour.png


### PR DESCRIPTION
Fixed #1264 
The getting started link on the events page now redirects to the correct link. See screenshot for the fixed link in question.
![image](https://user-images.githubusercontent.com/10714770/113069634-a166c480-9175-11eb-870e-97ce84fd9445.png)