### PR TITLE
Adjust Wins page styling 1336

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -125,8 +125,7 @@
 .wins-card-name{
     font-weight: bold;
     font-size: 20px;
-    line-height: 22px;
-    margin-top: 13px;
+    padding-bottom: .4em
 }
 .wins-card-team{
     font-weight: normal;
@@ -154,8 +153,38 @@
 }
 
 @media #{$bp-below-tablet} {
+    .wins-card {
+//NEW ADD
+        position: relative;
+    }
     .wins-card-text{
         height: 81px;
+        position: inherit;
+    }
+//NEW ADD
+    .wins-see-more-div {
+        height: 0;
+        margin-top: 4px;
+        padding: 0;
+//NEW ADDS
+        right: 7%;
+        top: 88.5%;
+    }
+    .home-getting-started-container {
+        h1 {font-size: 2rem;}
+    }
+
+    .project-inner {
+        font-size: 1rem;
+        line-height: 1.3rem;
+        margin-bottom: .3rem;
+    }
+    .btn--wins {
+        height: 40px;
+        padding: 0 20px;
+        border-radius: 20px;
+        font-size: 1rem;
+        line-height: 40px;
     }
 }
 
@@ -185,13 +214,11 @@
     .wins-card-name{
         font-size: 19px;
         line-height: 22px;
-        margin: 0;
-        padding-top: 5px;
     }
-    .wins-card-team{
-        font-size: 12px;
-        line-height: 16px;
-    }
+    // .wins-card-team{
+    //     font-size: 12px;
+    //     line-height: 16px;
+    // }
     .wins-card-icon{
         margin-left: 13.5px;
     }
@@ -311,7 +338,7 @@
 .wins-page-contain > ul.filter-list{
 	grid-template-columns: repeat(2, 1fr);
 	min-width: 216px;
-	width: 46%;
+	width: 40%;
 
 	
 }

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -125,7 +125,7 @@
 .wins-card-name{
     font-weight: bold;
     font-size: 20px;
-    padding-bottom: .4em
+    padding-bottom: .4em;
 }
 .wins-card-team{
     font-weight: normal;
@@ -169,7 +169,7 @@
         right: 7%;
         top: 88.5%;
     }
-    
+
     .home-getting-started-container {
         h1 {font-size: 2rem;}
     }

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -175,7 +175,7 @@
     }
 
     .project-inner {
-        font-size: 1rem;
+        font-size: .937rem;
         line-height: 1.3rem;
         margin-bottom: .3rem;
     }

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -154,22 +154,22 @@
 
 @media #{$bp-below-tablet} {
     .wins-card {
-//NEW ADD
         position: relative;
     }
+
     .wins-card-text{
         height: 81px;
         position: inherit;
     }
-//NEW ADD
+
     .wins-see-more-div {
         height: 0;
         margin-top: 4px;
         padding: 0;
-//NEW ADDS
         right: 7%;
         top: 88.5%;
     }
+    
     .home-getting-started-container {
         h1 {font-size: 2rem;}
     }
@@ -215,10 +215,7 @@
         font-size: 19px;
         line-height: 22px;
     }
-    // .wins-card-team{
-    //     font-size: 12px;
-    //     line-height: 16px;
-    // }
+
     .wins-card-icon{
         margin-left: 13.5px;
     }


### PR DESCRIPTION
Fixes #1336 

> - In mobile only: make the heading ('let's celebrate together!') 32px (instead of 38px) - use rem units
> -  In mobile only: make the "Team(s)" and "Role(s)" sections the same font size- 15px - use rem units (currently one is 12px and one is 16px)
> -  Try to also add a little margin between all of these lines (person's name, Teams, Roles) to give it some breathing room- maybe something like 3px?
> -  Remove the margin-top from the volunteers' names on the wins cards
> -  Change desktop .wins-page-contain>ul.filter-list width to 40% (instead of 46%) so that filters are less wide
> -  Try to make only this header button ("Share your wins") use the properties of class ".btn-md-narrow" (smaller size) only in mobile - without affecting the mobile version of any other buttons on the site that use the same button classes (this might require adding the properties to mobile media query in .btn--wins)

Additional style changes were put on "...see more" (appears during mobile view), as the changes from issue #1336 altered their placement. 

<details>
<summary>Adjustments to Wins Page Styling, mobile view</summary>

![image](https://user-images.githubusercontent.com/67438372/114256924-7ba99e80-9971-11eb-89d0-2b9f1cbb5eec.png)

</details>

<details>
<summary>Filter List Re-size, full screen view</summary>

<img width="630" alt="Screen Shot 2021-04-09 at 8 25 12 PM" src="https://user-images.githubusercontent.com/67438372/114256989-b90e2c00-9971-11eb-88a5-b5e40e8e63f3.png">

</details>