### PR TITLE
Add x modal wins page

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -279,6 +279,13 @@
         width: 60%;
         left: 20%;
     }
+    .overlay-close-icon {
+        float: right; 
+        font-size: 20px; 
+        font-weight: 500; 
+        padding: 20px 20px 0 0; 
+        cursor: pointer;
+    }
     .center-screen {
         opacity: 1;
 	}

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -280,9 +280,7 @@
         left: 20%;
     }
     .overlay-close-icon {
-        float: right; 
-        font-size: 20px; 
-        font-weight: 500; 
+        float: right;  
         padding: 20px 20px 0 0; 
         cursor: pointer;
     }

--- a/assets/images/wins-page/x.svg
+++ b/assets/images/wins-page/x.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 4L4 20" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 4L20 20" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pages/wins/wins-overlay.html
+++ b/pages/wins/wins-overlay.html
@@ -1,23 +1,26 @@
 <div class="overlay" onclick="hideOverlay()">
   <div id="overlay-project-card" class="modal-container">
     <div class="top-buffer" onclick="hideOverlay()"></div>
-    <div class="project-card wins-card center-screen">
-      <div class="wins-card-top">
-        <img class="wins-card-profile-img" id="overlay-profile-img" src="/assets/images/wins-page/avatar-default.svg">
-        <div class="wins-card-top-right">
-          <div class="wins-card-title project-card-inner">
-            <span id="overlay-name" class="wins-card-name">Blank</span>
-            <span id="overlay-icons" class="wins-card-icons"></span>
+    <div class="project-card">
+      <div class="overlay-close-icon" onclick="hideOverlay()">X</div>
+      <div class="wins-card center-screen">
+        <div class="wins-card-top">
+          <img class="wins-card-profile-img" id="overlay-profile-img" src="/assets/images/wins-page/avatar-default.svg">
+          <div class="wins-card-top-right">
+            <div class="wins-card-title project-card-inner">
+              <span id="overlay-name" class="wins-card-name">Blank</span>
+              <span id="overlay-icons" class="wins-card-icons"></span>
+            </div>
+            <div id="overlay-teams" class="project-inner wins-card-team">Team(s): Blank</div>
+            <div id="overlay-roles" class="project-inner wins-card-team">Role(s): Blank</div>
           </div>
-          <div id="overlay-teams" class="project-inner wins-card-team">Team(s): Blank</div>
-          <div id="overlay-roles" class="project-inner wins-card-team">Role(s): Blank</div>
         </div>
-      </div>
-      <div class="wins-card-bottom">
-        <img class="wins-card-big-quote" src="/assets/images/wins-page/quote-icon.svg">
-        <div class="project-inner overlay-card-text">
-          <p id="overlay-overview">Blank</p>
-          <p id="overlay-info" class="wins-card-info">Blank</p>
+        <div class="wins-card-bottom">
+          <img class="wins-card-big-quote" src="/assets/images/wins-page/quote-icon.svg">
+          <div class="project-inner overlay-card-text">
+            <p id="overlay-overview">Blank</p>
+            <p id="overlay-info" class="wins-card-info">Blank</p>
+          </div>
         </div>
       </div>
     </div>

--- a/pages/wins/wins-overlay.html
+++ b/pages/wins/wins-overlay.html
@@ -2,7 +2,7 @@
   <div id="overlay-project-card" class="modal-container">
     <div class="top-buffer" onclick="hideOverlay()"></div>
     <div class="project-card">
-      <div class="overlay-close-icon" onclick="hideOverlay()">X</div>
+      <img class="overlay-close-icon" src="/assets/images/wins-page/x.svg" onclick="hideOverlay()">
       <div class="wins-card center-screen">
         <div class="wins-card-top">
           <img class="wins-card-profile-img" id="overlay-profile-img" src="/assets/images/wins-page/avatar-default.svg">


### PR DESCRIPTION
Fixes #1552 

### What changes did you make and why did you make them ?

  - Added closing 'x' icon to modal overlay in wins page so that user can exit modal in another way other than clicking on the background.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Modal image from wins page with closing 'x' icon</summary>

<img width="591" alt="Screen Shot 2021-06-17 at 11 56 56 PM" src="https://user-images.githubusercontent.com/24802803/122520212-2ff61f80-cfc8-11eb-8ef8-ce67a661bccf.png">

</details>
