### PR TITLE
New Github Action: Automate Update Label Default Comment

### DIFF
--- a/.github/workflows/update-comment-on-update-label.yml
+++ b/.github/workflows/update-comment-on-update-label.yml
@@ -1,0 +1,22 @@
+name: Add comment
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: "${{ github.event.label.name == 'status: Needs Update' }}"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            @${{ github.event.issue.assignee.login }} Please add update
+            1. Progress
+            2. Blockers
+            3. Avaibility
+            4. ETA

--- a/.github/workflows/update-comment-on-update-label.yml
+++ b/.github/workflows/update-comment-on-update-label.yml
@@ -5,7 +5,7 @@ on:
       - labeled
 jobs:
   add-comment:
-    if: "${{ github.event.label.name == 'status: Needs Update' }}"
+    if: "${{ github.event.label.name == 'status: To Update!' }}"
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
Fixes #1712

This github action adds a default comment whenever a "status: Needs Update" label issue is added to an issue. Below is the default comment it adds:
> `@someusername` Please add update
> 1. Progress
> 2. Blockers
> 3. Avaibility
> 4. ETA


https://user-images.githubusercontent.com/32349001/121766921-36e1e580-cb23-11eb-850c-875f11734f98.mp4

