### PR TITLE
Fix Home Page Styling Issues 

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,5 +1,5 @@
 <a class="anchor" id="about"></a>
-<section class="content-section about">
+<section class="content-section about content-section--home">
   <div class="page-contain">
     <h2>
       Want to know more about Hack for LA?

--- a/_includes/current-projects.html
+++ b/_includes/current-projects.html
@@ -1,5 +1,5 @@
 <a class="anchor" id="projects"></a>
-<section class="content-section projects">
+<section class="content-section projects home-page-projects">
     <div class="page-contain projects-inner">
         <h2 class="project-header">Current Projects</h2>
         <p class="project-pitch">

--- a/_includes/home-getting-started.html
+++ b/_includes/home-getting-started.html
@@ -1,3 +1,3 @@
-<div class='home-getting-started-container content-section section-hack-nights'>
+<div class='home-getting-started-container section-hack-nights'>
     <a href='./getting-started'><button class='btn btn-primary btn-xl btn--home-getting-started'>Getting Started</button></a>
 </div>

--- a/_sass/components/_home-getting-started.scss
+++ b/_sass/components/_home-getting-started.scss
@@ -1,5 +1,6 @@
 .home-getting-started-container {
     text-align: center;
+    padding: 1em 0 2.3em;
 }
 
 .btn--home-getting-started {

--- a/_sass/components/_press.scss
+++ b/_sass/components/_press.scss
@@ -1,5 +1,12 @@
 .press {
   padding: 32px 16px;
+  // Fixes issues created from .content-section styling
+  min-height: auto;
+  color: $color-white;
+    .news-cards li a{
+      color: $color-red;
+    }
+    h2, .type-h4{color: $color-white;}
 }
 
 .news-cards {

--- a/_sass/components/_projects.scss
+++ b/_sass/components/_projects.scss
@@ -3,6 +3,12 @@
   padding: 32px 16px;
 }
 
+// Fixes issues created from .content-section styling
+.home-page-projects{
+  display: block;
+}
+
+
 .projects-inner {
   display: flex;
   flex-direction: column;

--- a/_sass/layouts/_main.scss
+++ b/_sass/layouts/_main.scss
@@ -21,3 +21,12 @@
 .content-section {
   padding: 32px 16px;
 }
+
+// Fixes issues created from .content-section styling
+.content-section--home, #sponsors {
+  min-height: auto;
+  color: $color-white;
+  h2 {
+    color: $color-white;
+  }
+}


### PR DESCRIPTION
Fixes #1388 

> Some new styling on the main page seems to have skewed the layout. Need to find and remove, or change, these stylings. Issues appear on the header, filter bar and footer. Insure that changes don't create issues on other pages. May need to create new, page specific, classes.

> - Remove extra spacing between header image/text and "Getting Started" button (refer to screenshots).
> -  Remove extra spacing between the bottom of the "Getting Started" button and the "Getting Started" header (refer to screenshots)
> -  Add spacing to .projects-inner (refer to screenshots)
> -  Add spacing to .filter-toolbar (refer to screenshots)
> -  Remove excess spacing in footer
> -  Fix font-color in footer, not currently readable

These changes additionally helped related footer-content items on: projects page, press page, connect page.

<details>
<summary>Showcasing Fixes — Refer to #1388 to see "before" screenshots</summary>

<img width="1429" alt="Screen Shot 2021-04-10 at 10 22 21 AM" src="https://user-images.githubusercontent.com/67438372/114278974-1d1f0780-99e7-11eb-8213-96ab61a064f6.png">


<img width="1440" alt="Screen Shot 2021-04-10 at 10 22 27 AM" src="https://user-images.githubusercontent.com/67438372/114278976-2019f800-99e7-11eb-82eb-38acc5c1b002.png">
<img width="1438" alt="Screen Shot 2021-04-10 at 10 22 36 AM" src="https://user-images.githubusercontent.com/67438372/114278983-2314e880-99e7-11eb-81a7-cb6a6d248650.png">
<img width="1428" alt="Screen Shot 2021-04-10 at 10 22 43 AM" src="https://user-images.githubusercontent.com/67438372/114278986-260fd900-99e7-11eb-99d0-b474050be6c8.png">
<img width="1427" alt="Screen Shot 2021-04-10 at 10 22 50 AM" src="https://user-images.githubusercontent.com/67438372/114278993-2f00aa80-99e7-11eb-8f3a-0075d22261d9.png">

</details>
