### PR TITLE
Adjusts Program Areas page image cards in mobile

### DIFF
--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -103,10 +103,10 @@
       flex: 0 0 auto;
       width: 327px;
       overflow: hidden;
+
       @media #{$bp-below-desktop} {
         width: 100%;
         max-height: 40vh;
-  
       }
     }
   
@@ -119,7 +119,7 @@
       object-fit: cover;
     
       @media #{$bp-below-tablet} {
-        height: auto;
+        height: 213px;
       /*  width: 100%;
         max-height: 40vh;
         overflow: hidden;*/

--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -119,7 +119,7 @@
       object-fit: cover;
     
       @media #{$bp-below-tablet} {
-        height: 213px;
+        height: 231px;
       /*  width: 100%;
         max-height: 40vh;
         overflow: hidden;*/


### PR DESCRIPTION
Fixes #1610 

### What changes did you make and why did you make them ?

  - Pulled desired image dimensions from Figma file
  - Updated height of image card from `auto` to `213px`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Program Areas page's image card</summary>

![Screen Shot 2021-06-17 at 8 06 13 PM](https://user-images.githubusercontent.com/40401149/122501916-72a8ff00-cfaa-11eb-81f9-1455c0fce199.png)

</details>
