### PR TITLE
removed flex property that caused bug with CSS in Firefox

### DIFF
--- a/_sass/components/_project-filter.scss
+++ b/_sass/components/_project-filter.scss
@@ -103,7 +103,6 @@ ul.filter-list li ul li {
 }
 
 .filter-tag {
-  flex: auto;
   align-self: flex-start;
   height: 24px;
   box-sizing: border-box;


### PR DESCRIPTION
fixes #1592 

flex:auto was not being used in chrome and was overriding the actual CSS of the tabs in firefox because of the flex grow and flex shrink properties.
