### PR TITLE
Standardize events page 1125

### DIFF
--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -110,7 +110,7 @@
   content: "\226A";
   float: left;
   transition: transform 0.25s ease-in;
-  color: $color-black
+  color: $color-black;
   font-weight: normal;
   font-size: 18px;
   margin: 0 6px;

--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -134,7 +134,6 @@
   max-width: 150px;
 }
 
-//Fixes for 
 .fullwidth-background-container {
   background-color: #f2c94d;
   margin: 0 -2em;
@@ -144,7 +143,6 @@
 }
 
 .getting-started-mobile-page {
-  // NEW MARkup BELOW
   @media #{$bp-below-mobile} {
     pading: 0 2em;
     display: inline;

--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -110,7 +110,7 @@
   content: "\226A";
   float: left;
   transition: transform 0.25s ease-in;
-  color: #000000;
+  color: $color-black
   font-weight: normal;
   font-size: 18px;
   margin: 0 6px;
@@ -391,7 +391,7 @@
     float: right;
     transform: rotate(-45deg);
     transition: transform 0.25s ease-in;
-    color: #fa114f;
+    color: $color-red;
     font-weight: bolder;
     font-size: 24px;
   }
@@ -424,7 +424,7 @@
     float: right;
     transform: rotate(-45deg);
     transition: transform 0.25s ease-in;
-    color: #fa114f;
+    color: $color-red;
     font-weight: bolder;
     font-size: 24px;
   }
@@ -563,7 +563,7 @@
 }
 
 .events-page-header {
-  color: #ffffff; 
+  color: $color-white; 
   margin-top: 48px; 
   font-size: 36px;
 }

--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -134,8 +134,19 @@
   max-width: 150px;
 }
 
+//Fixes for 
+.fullwidth-background-container {
+  background-color: #f2c94d;
+  margin: 0 -2em;
+}
+.add-padding-container {
+  padding: 0 2.5em;
+}
+
 .getting-started-mobile-page {
+  // NEW MARkup BELOW
   @media #{$bp-below-mobile} {
+    pading: 0 2em;
     display: inline;
     margin: 20px;
     border: 0 solid rgba(51, 51, 51, 0.06);
@@ -219,9 +230,8 @@
   font-weight: 700;
 
   @media #{$bp-below-mobile} {
-    text-align: justify;
-    padding: 12px;
     margin: 0;
+    padding: 1em 2em; 
     font-size: 16px;
     line-height: 19px;
   }
@@ -538,7 +548,7 @@
 
 
 
-.events-page{
+.events-page, .content-section{
   background: $color-blue-dark;
   min-height: 100vh;
   display: flex;

--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -135,7 +135,7 @@
 }
 
 .fullwidth-background-container {
-  background-color: #f2c94d;
+  background-color: $color-gold;
   margin: 0 -2em;
 }
 .add-padding-container {
@@ -209,7 +209,7 @@
 }
 
 .notification-banner {
-  background-color: #f2c94d;
+  background-color: $color-gold;
   width: 100%;
   display: flex;
   justify-content: center;
@@ -452,7 +452,7 @@
 .mobile-locations-dropdown {
   @media #{$bp-below-tablet} {
     display: none;
-    background: #f2c94d;
+    background: $color-gold;
   }
 }
 

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -17,6 +17,7 @@ $color-pink: #f7f5f5;
 $color-dodgerblue: #1587FF;
 $color-lightseagreen: #0DC583;  
 $color-orange: #F9B400;
+$color-gold: #F2C94D;
 $color-chocolate: #F16618;
 $color-firebrick: #D7261B;
 $color-deeppink: #FA207C;

--- a/pages/events/events.html
+++ b/pages/events/events.html
@@ -8,7 +8,7 @@ permalink: /events/
   {% include_relative header-container-content.html %}
 </div>
 
-<section class="events-pag content-section">
+<section class="events-page content-section">
 
     <h1 class = "events-page-header">Our Events</h1>
     <div class="flex-page-card">

--- a/pages/events/events.html
+++ b/pages/events/events.html
@@ -8,7 +8,7 @@ permalink: /events/
   {% include_relative header-container-content.html %}
 </div>
 
-<section class="events-page">
+<section class="events-pag content-section">
 
     <h1 class = "events-page-header">Our Events</h1>
     <div class="flex-page-card">
@@ -25,18 +25,22 @@ permalink: /events/
       Our Locations
     </h1>
     
-    <div class="notification-banner">
-      <p class="meetings-message">
-        In light of the COVID-19 pandemic, Hack for LA has suspended its in-person
-        events below. The organization remains fully active, and all events are
-        now being conducted remotely using Zoom at the days/times listed above.
-      </p>
+    <div class="fullwidth-background-container">
+      <div class="notification-banner">
+        <p class="meetings-message">
+          In light of the COVID-19 pandemic, Hack for LA has suspended its in-person
+          events below. The organization remains fully active, and all events are
+          now being conducted remotely using Zoom at the days/times listed above.
+        </p>
+    </div>
   
-      <div class="getting-started-mobile-page">
-        <h2 class="event-title-1">
-          <img class="vector-img" src="../assets/images/hack-nights/locations.svg" alt="image of a location icon" />
-          See our Locations
-        </h2>
+      <div class="add-padding-container">
+        <div class="getting-started-mobile-page">
+          <h2 class="event-title-1">
+            <img class="vector-img" src="../assets/images/hack-nights/locations.svg" alt="image of a location icon" />
+            See our Locations
+          </h2>
+        </div>
       </div>
     </div>
   


### PR DESCRIPTION
[Fixes 1125](https://github.com/hackforla/website/issues/1125)
Fixes #1125
I also added variable `$color-gold: #F2C94D`, to our _colors.scss file

And repaired all colors that weren't using our variables
- `#000000` became `$color-black`
- `#FFFFFF` became `$color-white`
- `#FA114F` became `$color-red`

<details>
<summary>Events Page: Banner full length & Icon + Pink Arrow have spacing</summary>

<img width="270" alt="Screen Shot 2021-04-07 at 8 09 36 PM" src="https://user-images.githubusercontent.com/67438372/113963453-749e5700-97de-11eb-8683-b69a5747524d.png">
</details>

