### PR TITLE
1489 update About text to match Partner text adding & County

### DIFF
--- a/_projects/heart.md
+++ b/_projects/heart.md
@@ -65,7 +65,7 @@ links:
     url: 'https://hackforla.slack.com/messages/CDWKEBYBB'
   - name: Wiki
     url: 'https://github.com/hackforla/heart/wiki'
-partner: LA City Attorney’s Homeless Engagement and Response Team
+partner: LA City & County Attorney’s Homeless Engagement and Response Team
 visible: true
 vertical: 'Justice'
 status: Completed

--- a/_projects/heart.md
+++ b/_projects/heart.md
@@ -1,7 +1,7 @@
 ---
 identification: '159286729'
 title: Heart
-description: Heart is a project working directly with the LA City Attorney’s Homeless Engagement and Response Team. The HEART program helps individuals experiencing homelessness resolve eligible traffic and pedestrian infractions and related warrants and fines by engaging with relevant services. Hack for LA is helping them build a database and case management system to streamline their workflow and enable them to scale their program.
+description: Heart is a project working directly with the LA City & County Attorney’s Homeless Engagement and Response Team. The HEART program helps individuals experiencing homelessness resolve eligible traffic and pedestrian infractions and related warrants and fines by engaging with relevant services. Hack for LA is helping them build a database and case management system to streamline their workflow and enable them to scale their program.
 image: /assets/images/projects/heart.png
 alt: 'Programming code icon that reads helping the homeless with code.'
 image-hero: /assets/images/projects/heart-hero.png

--- a/_projects/work-for-la.md
+++ b/_projects/work-for-la.md
@@ -18,7 +18,7 @@ links:
 location: 
   - Downtown LA
   - Remote
-partner: Department of Personnel
+partner: LA City Department of Personnel
 visible: true
 status: Completed
 completed-contact: WorkForLA@googlegroups.com


### PR DESCRIPTION
Fixes #1489 
This is an additional update related to original issue #1048 which only added "& County" to the Partner area and not to the About area.