### PR TITLE
Adjust links on join us page

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -67,23 +67,17 @@ permalink: /join
       <div class="join-us-card-body">
         <p class='join-us-remove-p-padding'>
           Hack for LA projects are currently recruiting for
-          <a href="https://www.hackforla.org/?">activists</a>,
-          <a href="https://www.hackforla.org/?looking=Development">coders</a>,
-          <a href="https://www.hackforla.org/?looking=UI/UX">designers</a>,
-          <a href="https://www.hackforla.org/?looking=UI/UX">researchers</a>,
-          <a href="https://www.hackforla.org/?looking=QA">testers</a>,
-          <a href="https://www.hackforla.org/?looking=Business+Analyst"
-            >business analysts</a
-          >,
-          <a href="https://www.hackforla.org/?looking=PM"
-            >project/product managers</a
-          >,
-          <a href="https://www.hackforla.org/?looking=Data">data scientists</a>,
-          <a href="https://www.hackforla.org/?looking=Ops">dev ops</a>,
-          <a href="https://www.hackforla.org/?looking=Content">writers</a>, and
-          <a href="https://www.hackforla.org/?looking=SEO/Marketing"
-            >marketers</a
-          >
+          <a href="https://www.hackforla.org/?" target='_blank' >activists</a>,
+          <a href="https://www.hackforla.org/?looking=Development" target='_blank' >coders</a>,
+          <a href="https://www.hackforla.org/?looking=UI/UX" target='_blank' >designers</a>,
+          <a href="https://www.hackforla.org/?looking=UI/UX" target='_blank' >researchers</a>,
+          <a href="https://www.hackforla.org/?looking=QA" target='_blank' >testers</a>,
+          <a href="https://www.hackforla.org/?looking=Business+Analyst" target='_blank' >business analysts</a>,
+          <a href="https://www.hackforla.org/?looking=PM" target='_blank' >project/product managers</a>,
+          <a href="https://www.hackforla.org/?looking=Data" target='_blank' >data scientists</a>,
+          <a href="https://www.hackforla.org/?looking=Ops" target='_blank' >dev ops</a>,
+          <a href="https://www.hackforla.org/?looking=Content" target='_blank' >writers</a>, and
+          <a href="https://www.hackforla.org/?looking=SEO/Marketing" target='_blank'>marketers</a>
           of all experiences and skill levels. Everyone is welcome!
         </p>
         <p>
@@ -91,7 +85,7 @@ permalink: /join
           something, growing their experiences, porfolios and ability to work on
           inter-disicplinary teams.
         </p>
-        <a href="https://www.hackforla.org/#projects" target="_blank"
+        <a href="https://www.hackforla.org/getting-started" target="_blank"
           ><button class="btn btn-primary btn-md">Project Volunteer</button></a
         >
       </div>


### PR DESCRIPTION
Closes #1251

-  Make each of the links in the "Volunteer with Us" card open into new tabs
-  Make  the "Project Volunteer" button in the "Volunteer with Us" card lead to the Getting Started page (instead of the homepage)