### PR TITLE
Standardized the page card classes in the About page

### DIFF
--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -143,12 +143,9 @@ a.anchor {
 }
 
 .page-card--about {
-  background: #fff;
+  overflow: hidden;
   border: 0 solid rgba(51, 51, 51, 0.06);
   border-radius: 16px;
-  box-shadow: 0 0 8px 0 rgba(51, 51, 51, 0.2);
-  overflow: hidden;
-  max-width: 896px;
   margin-bottom: 0;
   padding: 22px;
   height: fit-content;
@@ -157,6 +154,7 @@ a.anchor {
 
 // Make the Letter page card have square corners
 .page-card--ed {
+  box-shadow: 0 0 8px 0 rgba(51, 51, 51, 0.2); 
   border-radius: 0;
 }
 

--- a/pages/about/about-card-accomplishments.html
+++ b/pages/about/about-card-accomplishments.html
@@ -1,4 +1,4 @@
-<div class='page-card--about'>
+<div class='card-primary page-card-lg page-card--about'>
     <div class="about-us-section-header" data-hash="accomplishments"><span class="sec-head-img"><img src="/assets/images/about/section-header-elements/accomplishments.svg" alt="" /></span>Accomplishments</div>
     <div class="about-us-section-content">
         <div class="flex-container">

--- a/pages/about/about-card-donations.html
+++ b/pages/about/about-card-donations.html
@@ -1,4 +1,4 @@
-<div class='page-card--about'>
+<div class='card-primary page-card-lg page-card--about'>
     <div class="about-us-section-header" data-hash="donations"><span class="sec-head-img"><img src="/assets/images/about/section-header-elements/donations.svg" alt="" /></span>Make a Donation</div>
     <div class="about-us-section-content">
         <div class="flex-container">

--- a/pages/about/about-card-executive-letter.html
+++ b/pages/about/about-card-executive-letter.html
@@ -1,4 +1,4 @@
-<div class='page-card--about page-card--ed'>
+<div class='card-primary page-card--about page-card--ed'>
     <div class="about-us-section-header--ED" data-hash="letter"><span class="sec-head-img-ed">
         <img src="/assets/images/about/section-header-elements/letter.svg" alt="" /></span><span id="letterBR">Letter from the Executive Director</span>
     </div>

--- a/pages/about/about-card-metrics.html
+++ b/pages/about/about-card-metrics.html
@@ -1,4 +1,4 @@
-<div class='page-card--about'>
+<div class='card-primary page-card-lg page-card--about'>
     <div class="about-us-section-header" data-hash="metrics"><span class="sec-head-img"><img src="/assets/images/about/section-header-elements/metrics.svg" alt="" /></span>Metrics</div>
     <div class="about-us-section-content">
         <div class="top-paragraph">

--- a/pages/about/about-card-news.html
+++ b/pages/about/about-card-news.html
@@ -1,4 +1,4 @@
-<div class='page-card--about last-card'>
+<div class='card-primary page-card-lg page-card--about last-card'>
     <div class="about-us-section-header" data-hash="news"><span class="sec-head-img"><img src="/assets/images/about/section-header-elements/news.svg"></span>HfLA in the News</div>
     <div class="about-us-section-content">
         <div class="flex-container">

--- a/pages/about/about-card-partners.html
+++ b/pages/about/about-card-partners.html
@@ -1,4 +1,4 @@
-<div class='page-card--about'>
+<div class='card-primary page-card-lg page-card--about'>
     <div class="about-us-section-header" data-hash="partners"><span class="sec-head-img"><img
                 src="/assets/images/about/section-header-elements/partners.svg" alt="" /></span>Partners</div>
     <div class="about-us-section-content">

--- a/pages/about/about-card-platform.html
+++ b/pages/about/about-card-platform.html
@@ -1,4 +1,4 @@
-<div class='page-card--about page-card--platform' >
+<div class='card-primary page-card-lg page-card--about page-card--platform' >
     <div class="about-us-section-header" data-hash="platform">
         <span class="sec-head-img"><img src="/assets/images/about/section-header-elements/platform.svg" alt=""></span>Hack for LA Platform
     </div>

--- a/pages/about/about-card-sponsors.html
+++ b/pages/about/about-card-sponsors.html
@@ -1,4 +1,4 @@
-<div class='page-card--about'>
+<div class='card-primary page-card-lg page-card--about'>
     <div class="about-us-section-header" data-hash="sponsors"><span class="sec-head-img"><img
                 src="/assets/images/about/section-header-elements/sponsors.svg"
                 alt="Make your donation for Hack for LA Brigade on codeforamerica.org/donate. Choose the amount and select the payment frequency, then enter 'Hack for LA' under 'if your donation is for a Brigade, please select the Brigade Name(Optional)'." /></span>Sponsors

--- a/pages/about/about-card-sustainability.html
+++ b/pages/about/about-card-sustainability.html
@@ -1,4 +1,4 @@
-<div class='page-card--about' >
+<div class='card-primary page-card-lg page-card--about' >
     <div class="about-us-section-header" data-hash="sustainability">
         <span class="sec-head-img"><img src="/assets/images/about/section-header-elements/sustainability.svg" alt="" /></span>
         <span class="sdg-title-mobile">HfLA Supports SDGs</span><span class="sdg-title-full">Hack for LA Supports:<br />LA’s Sustainable Development Goals (SDG) Movement</span>


### PR DESCRIPTION
Fixes #1553

I tried to include most of the standardized classes as much as possible without changing things. I know it was mentioned to not touch the letter from the ED but if I deleted the white background from the .page-card--about class and use .card-primary class, the letter itself did not have a white background. So added the .card-primary to the letter from the ED. Same with the box shadow around the edges, I added it directly to the page-card--ed class itself since we only want the box shadow from the .page-card-lg class.

I wanted to also use the standardized class .page-card-base because we can then remove the overflow: hidden rule from the direct .page-card--about class. However the css rule width: 100% was messing up the mobile view of the page. So I decided to keep the overflow: hidden rule in the .page-card--about class.

@daniellex0 let me know if you need me to make other changes or if you need some clarification!

Here is a desktop view after changes are made:
<details>
<summary>Desktop View [Click Here!]</summary>

![image](https://user-images.githubusercontent.com/32349001/121545636-b1eab500-c9d8-11eb-9762-4c0d227332b4.png)


</details>

Here is a mobile view after changes are made:
<details>
<summary>Mobile View [Click Here!]</summary>

![image](https://user-images.githubusercontent.com/32349001/121545676-ba42f000-c9d8-11eb-9041-d8e910e028cc.png)


</details>
