### PR TITLE
Standardize About page header and body in mobile

### DIFF
--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -942,3 +942,23 @@ a.anchor {
     margin-left:3vw;
   }
 }
+
+@media #{$bp-below-tablet} {
+
+  .about-header-text-margin h1 {
+    font-size: 1rem; // equal to 16px
+    margin-bottom: 28px;
+  }
+  
+  .header-text--about-us {
+    margin-bottom: 36px;
+  }
+
+  .page-content-container-grid {
+    grid-template-columns: none; 
+  }
+  .sticky-nav-content-container {
+    margin-left: 0px;
+  }
+
+}

--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -600,6 +600,20 @@ a.anchor {
 
 /* Below are the breakpoints and adjustments for different size monitors */
 
+// Below tablet - 768px
+@media #{$bp-below-tablet} {
+  .about-header-text-margin h1 {
+    margin-bottom: 28px;
+  }
+  .header-text--about-us {
+    font-size: 16px;
+    margin-bottom: 36px;
+  }
+  .page-content-container-grid {
+    margin-top: 0; 
+  }
+} // End below tablet
+
 // Bigger than mobile - 480px
 @media #{$bp-mobile-up} {
 
@@ -854,6 +868,7 @@ a.anchor {
 } // End desktop-up
 
 // These are to control the responsive location of the sticky nav
+
 @media only screen and (max-width: 1321px) {
   .page-content-container-grid {
     grid-template-columns: auto auto;
@@ -942,23 +957,11 @@ a.anchor {
     margin-left:3vw;
   }
 }
-
-@media #{$bp-below-tablet} {
-
-  .about-header-text-margin h1 {
-    font-size: 1rem; // equal to 16px
-    margin-bottom: 28px;
-  }
-  
-  .header-text--about-us {
-    margin-bottom: 36px;
-  }
-
+@media only screen and (max-width: 960px) {
   .page-content-container-grid {
     grid-template-columns: none; 
   }
   .sticky-nav-content-container {
     margin-left: 0px;
   }
-
 }

--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -602,12 +602,15 @@ a.anchor {
 
 // Below tablet - 768px
 @media #{$bp-below-tablet} {
-  .about-header-text-margin h1 {
-    margin-bottom: 28px;
+  .about-header-text-margin{
+    margin-bottom: 36px;
+    
+    h1 {
+      margin-bottom: 28px;
+    }
   }
   .header-text--about-us {
     font-size: 16px;
-    margin-bottom: 36px;
   }
   .page-content-container-grid {
     margin-top: 0; 


### PR DESCRIPTION
Fixes #1605 

I put the "About Us" header to 16px/1rem as suggested, but let me know?

<details>
<summary>Before & After: 1</summary>

<img width="307" alt="Screen Shot 2021-05-23 at 7 22 09 PM" src="https://user-images.githubusercontent.com/67438372/119287867-4e047600-bbfc-11eb-8ae1-105403a09adb.png">

<img width="303" alt="Screen Shot 2021-05-23 at 7 22 16 PM" src="https://user-images.githubusercontent.com/67438372/119287871-50ff6680-bbfc-11eb-8ea2-aede7d9f21b2.png">

</details>

<details>
<summary>Before & After: 2</summary>

<img width="305" alt="Screen Shot 2021-05-23 at 7 22 26 PM" src="https://user-images.githubusercontent.com/67438372/119287899-5d83bf00-bbfc-11eb-9d04-da1344b215fc.png">

<img width="306" alt="Screen Shot 2021-05-23 at 7 22 41 PM" src="https://user-images.githubusercontent.com/67438372/119287907-5fe61900-bbfc-11eb-9ac6-e12dd7f3b886.png">

</details>