### PR TITLE
Create add-issue-labels-to-pr.yml

### DIFF
--- a/.github/workflows/add-issue-labels-to-pr.yml
+++ b/.github/workflows/add-issue-labels-to-pr.yml
@@ -102,6 +102,7 @@ jobs:
             
             // PUT request to apply labels to pull request
             // https://octokit.github.io/rest.js/v18#issues-add-labels
+            github.auth = ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
             let results;
             try {
               results = await github.issues.setLabels({

--- a/.github/workflows/add-issue-labels-to-pr.yml
+++ b/.github/workflows/add-issue-labels-to-pr.yml
@@ -1,0 +1,121 @@
+# Name that appears on the workflow
+name: Pull Request Comment Test
+on:
+  pull_request:
+    types: [opened, edited]
+jobs:
+# Adds linked issue labels to pull request
+# Step1: Reads pull request comment and return the linked issue
+# Step2: Perform a GET request to retrieve labels from linked issue
+# Step3: Perform a PUT request to apply labels to original pull request
+  Add-Linked-Issue-Labels-to-Pull-Request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrieve Linked Issue From Comment
+        # https://github.com/actions/github-script
+        uses: actions/github-script@v4
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        id: issue-number
+        with:
+          result-encoding: string
+          script: |
+            // Retrieve comments
+            const { BODY } = process.env
+            
+            // RegEx for capturing linked issue
+            const KEYWORDS = ['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved']
+            let reArr = []
+            for (const word of KEYWORDS) {
+              reArr.push(`[\\n|\\s|^]${word} #\\d*\\s|^${word} #\\d*\\s|\\s${word} #\\d*$|^${word} #\\d*$`)
+            }
+            let re = new RegExp(reArr.join('|'), 'gi')
+            
+            // Receive and unpack matches into an Array of Array objs
+            let match = BODY.matchAll(re)
+            match = [...match]
+            
+            // If only one match is found, return the issue number. Else return false. Also console.log results.
+            if (match.length == 1) {
+              const linkedIssue = match[0][0]
+              const issueNumber = match[0][0].match(/\d+/)
+              console.log(`Issue number found for PR #${context.payload.number}. Issue #${issueNumber}`)
+              return issueNumber[0]
+            } else {
+              console.log('Make sure there is only one issue!')
+              return false
+            }
+
+
+      # https://docs.github.com/en/rest/reference/issues#list-labels-for-an-issue
+      - name: Get Labels from Linked Issue
+        uses: actions/github-script@v4
+        id: linked-labels
+        with:
+          script: |
+            // Set up request URL.
+            const issueNum = ${{ steps.issue-number.outputs.result }}
+            if (!issueNum) {
+              return false
+            }
+            const getLabelsAPIURL = `https://api.github.com/repos/${{ github.repository }}/issues/${issueNum}/labels`
+            
+            // GET request to retrieve data from results of request
+            const results = await github.request(getLabelsAPIURL)
+            let data;
+            if (results['data']) {
+              data = results.data
+            } else {
+              console.log('Error with GET Request')
+              console.log(results)
+              return false
+            }
+            
+            // Gather all label names into an array of strings and return the array
+            let labelNameArray = []
+            for (const label of data) {
+              labelNameArray.push(label.name)
+            }
+            console.log(`Labels found on Issue #${issueNum}: ${labelNameArray.join(', ')}`)
+            return labelNameArray
+
+
+      # https://docs.github.com/en/rest/reference/issues#set-labels-for-an-issue
+      - name: Put Labels to Pull Request
+        uses: actions/github-script@v4
+        id: final-result
+        with:
+          script: |
+            // Retrieve labels
+            const arrayOfLabels = ${{ steps.linked-labels.outputs.result }}
+            if (!arrayOfLabels) {
+              return false
+            }
+            
+            // PUT request to apply labels to pull request
+            const pullRequestNum = ${{ github.event.number }}
+            const putLabelsAPIURL = `https://api.github.com/repos/${{ github.repository }}/issues/${pullRequestNum}}/labels`
+            const results = await github.request(putLabelsAPIURL, {
+              method: 'PUT',
+              labels: arrayOfLabels,
+            })
+            
+            console.log(results)
+            
+            if (results.status == 200) {
+              return true
+            } else {
+              return false
+            }
+
+            
+      # For use if there are follow-up actions following script success or failure.
+      - name: Return Failure
+        if: steps.final-result.outputs.result == 'false'
+        run: |
+          echo "Please expand above outputs for errors."
+          exit 1
+      - name: Return Success
+        run: |
+          echo "${{ steps.final-result.outputs.result }}"
+          echo "Success"

--- a/.github/workflows/add-issue-labels-to-pr.yml
+++ b/.github/workflows/add-issue-labels-to-pr.yml
@@ -91,6 +91,8 @@ jobs:
       # https://docs.github.com/en/rest/reference/issues#set-labels-for-an-issue
       - name: Put Labels to Pull Request
         uses: actions/github-script@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
         id: final-result
         with:
           script: |
@@ -102,7 +104,6 @@ jobs:
             
             // PUT request to apply labels to pull request
             // https://octokit.github.io/rest.js/v18#issues-add-labels
-            github.auth = ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
             let results;
             try {
               results = await github.issues.setLabels({

--- a/.github/workflows/add-issue-labels-to-pr.yml
+++ b/.github/workflows/add-issue-labels-to-pr.yml
@@ -9,6 +9,7 @@ jobs:
 # Step2: Perform a GET request to retrieve labels from linked issue
 # Step3: Perform a PUT request to apply labels to original pull request
 # Note: Step1 uses RegEx to extract linked issues. This is not the best choice, but is required as GitHub does not include linked issues in the context. If this changes in the future, please revise Step1 ASAP for a more robust code.
+# Note2: Below you will see ${{ github }} and the github variable used. The former is a context from GitHub actions and the latter is an object argument of the actions/github-script@v4 workflow. These two are not the same and should not be treated as such!
   Add-Linked-Issue-Labels-to-Pull-Request:
     runs-on: ubuntu-latest
     steps:
@@ -25,15 +26,15 @@ jobs:
             // Retrieve comments
             const { BODY } = process.env
             
-            // RegEx for capturing linked issue
+            // Create RegEx for capturing KEYWORD #ISSUE-NUMBER syntax (i.e. resolves #1234)
             const KEYWORDS = ['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved']
             let reArr = []
             for (const word of KEYWORDS) {
               reArr.push(`[\\n|\\s|^]${word} #\\d*\\s|^${word} #\\d*\\s|\\s${word} #\\d*$|^${word} #\\d*$`)
             }
-            let re = new RegExp(reArr.join('|'), 'gi')
             
             // Receive and unpack matches into an Array of Array objs
+            let re = new RegExp(reArr.join('|'), 'gi')
             let match = BODY.matchAll(re)
             match = [...match]
             
@@ -47,29 +48,34 @@ jobs:
               console.log('Make sure there is only one issue!')
               return false
             }
-
-
+            
+            
       # https://docs.github.com/en/rest/reference/issues#list-labels-for-an-issue
       - name: Get Labels from Linked Issue
         uses: actions/github-script@v4
         id: linked-labels
         with:
           script: |
-            // Set up request URL.
+            // Retrieve issue number from previous step.
             const issueNum = ${{ steps.issue-number.outputs.result }}
             if (!issueNum) {
               return false
             }
-            const getLabelsAPIURL = `https://api.github.com/repos/${{ github.repository }}/issues/${issueNum}/labels`
             
             // GET request to retrieve data from results of request
-            const results = await github.request(getLabelsAPIURL)
+            // https://octokit.github.io/rest.js/v18#issues-list-labels-on-issue
             let data;
-            if (results['data']) {
+            try {
+              const results = await github.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNum,
+              });
               data = results.data
-            } else {
-              console.log('Error with GET Request')
-              console.log(results)
+            }
+            catch(err) {
+              console.log('Error with GET Request to get labels')
+              console.log(err)
               return false
             }
             
@@ -80,36 +86,45 @@ jobs:
             }
             console.log(`Labels found on Issue #${issueNum}: ${labelNameArray.join(', ')}`)
             return labelNameArray
-
-
+            
+            
       # https://docs.github.com/en/rest/reference/issues#set-labels-for-an-issue
       - name: Put Labels to Pull Request
         uses: actions/github-script@v4
         id: final-result
         with:
           script: |
-            // Retrieve labels
+            // Retrieve labels from previous step
             const arrayOfLabels = ${{ steps.linked-labels.outputs.result }}
             if (!arrayOfLabels) {
               return false
             }
             
             // PUT request to apply labels to pull request
-            const pullRequestNum = ${{ github.event.number }}
-            const putLabelsAPIURL = `https://api.github.com/repos/${{ github.repository }}/issues/${pullRequestNum}}/labels`
-            const results = await github.request(putLabelsAPIURL, {
-              method: 'PUT',
-              labels: arrayOfLabels,
-            })
+            // https://octokit.github.io/rest.js/v18#issues-add-labels
+            let results;
+            try {
+              results = await github.issues.setLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ github.event.number }},
+                labels: arrayOfLabels,
+              })
+            }
+            catch(err) {
+              console.log('Error with PUT Request to edit labels')
+              console.log(err)
+              return false
+            }
             
