### PR TITLE
Replace alt text in people2.yml from 'Image of people' to 'Fireside discussion concept illustration'

### DIFF
--- a/_data/internal/credits/people2.yml
+++ b/_data/internal/credits/people2.yml
@@ -7,6 +7,6 @@ artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/hack-nights/happy-hour.png
-alt: 'Image of People'
+alt: 'Fireside discussion concept illustration'
 type: icon
 ---


### PR DESCRIPTION
Fixes #1578

Changed alt text in  people2.yml from 'Image of people' to 'Fireside discussion concept illustration'.

