### PR TITLE
"changed margin in _guide-pages.scss to 2 and 12 percent"

### DIFF
--- a/_sass/components/_guide-pages.scss
+++ b/_sass/components/_guide-pages.scss
@@ -140,7 +140,7 @@
   background: $color-white;
   box-shadow: 0px 4px 8px rgba(51, 51, 51, 0.2);
   border-radius: 10px;
-  margin: 5%;
+  margin: 2% 12%;
   padding: 5% 12.5%;
   text-align: center;
 }


### PR DESCRIPTION
Fixes #1332 
New issue discovered when viewing in IPAD mode.  Breakpoint needs to be adjusted so section-container underlines in 2FA page accordion areas re-size correctly.  Most likely breakpoint needs adjusting, see screenshots below:

![image](https://user-images.githubusercontent.com/81199122/114803007-91dda300-9d53-11eb-9329-b6a9969eec21.png)

![image](https://user-images.githubusercontent.com/81199122/114803055-a3bf4600-9d53-11eb-80bc-d38d476ce776.png)

New issue to be created to correct this re-sizing error.
