### PR TITLE
Change Action icon alt text on Credit page

### DIFF
--- a/_data/internal/credits/act.yml
+++ b/_data/internal/credits/act.yml
@@ -7,6 +7,6 @@ artist: Creative Stall
 provider: Noun Project 
 provider-link: https://thenounproject.com/
 image-url: /assets/images/join-us/volunteer-with-us-icon.svg
-alt: 'Image of Action'
+alt: 'Action Icon'
 type: icon
 ---


### PR DESCRIPTION
Changes the Credit pages alt attribute value of the Action icon from 'Image of Action' to 'Action Icon'.

Fixes #1559 