### PR TITLE
filtered unintended commas out of cardList

### DIFF
--- a/pages/wins/wins.html
+++ b/pages/wins/wins.html
@@ -269,8 +269,23 @@ permalink: /wins/
   	}
   }
 
+ 
 	function insertIcons(cloneCardTemplate, cardClass, cardString) {
-		let cardList = cardString.split(',').map(item => item.trim())
+		let initialCardList = cardString.split(',').map(item => item.trim())
+		let otherWinsText = [];
+		let cardList = [];
+		
+		initialCardList.forEach(win => {
+			if (badgeIcons.hasOwnProperty(win)){
+				cardList.push(win);
+			} else if (win === " "){
+				return
+			} else {
+				otherWinsText.push(win);
+			}
+		});
+		cardList.push(otherWinsText.join(", "));
+
 		const SVG_FILE_PATH = `/assets/images/wins-page/wins-badges/`
 
 		cardList.map(function (item) {
@@ -479,6 +494,7 @@ permalink: /wins/
 			const item = string.trim()
 			const SVG_FILE_PATH = `/assets/images/wins-page/wins-badges/`
 
+			
 			if (badgeIcons.hasOwnProperty(item)) {
 				cloneCardTemplate.insertAdjacentHTML('beforeend',
 					`<div class='overlay-item-container'>
@@ -498,6 +514,7 @@ permalink: /wins/
 				)
 				return
 			}
+			
 		})
 	}
 


### PR DESCRIPTION
fixes #1439 

Wrote a function that filters out the 'other' wins text input and rejoins it if there were any commas. There will only ever be one star icon on a wins card now with multiple achievements separated by comma in the text

This WINS card used to have 3 stars because of commas in the other section, now it only has one.
<img width="615" alt="Screen Shot 2021-05-20 at 8 22 02 PM" src="https://user-images.githubusercontent.com/58538332/119077532-45683180-b9a9-11eb-9fde-e3005ce3f904.png">

All text from other section input, separated by commas
<img width="631" alt="Screen Shot 2021-05-20 at 8 22 27 PM" src="https://user-images.githubusercontent.com/58538332/119077521-400ae700-b9a9-11eb-9551-b80ba45eeaaa.png">
