### PR TITLE
Subheading adjusted to one line

### DIFF
--- a/_sass/components/_join-us.scss
+++ b/_sass/components/_join-us.scss
@@ -68,7 +68,6 @@
     h2 {
       font-size: 16px;
       width: 100%;
-      max-width: 300px;
     }
 
     .join-us-card-img {


### PR DESCRIPTION
- Explicit Max-width propery was removed. It is now inherited and defaults to 100%
- Closes #1253