### PR TITLE
Wins badge change setup to set up

### DIFF
--- a/pages/wins/wins-share-form.html
+++ b/pages/wins/wins-share-form.html
@@ -340,7 +340,7 @@ Enter text here...</textarea
         "I increased the number of commits on my github profile",
         "I learned a new language",
         "I became proficient at GitHub",
-        "I setup 2FA",
+        "I set up 2FA",
         "I worked on an enterprise project",
         "I migrated google forms to personalized forms",
         "I worked on a project that will help the people of Los Angeles",

--- a/pages/wins/wins.html
+++ b/pages/wins/wins.html
@@ -63,7 +63,7 @@ permalink: /wins/
 		"I learned how to work better on a team": `team.svg`,
 		"I increased the number of commits on my Github profile": `github.svg`,
 		"I learned a new language": `code.svg`,
-		"I setup 2FA": `twofa.svg`,
+		"I set up 2FA": `twofa.svg`,
 		"I became part of a a caring community": `$community.svg`,
 		"I worked on an enterprise project": `enterprise.svg`,
 		"I worked on a project that will help the people of Los Angeles": `giving.svg`,


### PR DESCRIPTION
Fixes #1718 

### What changes did you make and why did you make them ?

  - Changed badge description from 'setup' to 'set up' in wins page

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Changed badge description from 'setup' to 'set up'</summary>

<img width="513" alt="Screen Shot 2021-06-18 at 4 08 11 PM" src="https://user-images.githubusercontent.com/24802803/122623211-17314c80-d050-11eb-8ab1-a0f20dc2980f.png">

</details>
