### PR TITLE
added la city to dept of personnel

### DIFF
--- a/_projects/heart.md
+++ b/_projects/heart.md
@@ -65,7 +65,7 @@ links:
     url: 'https://hackforla.slack.com/messages/CDWKEBYBB'
   - name: Wiki
     url: 'https://github.com/hackforla/heart/wiki'
-partner: LA City Attorney’s Homeless Engagement and Response Team
+partner: LA City & County Attorney’s Homeless Engagement and Response Team
 visible: true
 vertical: 'Justice'
 status: Completed

--- a/_projects/work-for-la.md
+++ b/_projects/work-for-la.md
@@ -18,7 +18,7 @@ links:
 location: 
   - Downtown LA
   - Remote
-partner: Department of Personnel
+partner: LA City Department of Personnel
 visible: true
 status: Completed
 completed-contact: WorkForLA@googlegroups.com


### PR DESCRIPTION
I updated Dept of Personnel to include LA City Dept of Personnel in the workforla/projects file.  
Fixes #1049 