### PR TITLE
adjust header text size for mobile and tablet

### DIFF
--- a/_sass/components/_sitemap.scss
+++ b/_sass/components/_sitemap.scss
@@ -47,12 +47,15 @@
   }
   h1 {
     font-size: 48px;
+    @media #{$bp-tablet-up} {
+      font-size: 40px;
+    }
   }
   @include mobile {
     margin: auto;
     margin-bottom: 36px;
     h1 {
-      font-size: 24px;
+      font-size: 32px;
       margin-bottom: 20px;
     }
   }


### PR DESCRIPTION
Fixes #1599 

   - Changed size of site map header text from 24px to 32px in mobile sizes:
Before:

![issue1559_mobile_before](https://user-images.githubusercontent.com/58964358/121618946-8f7a8b00-ca1c-11eb-910f-028b763b3cb5.PNG)

After:

![issue1559_mobile_after](https://user-images.githubusercontent.com/58964358/121618969-9a352000-ca1c-11eb-991c-9d36ba4f3b01.PNG)


   - Changed size of site map header text from 48px to 40px in tablet sizes:
Before:

![issue1559_tablet_before](https://user-images.githubusercontent.com/58964358/121619072-ccdf1880-ca1c-11eb-99c0-e47e153351ad.PNG)

After:

![issue1559_tablet_after](https://user-images.githubusercontent.com/58964358/121619130-e6806000-ca1c-11eb-995f-2bbee4c35529.PNG)

