### PR TITLE
Changed text in Step 6 content area to match text in Step 6 Table of Contents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ To develop the site, you'll need to first clone the repository on to your comput
 
 5. [Read Hack for LA's Site Architecture to get acquainted with how the website is structured](https://github.com/hackforla/website/wiki/Hack-for-LA's-Site-Architecture)
 
-6. [Switch to new issue branch before you start making changes](#step-6-change-to-a-new-branch)
+6. [Switch to new issue branch before you start making changes](#step-6-work-on-an-issue-using-git)
 
 
 **After you've worked on your issue and before you make a pull request:**
@@ -181,7 +181,7 @@ docker-compose up
 
 #### Step 5: Read [Hack for LA's Site Architecture](https://github.com/hackforla/website/wiki/Hack-for-LA's-Site-Architecture) to get acquainted with how the website is structured
 
-#### Step 6: Work on an issue using git
+#### Step 6:  Work on an issue using git  
 
 Create a new branch for each issue you work on. Doing all your work on topic branches leaves your repository's main branch (named `gh-pages`) unmodified and greatly simplifies keeping your fork in sync with the main project.
 


### PR DESCRIPTION
Fixes #1434 
Changed text so that it's the same in Step 6 Table of Contents link and in the corresponding area of the document.

Per screenshots below:
![image](https://user-images.githubusercontent.com/81199122/115777277-ed1e1f80-a369-11eb-8ced-0de57e36569d.png)

![image](https://user-images.githubusercontent.com/81199122/115777350-02934980-a36a-11eb-9406-da2ac41249a7.png)
