### PR TITLE
Update CONTRIBUTING.md with the "How to Review Pull Requests" Wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -433,4 +433,8 @@ If you find an error in your code or your reviewer asks you to make a change, pl
 - [dockercompose](https://docs.docker.com/compose/gettingstarted/)
 - [dockerdesktop](https://docs.docker.com/install/)
 
+### Other Documentation
+
+For new volunteers, check this [Wiki](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests) for more ways to contribute to the project.
+
 [Back to Top](#overview)


### PR DESCRIPTION
Adding another section to Contributing.md called "Other Documentation" that contains a link to the "How to Review Pull Requests" Wiki.

https://github.com/hackforla/website/compare/gh-pages...Zak234-patch-2?quick_pull=1#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055

Fixes #1556 