### PR TITLE
Teamwork image from Communities of Practice added to credits page

### DIFF
--- a/_data/internal/credits/teamwork.yml
+++ b/_data/internal/credits/teamwork.yml
@@ -7,6 +7,6 @@ artist: freepik
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/communities-of-practice/comm-prac-header.svg
-alt: 'Image of Technology'
+alt: 'Multiple people working around a busy table illustration'
 type: icon
 ---

--- a/_data/internal/credits/teamwork.yml
+++ b/_data/internal/credits/teamwork.yml
@@ -1,0 +1,12 @@
+---
+title: Teamwork
+title-link: https://www.freepik.com/premium-vector/teamwork-concept-landing-page_5168259.htm#page=1&query=team%20work&position=0
+content: icon
+used-in: Communities of Practice
+artist: freepik
+provider: Freepik
+provider-link: 'https://www.freepik.com/'
+image-url: /assets/images/communities-of-practice/comm-prac-header.svg
+alt: 'Image of Technology'
+type: icon
+---


### PR DESCRIPTION
Fixes #1506 

Added new teamwork.yml to _data/internal/credits. 

This adds the header image from the communities of practice page to the credits page. 

Other issue discovered:
![hackforla_credits_img](https://user-images.githubusercontent.com/58964358/118751452-2d13dd80-b816-11eb-8448-b543b85ff681.PNG)

I noticed when updating this that in all of the credits, the Name and Provider field each link to the same address, in the picture I uploaded that would be www.freepik.com. I would imagine that the Name field would want to link to the image address itself?

If you look into the credits.html page, both of the links do indeed feed from the same location. The anchor tag is pointing toward {{item[1].provider-link}} for both the Name and Provider fields. I would assume the Name field would point toward {{item[1].title-link}} instead since that field indeed exists in the credit yml files as the web address of the photo itself.

Resolving this would likely just require changing the credits.html page anchor tag for the name field, but I'm not 100% sure.