### PR TITLE
Links program areas page mini cards to their pages

### DIFF
--- a/_data/internal/program-areas/citizen-engagement-card.yml
+++ b/_data/internal/program-areas/citizen-engagement-card.yml
@@ -19,12 +19,15 @@ projects:
     name: Not Today
     image: /assets/images/projects/not-today.png
     image_alt: Not Today logo. A person embrace another person with full support. Art by C.W. Moss
+    link: https://www.hackforla.org/projects/not-today.html
   - id: 228981080
     name: Home Unite Us
     image: /assets/images/projects/home-heart.png
     image_alt: Home Unite Us logo, blue circle with white heart in the center, two hands hugging the logo with "Home Unite Us" above the heart.
+    link: https://www.hackforla.org/projects/home-unite-us
   - id: 215666884
     name: Food Oasis
     image: /assets/images/projects/food-oasis.jpg
     image_alt: Stacks of freshly harvested beets
+    link: https://www.hackforla.org/projects/food-oasis
 ---

--- a/_data/internal/program-areas/civic-tech-infrastructure-card..yml
+++ b/_data/internal/program-areas/civic-tech-infrastructure-card..yml
@@ -20,28 +20,35 @@ projects:
     name: Not Today
     image: /assets/images/projects/not-today.png
     image_alt: Not Today logo. A person embrace another person with full support. Art by C.W. Moss
+    link: https://www.hackforla.org/projects/not-today.html
   - id: 228981080
     name: Home Unite Us
     image: /assets/images/projects/home-heart.png
     image_alt: Home Unite Us logo, blue circle with white heart in the center, two hands hugging the logo with "Home Unite Us" above the heart.
+    link: https://www.hackforla.org/projects/home-unite-us
   - id: 215666884
     name: Food Oasis
     image: /assets/images/projects/food-oasis.jpg
     image_alt: Stacks of freshly harvested beets
+    link: https://www.hackforla.org/projects/food-oasis
   - id: 202051333
     name: Not Today
     image: /assets/images/projects/not-today.png
     image_alt: Not Today logo. A person embrace another person with full support. Art by C.W. Moss
+    link: https://www.hackforla.org/projects/not-today.html
   - id: 228981080
     name: Home Unite Us
     image: /assets/images/projects/home-heart.png
     image_alt: Home Unite Us logo, blue circle with white heart in the center, two hands hugging the logo with "Home Unite Us" above the heart.
+    link: https://www.hackforla.org/projects/home-unite-us
   - id: 215666884
     name: Food Oasis
     image: /assets/images/projects/food-oasis.jpg
     image_alt: Stacks of freshly harvested beets
+    link: https://www.hackforla.org/projects/food-oasis
   - id: 215666884
     name: Food Oasis
     image: /assets/images/projects/food-oasis.jpg
     image_alt: Stacks of freshly harvested beets
+    link: https://www.hackforla.org/projects/food-oasis
 ---

--- a/_data/internal/program-areas/diversity-equity-inclusion-card.yml
+++ b/_data/internal/program-areas/diversity-equity-inclusion-card.yml
@@ -20,8 +20,10 @@ projects:
     name: Write for All&#8482;
     image: /assets/images/projects/writeforall.png
     image_alt: A rainbow document searcher icon, the words &quot;Write for All TM&quot;, and a rainbow-like border.
+    link: https://www.hackforla.org/projects/writeforall
   - id: 222602391
     name: New Schools Today
     image: /assets/images/projects/new-schools-today.jpg
     image_alt: Team of students each with a laptop sitting around the conference table, attentively engege in a video conference call meeting.
+    link: https://www.hackforla.org/projects/new-schools-today
 ---

--- a/_data/internal/program-areas/envirnoment-card.yml
+++ b/_data/internal/program-areas/envirnoment-card.yml
@@ -20,16 +20,20 @@ projects:
     name: LA TDM Calculator
     image: /assets/images/projects/not-today.png
     image_alt: LA TDM Calculator Landing Page (Mock Up)
+    link: https://www.hackforla.org/projects/tdm-calculator
   - id: 128148093
     name: Public Tree Map
     image: /assets/images/projects/public-tree-map.png
     image_alt: Zoomed-in map showing ten streets of the neighborhood. Each dot on the map displaying a tree from the urban forest
+    link: https://www.hackforla.org/projects/public-tree-map
   - id: 00000000
     name: Climate
     image: /assets/images/projects/placeholder.jpg
     image_alt: placeholder
+    link: 
   - id: 155295655
     name: Railstats LA
     image: /assets/images/projects/metro-ontime.png
     image_alt: LA Metro Rail logo