-            // Logs result of script
+            // Log result of script
             console.log(results)
             if (results.status == 200) {
               return true
             } else {
               return false
             }
-
+            
             
       # For use if there are follow-up actions following script success or failure.
       - name: Return Failure

--- a/.github/workflows/add-issue-labels-to-pr.yml
+++ b/.github/workflows/add-issue-labels-to-pr.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/github-script@v4
         id: final-result
         with:
-          github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
+          github-token: ${{ secrets.GH_BOT_TOKEN_1 }}
           script: |
             // Retrieve labels from previous step
             const arrayOfLabels = ${{ steps.linked-labels.outputs.result }}

--- a/.github/workflows/add-issue-labels-to-pr.yml
+++ b/.github/workflows/add-issue-labels-to-pr.yml
@@ -91,10 +91,9 @@ jobs:
       # https://docs.github.com/en/rest/reference/issues#set-labels-for-an-issue
       - name: Put Labels to Pull Request
         uses: actions/github-script@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
         id: final-result
         with:
+          github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
           script: |
             // Retrieve labels from previous step
             const arrayOfLabels = ${{ steps.linked-labels.outputs.result }}

--- a/.github/workflows/add-issue-labels-to-pr.yml
+++ b/.github/workflows/add-issue-labels-to-pr.yml
@@ -8,6 +8,7 @@ jobs:
 # Step1: Reads pull request comment and return the linked issue
 # Step2: Perform a GET request to retrieve labels from linked issue
 # Step3: Perform a PUT request to apply labels to original pull request
