### PR TITLE
Increase header font size for mobile and tablet on Communities of Practice page

### DIFF
--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -34,8 +34,11 @@
     h1 {
       font-size: 48px;
       @media #{$bp-below-tablet} {
-        font-size: 24px;
+        font-size: 40px;
         margin-bottom: 28px;
+      }
+      @media #{$bp-below-mobile} {
+        font-size: 32px;
       }
     }
   }


### PR DESCRIPTION
Fixes #1597 

Increase header font size for tablet from 24px to 40px, and set header font size for mobile to 32px.

Tablet:
![Screen Shot 2021-05-27 at 1 08 15 PM](https://user-images.githubusercontent.com/40401149/119890462-ba2cf580-beec-11eb-8970-d49d54157555.png)

Mobile:
![Screen Shot 2021-05-27 at 1 08 35 PM](https://user-images.githubusercontent.com/40401149/119890511-c618b780-beec-11eb-8893-7aae96072827.png)
