### PR TITLE
adds JoinUs page content to Credits

### DIFF
--- a/_data/internal/credits/act.yml
+++ b/_data/internal/credits/act.yml
@@ -1,0 +1,12 @@
+---
+title: Action
+title-link: https://thenounproject.com/
+content: icon
+used-in: Join Us
+artist: Creative Stall
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/join-us/volunteer-with-us-icon.svg
+alt: 'Image of Action'
+type: icon
+---

--- a/_data/internal/credits/contact.yml
+++ b/_data/internal/credits/contact.yml
@@ -1,0 +1,12 @@
+---
+title: Contact
+title-link: https://www.freepik.com/free-vector/contact-us-concept-landing-page_4661521.htm
+content: Image
+used-in: Join Us
+artist: Jonathan Larenas
+provider: Freepik
+provider-link: https://www.freepik.com/
+image-url: /assets/images/join-us/banner-icon.svg
+alt: 'Image of Contact'
+type: icon
+--- 

--- a/_data/internal/credits/delegate.yml
+++ b/_data/internal/credits/delegate.yml
@@ -1,0 +1,12 @@
+---
+title: Delegate
+title-link: https://thenounproject.com/
+content: icon
+used-in: Join Us
+artist: Vectors Market
+provider: Noun Project
+provider-link: https://thenounproject.com/
+image-url: /assets/images/join-us/advice-us-icon.svg
+alt: 'Iamge of Delegate'
+type: icon
+--- 

--- a/_data/internal/credits/give.yml
+++ b/_data/internal/credits/give.yml
@@ -1,0 +1,12 @@
+---
+title: Give
+title-link: https://thenounproject.com/
+content: icon
+used-in: Join Us
+artist: Nawicon
+provider: Noun Project
+provider-link: https://thenounproject.com/
+image-url: /assets/images/join-us/help-us-icon.svg
+alt: 'Image of Give'
+type: icon
+--- 

--- a/_data/internal/credits/partnership.yml
+++ b/_data/internal/credits/partnership.yml
@@ -1,0 +1,12 @@
+---
+title: Partnership
+title-link: https://thenounproject.com/
+content: icon
+used-in: Join Us
+artist: Vectorstall
+provider: Noun Project
+provider-link: https://thenounproject.com/
+image-url: /assets/images/join-us/partner-with-us-icon.svg
+alt: 'Image of Partnership'
+type: icon
+--- 


### PR DESCRIPTION
fixes #1457

added Join Us page images and content to Credits page

<img width="373" alt="Screen Shot 2021-05-04 at 4 09 55 PM" src="https://user-images.githubusercontent.com/79604590/117082184-70d6f500-acf6-11eb-9ddc-bd7aa40a182c.png">

<img width="378" alt="Screen Shot 2021-05-04 at 4 10 02 PM" src="https://user-images.githubusercontent.com/79604590/117082187-72082200-acf6-11eb-8cb1-23d89adb21e7.png">