### PR TITLE
Changed margin for toolkit page header

### DIFF
--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -9,7 +9,6 @@
         margin-right: 5rem;
 
         h1 {
-            margin-top: 2.25rem;
             margin-bottom: 3.125rem;
         }
     }
@@ -66,7 +65,7 @@
             margin-right: 0;
 
             h1 {
-                margin-bottom: 0.4rem;
+                margin-bottom: 2.25rem;
             }
         }
 


### PR DESCRIPTION
Fixes #1606 

These are the new margins to standardize the Toolkit page header in mobile to make it consistent with other pages and our design system.

Property under ".toolkit-header__text" h1 class

`margin-bottom: 3.125rem;`

Property under ".toolkit-header__text" h1 class - mobile

`margin-bottom: 2.25rem;`