### PR TITLE
Change Alt Text for Meetup Logo

### DIFF
--- a/_data/internal/credits/button.yml
+++ b/_data/internal/credits/button.yml
@@ -7,6 +7,6 @@ artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/getting-started/step2.png
-alt: 'Image of Button'
+alt: 'Meetup Logo'
 type: icon
 ---


### PR DESCRIPTION
Fixes #1574

  - changed alt text from 'Image of Meetup' to 'Meetup Logo'

# Screenshots of Proposed Changes (if any)

<details>
<summary>Meetup Logo</summary>

<img width="504" alt="Screen Shot 2021-06-16 at 7 53 28 PM" src="https://user-images.githubusercontent.com/67209686/122323799-87b75c80-cedc-11eb-802a-69f592b3f618.png">

</details>
