### PR TITLE
Remove link on volunteer opportunities, leave text

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -82,7 +82,7 @@ permalink: /getting-started
                 <div class="project-position-3">
                     <h3>Join a Community of Practice</h3>
                     <img class="step-img" src="./assets/images/getting-started/icon-comm-of-prac-discu.svg" alt="" />
-                    <p class="getting-started-onboarding-instructions">Join your <a href="https://www.hackforla.org/communities-of-practice" target="_blank">Community of Practice</a>, attend their meetings and review potential <a href="https://github.com/hackforla/communities-of-practice" target="_blank">volunteer opportunities</a>.
+                    <p class="getting-started-onboarding-instructions">Join your <a href="https://www.hackforla.org/communities-of-practice" target="_blank">Community of Practice</a>, attend their meetings, and review potential volunteer opportunities</a>.
                                              
                     </p>
                 </div>


### PR DESCRIPTION
Removed anchor tag on volunteer opportunities link, left the text in place and added an oxford comma for syntax.

Fixes #1511 

![remove-volunteer-opportunities-link](https://user-images.githubusercontent.com/58964358/117490269-6ea5ae00-af23-11eb-9d35-d69b38ca30cd.PNG)
