### PR TITLE
adjusted icon size for mobile - 1.4em collapsed, 1em expanded

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -480,5 +480,19 @@
             width: 100%;
         }
     }
+    // when card is collapsed in mobile, icons will be 1.4em
+    .wins-badge-icon {
+        min-width: 1.4em;
+        max-width: 1.4em;
+        min-height: 1.4em;
+        max-height: 1.4em;
+    }
+    // when card is opened with "See More", icons will shrink to 1em
+    .wins-tablet .wins-badge-icon {
+        min-width: 1em;
+        max-width: 1em;
+        min-height: 1em;
+        max-height: 1em;
+    }
 }
 //wins page filter override section end


### PR DESCRIPTION
Fixes #1550
  


COLLAPSED (Before) - Icons in mobile were 1.7em
![2021-06-13 (8)](https://user-images.githubusercontent.com/67043889/121860601-b642f680-cc94-11eb-9641-f576737d1191.png)

COLLAPSED (After) - Icons in mobile are now 1.4em
![2021-06-13 (16)](https://user-images.githubusercontent.com/67043889/121860635-c2c74f00-cc94-11eb-859b-e1e7aa5f4838.png)

EXPANDED (Before)- Icons in mobile were 1.5em
![2021-06-13 (18)](https://user-images.githubusercontent.com/67043889/121860712-d5418880-cc94-11eb-9567-3362547c7e22.png)

EXPANDED (After) - Icons in mobile are now 1em
![2021-06-13 (12)](https://user-images.githubusercontent.com/67043889/121860750-df638700-cc94-11eb-8b3a-861847fa6e76.png)


