### PR TITLE
add missing periods in the Getting Started Page

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -103,7 +103,7 @@ permalink: /getting-started
                     <img class="step-img" src="assets/images/getting-started/proj-1.png" alt="" />
                     <li class="g-s-list">Review the <a href="/#projects" target="_blank">Projects Section</a>
                         and choose a
-                        project. If still in doubt, attend one of our onboarding sections</li>
+                        project. If still in doubt, attend one of our onboarding sections.</li>
 
                 </div>
                 <div class="project-position">
@@ -111,7 +111,7 @@ permalink: /getting-started
                     <li class="g-s-list">Check the <a href="/project-meetings" target="_blank">Team Meeting
                             Overview</a> to
                         see
-                        if the team you are interested in meets at a time that fits into your schedule</li>
+                        if the team you are interested in meets at a time that fits into your schedule.</li>
                 </div>
                 <div class="project-position">
                     <img class="step-img" src="assets/images/getting-started/proj-3.png" alt="" />
@@ -151,7 +151,7 @@ permalink: /getting-started
                     <img class="step-img" src="assets/images/getting-started/join-2.png" alt="" />
                     <li class="g-s-list">If you do not already have one, sign up for a <a
                             href="https://github.com/" target="_blank">GitHub
-                            Account</a>
+                            Account</a>.
                     </li>
 
                 </div>
@@ -186,7 +186,7 @@ permalink: /getting-started
                     <img class="step-img" src="assets/images/getting-started/adopt-1.png" alt="" />
                     <li class="g-s-list">Set up <a href="/guide-pages/2FA.html" target="_blank">two-factor
                             authentication</a>
-                        while waiting for the GitHub Admin to send you the invite</li>
+                        while waiting for the GitHub Admin to send you the invite.</li>
 
                 </div>
                 <div class="project-position">
@@ -194,9 +194,9 @@ permalink: /getting-started
                     <li class="g-s-list">After you have accepted the email invitation to our GitHub organization/repo,
                         mark your Hack
                         for
-                        LA membership<a
+                        LA membership <a
                             href="https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/publicizing-or-hiding-organization-membership#changing-the-visibility-of-your-organization-membership" target="_blank">
-                            Public.</a>
+                            Public</a>.
                     </li>
 
                 </div>


### PR DESCRIPTION
Fixes #1693
### What changes did you make and why did you make them?

  - add missing periods in the Getting Started Page

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Edit_This_To_Add_Image_Description</summary>


<img width="897" alt="Screen Shot 2021-06-21 at 12 07 10 PM" src="https://user-images.githubusercontent.com/74341752/122814622-4ed70900-d289-11eb-9995-e30f6677e115.png">

<img width="881" alt="Screen Shot 2021-06-21 at 12 06 57 PM" src="https://user-images.githubusercontent.com/74341752/122814749-7a59f380-d289-11eb-82f2-17ca26389e84.png">


</details>
