### PR TITLE
Update alt text for winner image on credit page

### DIFF
--- a/_data/internal/credits/winner.yml
+++ b/_data/internal/credits/winner.yml
@@ -7,6 +7,6 @@ artist: freepik
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: assets/images/wins-page/wins-trophy.png
-alt: 'Image of Winner'
+alt: 'Winner holding trophy concept illustration'
 type: icon
 ---


### PR DESCRIPTION
Resolves #1588

<img width="1167" alt="Screen Shot 2021-05-22 at 9 19 33 AM" src="https://user-images.githubusercontent.com/9373317/119233646-edcbe200-bade-11eb-94c2-ded567d4036e.png">
