### PR TITLE
changed alt text for Partnership Icon on Credit page

### DIFF
--- a/_data/internal/credits/partnership.yml
+++ b/_data/internal/credits/partnership.yml
@@ -7,6 +7,6 @@ artist: Vectorstall
 provider: Noun Project
 provider-link: https://thenounproject.com/
 image-url: /assets/images/join-us/partner-with-us-icon.svg
-alt: 'Image of Partnership'
+alt: 'Partnership Icon'
 type: icon
---- 
+---


### PR DESCRIPTION
Fixes #1576

### What changes did you make and why did you make them ?
  - Changed the alt attribute value to 'Partnership Icon' on the Credit Page
  - I was requested to, and this is better alt text ("Image of" is unnecessary)
 
  https://github.com/hackforla/website/blob/90a20d1e088b0a05a286af101f82135ad4774e39/_data/internal/credits/partnership.yml

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
none
