### PR TITLE
changed alt text for designer life image on credits page

### DIFF
--- a/_data/internal/credits/designer-life.yml
+++ b/_data/internal/credits/designer-life.yml
@@ -7,6 +7,6 @@ artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/toolkit/toolkit-hero.svg
-alt: 'Image of Hero Working'
+alt: 'Designer Life concept illustration'
 type: icon
 ---


### PR DESCRIPTION
Fixes #1569 

What changes did you make and why did you make them ?

  -Changed alt text for the designer life image on the credit page to "Designer Life concept illustration."
  -It was a good first issue

Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

None
