### PR TITLE
fix mobile subheading of community practice page

### DIFF
--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -123,6 +123,9 @@
     }
   }
   .page-card-content h3 {
+    @media #{$bp-below-mobile} {
+      font-size: 1.25rem
+    }
     @media #{$bp-mobile-up} {
       font-size: 1.25rem;
     }


### PR DESCRIPTION
- [x]  Make the font size of the mobile subheadings in the Communities of Practice page 20px (instead of 22px)

Fix #1460 