### PR TITLE
toggle see more/see less on wins card

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -401,6 +401,9 @@
     }
     .expanded{
         height: auto;
+        .wins-see-more-div {
+            z-index: 10;
+        }
     }
     
 }

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -272,6 +272,10 @@
 @media #{$bp-below-mobile} {
     .wins-card-text{
         height: 80px;
+        margin-top: 16px;
+    }
+    .wins-card-overview{
+        height: 100%;
     }
     .wins-card{
         padding: 24px;
@@ -308,9 +312,6 @@
         height: 20px;
         width: 20px;
     }
-    .wins-card-text{
-        margin-top: 16px;
-    }
 
     .wins-card-overview{
         margin-top: 0;
@@ -323,6 +324,7 @@
 //modal overlay
 @media #{$bp-desktop-up} {
     .wins-card-overview{
+        height: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
     }

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -401,10 +401,6 @@
     }
     .expanded{
         height: auto;
-        // .wins-see-more-div {
-        //     position: relative;
-        //     text-align: right;
-        // }
     }
     
 }

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -399,11 +399,12 @@
     }
     .expanded{
         height: auto;
-        .wins-see-more-div {
-            position: relative;
-            text-align: right;
-        }
+        // .wins-see-more-div {
+        //     position: relative;
+        //     text-align: right;
+        // }
     }
+    
 }
 
 .wins-card-content > * {

--- a/assets/images/wins-page/caret.svg
+++ b/assets/images/wins-page/caret.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="6" viewBox="0 0 8 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.5 4.82422L4 1.32422L7.5 4.82422" stroke="#FA114F" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pages/wins/wins.html
+++ b/pages/wins/wins.html
@@ -377,12 +377,9 @@ permalink: /wins/
 			let innerHeight = Array.from(winText.childNodes).reduce((acc, el) => (el.offsetHeight || 0) + acc, 0) - 22
 
 			//makes the see more span on the bottom of the card
-			if (innerHeight <= winText.offsetHeight) { //checks if see more is needed.
-				winText.querySelector('.wins-see-more-div').setAttribute('hidden', 'true')
-			} else {
-				winText.querySelector('.wins-see-more-div').removeAttribute('hidden')
+			if (innerHeight => winText.offsetHeight) { //checks if see more is needed.
 				winsBelowDesktop()
-			}
+			} 
 		}
 		addSeeMore()
 
@@ -395,39 +392,39 @@ permalink: /wins/
   	if (screenWidth > 960){
   		updateOverlay(id);
   	}else{
-		  mobileSeeMore(id);
+		toggleSeeMoreLess(id);
   	}
   }
 
   //Adds event listener to badge icons when viewers interface is below desktop size
-  //Click expands wins text and removes "see more"
+  //Click to toggle "see more" and "see less" to expand and collapse wins text
   function winsBelowDesktop() {
 		document.querySelectorAll('.wins-badge-icon').forEach(img => img.addEventListener('click', function (event) {
 			const container = event.target.parentElement.parentElement;
-			const id = container.dataset.index
+			const id = container.dataset.index;
 
-			mobileSeeMore(id)
-			container.setAttribute('class', 'wins-tablet wins-icon-container');
+			toggleSeeMoreLess(id);
 		}))
 	}
 
-  function mobileSeeMore(id){
+  function toggleSeeMoreLess(id){
 		let span = document.getElementById(id);
 		let parent = span.parentElement.parentElement;
 		let winsInfo = span.parentElement.parentElement.parentElement.parentElement;
-		let winsIconContainer = winsInfo.nextElementSibling
-		parent.classList.add('expanded');
-		winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
-		//FIXME: this is here for when see more/see less logic is added
-		// if (parent.classList.contains('expanded')) {
-		// 	span.innerHTML = "see less";
-		// 	winsInfo.nextElementSibling.setAttribute('class', 'wins-tablet wins-icon-container');
-		// }
-		// else {
-		// 	span.innerHTML = "...see more";
-		// 	winsInfo.nextElementSibling.removeAttribute('class', 'wins-tablet');
-		// }
+		let winsIconContainer = winsInfo.nextElementSibling;
+
+		if (!parent.classList.contains('expanded')) {
+			parent.setAttribute('class','project-inner wins-card-text expanded');
+			span.innerHTML = "see less";
+			winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
+		}
+		else {
+			parent.setAttribute('class','project-inner wins-card-text');
+			span.innerHTML = "...see more";
+			winsIconContainer.setAttribute('class', 'wins-icon-container');
+		}
   }
+
   // need to delete makeElement and makeIcon
   function makeElement(elementType, parent, className) {
 		let child = document.createElement(elementType);

--- a/pages/wins/wins.html
+++ b/pages/wins/wins.html
@@ -371,19 +371,6 @@ permalink: /wins/
 		cloneCardTemplate.querySelector('span.see-more-div').id = index;
 
 		winsCardContainer.append(cloneCardTemplate);
-		
-		// const winText = cloneCardTemplate.querySelector('.wins-card-text')
-		// function addSeeMore() {
-		// 	let innerHeight = Array.from(winText.childNodes).reduce((acc, el) => (el.offsetHeight || 0) + acc, 0) - 22
-
-		// 	//makes the see more span on the bottom of the card
-		// 	if (innerHeight => winText.offsetHeight) { //checks if see more is needed.
-		// 		winsBelowDesktop()
-		// 	} 
-		// }
-		// addSeeMore()
-
-		// new ResizeObserver(addSeeMore).observe(winText)
 	})
   }
 

--- a/pages/wins/wins.html
+++ b/pages/wins/wins.html
@@ -372,18 +372,18 @@ permalink: /wins/
 
 		winsCardContainer.append(cloneCardTemplate);
 		
-		const winText = cloneCardTemplate.querySelector('.wins-card-text')
-		function addSeeMore() {
-			let innerHeight = Array.from(winText.childNodes).reduce((acc, el) => (el.offsetHeight || 0) + acc, 0) - 22
+		// const winText = cloneCardTemplate.querySelector('.wins-card-text')
+		// function addSeeMore() {
+		// 	let innerHeight = Array.from(winText.childNodes).reduce((acc, el) => (el.offsetHeight || 0) + acc, 0) - 22
 
-			//makes the see more span on the bottom of the card
-			if (innerHeight => winText.offsetHeight) { //checks if see more is needed.
-				winsBelowDesktop()
-			} 
-		}
-		addSeeMore()
+		// 	//makes the see more span on the bottom of the card
+		// 	if (innerHeight => winText.offsetHeight) { //checks if see more is needed.
+		// 		winsBelowDesktop()
+		// 	} 
+		// }
+		// addSeeMore()
 
-		new ResizeObserver(addSeeMore).observe(winText)
+		// new ResizeObserver(addSeeMore).observe(winText)
 	})
   }
 

--- a/pages/wins/wins.html
+++ b/pages/wins/wins.html
@@ -415,7 +415,7 @@ permalink: /wins/
 
 		if (!parent.classList.contains('expanded')) {
 			parent.setAttribute('class','project-inner wins-card-text expanded');
-			span.innerHTML = "see less";
+			span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" alt="caret">&nbsp; see less';
 			winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
 		}
 		else {


### PR DESCRIPTION
fix #1549 
   
1. toggles `see more`/`see less` on the bottom right of the wins card
2 `see more` has ellipsis, sticking with same Figma design

https://user-images.githubusercontent.com/68657634/121805548-93ff9900-cc00-11eb-9d1d-21183bd2d3b7.mov

