### PR TITLE
Update Project Profile: Food Oasis

### DIFF
--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -7,45 +7,45 @@ alt: 'Stacks of freshly harvested beets'
 image-hero: /assets/images/projects/food-oasis-hero.jpg
 alt-hero: 'Stacks of freshly harvested carrots, beets and vegetables'
 leadership:
-  - name: Jenny Mikesell
-    role: Product Manager
-    links:
-      slack: "https://hackforla.slack.com/team/UM4FE6ELQ"
-      github: "https://github.com/jpmikesell"
-    picture: https://avatars.githubusercontent.com/jpmikesell
-  - name: Tina Moh
-    role: UX/Service Lead
-    links:
-      slack: "https://hackforla.slack.com/team/UP4AZM459"
-      github: "https://github.com/tina-moh"
-    picture: https://avatars.githubusercontent.com/tina-moh
   - name: John Darragh
-    role: Architect
+    role: Architect & Technology Lead
     links:
       slack: "https://hackforla.slack.com/team/UFLDX9V19"
       github: "https://github.com/entrotech"
     picture: https://avatars.githubusercontent.com/entrotech
-  - name: Lucas Homer
-    role: Sr. Developer
+  - name: Erika Gill
+    role: Product Manager
     links:
-      slack: "https://hackforla.slack.com/team/UMQ5H55TN"
-      github: "https://github.com/lucas-homer"
-    picture: https://avatars.githubusercontent.com/lucas-homer
-  - name: Gaby Cohen
-    role:
+      slack: "https://hackforla.slack.com/team/U01NB9SEKUJ"
+      github: "https://github.com/erigilg"
+    picture: https://avatars.githubusercontent.com/erigilg
+  - name: Katie Jensen
+    role: Product Manager
     links:
-      slack: "https://hackforla.slack.com/team/UQG8PEXPX"
-      github: "https://github.com/gcohen02"
-    picture: https://avatars.githubusercontent.com/gcohen02
-  - name: Steven Ettinger
-    role: Blockchain Developer
+      slack: "https://hackforla.slack.com/team/U01JKTLQGBF"
+      github: "https://github.com/ktjnyc"
+    picture: https://avatars.githubusercontent.com/ktjnyc
+  - name: Andrew Strauss
+    role: Product Manager
     links:
-      slack: "https://hackforla.slack.com/team/UNFG6M8FN"
-      github: "https://github.com/disregardfiat"
-    picture: https://avatars.githubusercontent.com/disregardfiat
+      slack: "https://hackforla.slack.com/team/U018LSRS37Y"
+      github: "https://github.com/pageignited"
+    picture: https://avatars.githubusercontent.com/pageignited
+  - name: Thy Tran
+    role: Subject Matter Expert & User Researcher
+    links:
+      slack: "https://hackforla.slack.com/team/U01R74KS81Y"
+      github: "https://github.com/wanderingspoon"
+    picture: https://avatars.githubusercontent.com/wanderingspoon
+  - name: Bryan Wu
+    role: UX Designer
+    links:
+      slack: "https://hackforla.slack.com/team/U01PG6RD0T1"
+      github: "https://github.com/fancyham"
+    picture: https://avatars.githubusercontent.com/fancyham
 links:
   - name: GitHub
-    url: "https://github.com/foodoasisla"
+    url: "https://github.com/hackforla/food-oasis"
   - name: Site
     url: "https://foodoasis.la/"
   - name: Readme
@@ -53,7 +53,7 @@ links:
   - name: Slack
     url: "https://hackforla.slack.com/archives/C6JBH478W"
   - name: Test Site
-    url: "http://food-oasis.herokuapp.com/"
+    url: "https://devla.foodoasis.net/"
 looking:
 technologies:
   - ReactJS


### PR DESCRIPTION
Updated leadership names, roles, and slack and github links for food oasis. Also updated project github and testsite links. fixes #1436

Removed Jenny, Tina, Lucas, Gaby, Steven, and updated to the following:

Name: John Darragh
Role: Architect & Technology Lead
Slack: UFLDX9V19
Github: entrotech

Name: Erika Gill
Role: Product Manager
Slack: U01NB9SEKUJ
Github: erigilg

Name: Katie Jensen
Role: Product Manager
Slack: U01JKTLQGBF
Github: ktjnyc

Name: Andrew Strauss
Role: Product Manager
Slack: U018LSRS37Y
Github: pageignited

Name: Thy Tran
Role: Subject Matter Expert & User Researcher
slack: U01R74KS81Y
github: wanderingspoon

Name: Bryan Wu
Role: UX Designer
slack: U01PG6RD0T1
github: fancyham

Github
https://github.com/hackforla/food-oasis

Testsite
https://devla.foodoasis.net/

<img width="919" alt="Screen Shot 2021-04-27 at 3 21 13 PM" src="https://user-images.githubusercontent.com/79604590/116321373-c3e8ff00-a76e-11eb-9717-87ff89732270.png">
