### PR TITLE
Fix Typo On Join Page

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -37,9 +37,9 @@ permalink: /join
       <div class="join-us-card-body">
         <p>
           Hack for LA needs Advisors in a variety of areas. These roles are
-          flexible and can be short term or ongoing. If you deeply experienced
+          flexible and can be short-term or ongoing. If you are deeply experienced
           in a specific area such as Fundraising, Marketing, Scalable System
-          Architecture, Diversity Equity and Inclusion initiatives, etc. we are
+          Architecture, Diversity Equity and Inclusion initiatives, etc., we are
           interested in talking to you.
         </p>
         <p class='join-us-remove-p-padding'>How to get involved:</p>
@@ -50,7 +50,7 @@ permalink: /join
             <a href="https://www.linkedin.com/in/bonnieawolfe/" target="_blank">Bonnie Wolfe</a>
           </li>
           <li>
-            <a href="mailto:civicopportunity@hackforla.org">Send and email</a> to our
+            <a href="mailto:civicopportunity@hackforla.org">Send an email</a> to our
             Civic Opportunity team
           </li>
         </ol>
@@ -87,9 +87,9 @@ permalink: /join
           of all experiences and skill levels. Everyone is welcome!
         </p>
         <p>
-          We are a Do-ocracy, we are not a school, yet everyone here is learning
-          something, growing their experiences, porfolios and ability to work on
-          inter-disicplinary teams.
+          We are a Do-ocracy: we are not a school, yet everyone here is learning
+          something, growing their experiences, portfolios and ability to work on
+          inter-disciplinary teams.
         </p>
         <a href="https://www.hackforla.org/#projects" target="_blank"
           ><button class="btn btn-primary btn-md">Project Volunteer</button></a
@@ -133,9 +133,9 @@ permalink: /join
         <h2>Running Hack for LA costs money</h2>
         <p>
           In support of the development and launch of enterprise software
-          products with Government and non profit partners, we are standardizing
+          products with Government and nonprofit partners, we are standardizing
           our infrastructure and procedures. This enables Hack for LA to provide
-          world class training to our members and valuable, scaleable, impactful
+          world-class training to our members and valuable, scalable, impactful
           products to the commmunity.
         </p>
         <img


### PR DESCRIPTION
Closes #1252

- Advise Us card, 2nd line: change add a dash between "short term" > should be "short-term"
- Advise Us card, 2nd line: Add "are" between "If you" and "deeply experienced"
- Advise Us card, 4th line: Add a comma between "initiatives, etc." and "we are" > should be "initiatives, etc., we are.."
- Advise Us card, step # 3: Change "and" to "an" in "send and email" (should be "send an email")
- Volunteer with Us card, 5th line: Change the comma after "Do-ocracy" to a colon ( : ). So should be: "We are a Do-ocracy: we are not.."
- Volunteer with Us card, 6th line: Add a t in porfolios > should be portfolios
- Volunteer with Us card, 7th line: Change "anti-disicplinary" spelling to "anti-disciplinary"
- Help Us Keep the Lights On card, 2nd line: turn "non profit" into one word> should be "nonprofit"
- Help Us Keep the Lights On card, 4th line: add a dash between "world class" > should be "world-class"
- Help Us Keep the Lights On card, 5th line: change "scaleable" spelling to "scalable"


<details>
<summary>Evidence 😈 </summary>

![image](https://user-images.githubusercontent.com/32349001/113604721-a6af8d80-9613-11eb-8eef-e20a2d00cfbf.png)

</details>