### PR TITLE
remove margin: auto to split header paragraphs on cop page

### DIFF
--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -27,7 +27,6 @@
       text-align: left;
       @media #{$bp-below-tablet} {
         max-width: 300px;
-        margin: auto;
         font-size: 16px;
         }
     }


### PR DESCRIPTION
Fixes #1611 

Removed the `margin: auto;` under `@media #{$bp-below-tablet}` for the `header-text--communities` class in `_communities-of-practice.scss`

<details>
<summary>Old paragraph spacing</summary>

![cop-paragraph-spacing-old](https://user-images.githubusercontent.com/77088922/122656671-95095c80-d111-11eb-8bb1-6a0cb604a183.png)

</details>

<details>

<summary>New paragraph spacing</summary>

![cop-paragraph-spacing](https://user-images.githubusercontent.com/77088922/122656559-7bb3e080-d110-11eb-9af8-1f9fc2083533.png)

</details>
