### PR TITLE
Change Alt Text for Delegate Icon on Credit page

### DIFF
--- a/_data/internal/credits/button.yml
+++ b/_data/internal/credits/button.yml
@@ -7,6 +7,6 @@ artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/getting-started/step2.png
-alt: 'Image of Button'
+alt: 'Meetup Logo'
 type: icon
 ---

--- a/_data/internal/credits/delegate.yml
+++ b/_data/internal/credits/delegate.yml
@@ -7,6 +7,6 @@ artist: Vectors Market
 provider: Noun Project
 provider-link: https://thenounproject.com/
 image-url: /assets/images/join-us/advice-us-icon.svg
-alt: 'Iamge of Delegate'
+alt: 'Delegate Icon'
 type: icon
 --- 


### PR DESCRIPTION
Fixes #1567 

- changed alt text from 'Iamge of Delegate' to 'Delegate Icon'