+# Note: Step1 uses RegEx to extract linked issues. This is not the best choice, but is required as GitHub does not include linked issues in the context. If this changes in the future, please revise Step1 ASAP for a more robust code.
   Add-Linked-Issue-Labels-to-Pull-Request:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/add-issue-labels-to-pr.yml
+++ b/.github/workflows/add-issue-labels-to-pr.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Retrieve Linked Issue From Comment
         # https://github.com/actions/github-script
         uses: actions/github-script@v4
+        # Escapes user input for injection attacks
         env:
           BODY: ${{ github.event.pull_request.body }}
         id: issue-number
@@ -101,8 +102,8 @@ jobs:
               labels: arrayOfLabels,
             })
             
+            // Logs result of script
             console.log(results)
-            
             if (results.status == 200) {
               return true
             } else {

--- a/.github/workflows/add-issue-labels-to-pr.yml
+++ b/.github/workflows/add-issue-labels-to-pr.yml
@@ -1,5 +1,5 @@
 # Name that appears on the workflow
-name: Pull Request Comment Test
+name: Add Linked Issue Labels to Pull Request
 on:
   pull_request:
     types: [opened, edited]


### PR DESCRIPTION
Close #1707 

No photos as issue is not front-end based.
Note that below you might notice a "All checks have failed" error. This [comment and thread](https://github.com/actions/first-interaction/issues/10#issuecomment-546628432) explains why. To prevent this from happening with other pulls, I have [manually disabled](https://github.com/hackforla/website/actions/workflows/add-issue-labels-to-pr.yml) the action.

Considerations:
1. Currently there are multiple ways to add a linked issue. In addition to the usual KEYWORD #ISSUE-NUMBER syntax, there is also the KEYWORD OWNER/REPOSITORY#ISSUE-NUMBER syntax and adding multiple issues through comma-separated syntax. The script currently only detects KEYWORD #ISSUE-NUMBER syntax.
2. The workflow uses actions/github-script@v4 as a workflow dependency. Should this ever break in some way, it must be manually updated in the future.
3. The workflow has been designed such that errors in the run will lead to a safe exit 1, skipping potentially dangerous API calls. This might impede debugging should errors arise. Several log statements are provided to aid debugging.
4. Logged API response results JSON might contain sensitive information, although they help in the event of errors.

Ignore below this:
Test.