### PR TITLE
Update Toolkit page's filter banner font weight 

### DIFF
--- a/_data/internal/credits/button.yml
+++ b/_data/internal/credits/button.yml
@@ -7,6 +7,6 @@ artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/getting-started/step2.png
-alt: 'Image of Button'
+alt: 'Meetup Logo'
 type: icon
 ---

--- a/_data/internal/credits/delegate.yml
+++ b/_data/internal/credits/delegate.yml
@@ -7,6 +7,6 @@ artist: Vectors Market
 provider: Noun Project
 provider-link: https://thenounproject.com/
 image-url: /assets/images/join-us/advice-us-icon.svg
-alt: 'Iamge of Delegate'
+alt: 'Delegate Icon'
 type: icon
 --- 

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -23,7 +23,7 @@
     
     
             a {
-                font-weight: 300;
+                font-weight: 400;
                 text-decoration: none;
                 color: $color-black;
             }


### PR DESCRIPTION
Fixes #1688

  - Changed font-weight from 300 to 400, while not affecting the selected (pink) category.


<details>

<summary>before</summary>
<img width="1140" alt="Screen Shot 2021-06-21 at 7 21 43 PM" src="https://user-images.githubusercontent.com/67209686/122852745-f8d48680-d2c5-11eb-90c3-029d35111cbf.png">

<summary>after</summary>
<img width="895" alt="Screen Shot 2021-06-21 at 7 21 57 PM" src="https://user-images.githubusercontent.com/67209686/122852753-fc680d80-d2c5-11eb-87b7-25d10dbb6d9e.png">


</details>