+    link: https://www.hackforla.org/projects/metro-ontime
 ---

--- a/_data/internal/program-areas/justice-card.yml
+++ b/_data/internal/program-areas/justice-card.yml
@@ -21,16 +21,20 @@ projects:
     name: Expunge Assist
     image: /assets/images/projects/expunge-assist.png
     image_alt: Expunge Assist logo
+    link: https://www.hackforla.org/projects/expunge-assist
   - id: 159286729
     name: Heart
     image: /assets/images/projects/heart.png
     image_alt: Programming code icon that reads helping the homeless with code.
+    link: https://www.hackforla.org/projects/heart
   - id: 00000000
     name: Racial Justice
     image: /assets/images/projects/placeholder.jpg
     image_alt: placeholder
+    link: 
   - id: 324048462
     name: Youth Justice Nav
     image: /assets/images/projects/youthjusticenav.png
     image_alt: All capital letters spelling out title of project - YOUTH JUSTICE NAV
+    link: https://www.hackforla.org/projects/youthjusticenav
 ---

--- a/_data/internal/program-areas/social-safety-net-card.yml
+++ b/_data/internal/program-areas/social-safety-net-card.yml
@@ -21,12 +21,15 @@ projects:
     name: Not Today
     image: /assets/images/projects/not-today.png
     image_alt: Not Today logo. A person embrace another person with full support. Art by C.W. Moss
+    link: https://www.hackforla.org/projects/not-today.html
   - id: 228981080
     name: Home Unite Us
     image: /assets/images/projects/home-heart.png
     image_alt: Home Unite Us logo, blue circle with white heart in the center, two hands hugging the logo with "Home Unite Us" above the heart.
+    link: https://www.hackforla.org/projects/home-unite-us
   - id: 215666884
     name: Food Oasis
     image: /assets/images/projects/food-oasis.jpg
     image_alt: Stacks of freshly harvested beets
+    link: https://www.hackforla.org/projects/food-oasis
 ---

--- a/_data/internal/program-areas/vote-representation-card.yml
+++ b/_data/internal/program-areas/vote-representation-card.yml
@@ -20,16 +20,20 @@ projects:
     name: BallotNav
     image: /assets/images/projects/ballotnav.jpg
     image_alt: Two hands holding a mobile device with BallotNav's web application on display.
+    link: https://www.hackforla.org/projects/ballot-nav
   - id: 221070186
     name: Undebate
     image: /assets/images/projects/undebate.jpg
     image_alt: 'Undebate with moderator and 4 participants, displayed question as "Why are you running for office?".'
+    link: https://www.hackforla.org/projects/undebate
   - id: 76137532
     name: HelloGOV
     image: /assets/images/projects/hellogov.jpg
     image_alt: helloGOV log on top, three mobile devices displaying different areas of the helloGOV application
+    link: https://www.hackforla.org/projects/hellogov
   - id: 321544578
     name: Open Community Survey
     image: /assets/images/projects/open-community-survey.jpg
     image_alt: Open Community Survey accessible to three participants with different background and perspectives.
+    link: https://www.hackforla.org/projects/open-community-survey
 ---

--- a/_data/internal/program-areas/workforce-development-card.yml
+++ b/_data/internal/program-areas/workforce-development-card.yml
@@ -20,12 +20,15 @@ projects:
     name: Work for LA
     image: /assets/images/projects/work-for-la.jpg
     image_alt: Los Angeles City Hall building
+    link: https://www.hackforla.org/projects/work-for-la
   - id: 130000551
     name: Hackforla.org Website
     image: /assets/images/projects/website.png
     image_alt: Five women in tech collaborating, engaging in a joyful conversation.
+    link: https://www.hackforla.org/projects/website
   - id: 000000000
     name: Streaming
     image: /assets/images/projects/project-in-formation.png
     alt: placeholder image
+    link: 
 ---

--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -42,7 +42,7 @@ permalink: /program-areas
                 {% for project in program_areas[1].projects%}
                 <li class="project-card-mini inline-list" id="{{project.id}}">
                     <img class="project-card-mini-image" src="{{project.image}}" alt="{{project.image_alt}}" />
-                    <a class="project-card-mini-title" href="">{{project.name}}</a>
+                    <a class="project-card-mini-title" href="{{project.link}}">{{project.name}}</a>
                 </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
fixes #1617

Added links to all projects where available. Climate, Racial Justice, and Streaming mini cards left as they were (linked to the [program areas](https://www.hackforla.org/program-areas) page)

