### PR TITLE
Updated the alt attribute value for Design Image

### DIFF
--- a/_data/internal/credits/design.yml
+++ b/_data/internal/credits/design.yml
@@ -7,6 +7,6 @@ artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/credits/credits-hero.svg
-alt: 'Image of Design'
+alt: 'Design Community Concept Illustration'
 type: icon
 ---


### PR DESCRIPTION
Fixes #1568

### What changes did you make and why did you make them ?

  - Updated the alt attribute value for the Design Image on the Credit Page to 'Design Community Concept Illustration' from 'Image of Design'

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Edit_This_To_Add_Image_Description</summary>

Paste_Your_Image_Link_Here

</details>
