### PR TITLE
Update alt text for "Technology" image within the "Credits" page

### DIFF
--- a/_data/internal/credits/technology.yml
+++ b/_data/internal/credits/technology.yml
@@ -7,6 +7,6 @@ artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/getting-started/step4.png
-alt: 'Image of Technology'
+alt: 'Secure data concept illustration'
 type: icon
 ---


### PR DESCRIPTION
Fixes #1586

### What changes did you make and why did you make them ?
Updated the alt attribute value for the Technology Image on the Credit Page to 'Secure data concept illustration' from 'Image of Technology'

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
  <summary><strong><em>Before</strong></em></summary>
  <br>
  <p><strong>http://localhost:4000/credits/</strong></p>
  <img src="https://user-images.githubusercontent.com/21162229/122619021-55c10a00-d044-11eb-87c7-d8404938a2e4.jpg" alt="Technology image before changes" />
</details>

<details>
  <summary><strong><em>After Changes</strong></em></summary>
  <br>
  <p><strong>http://localhost:4000/credits/</strong></p>
  <img src="https://user-images.githubusercontent.com/21162229/122619361-278ffa00-d045-11eb-9202-6fa6e024c982.jpg" alt="Technology image after changes" />
</details>



