### PR TITLE
Fix "Online Project Team Meetings" button in mobile view within Events Page

### DIFF
--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -432,6 +432,10 @@
     font-weight: bolder;
     font-size: 24px;
   }
+
+  .event-title span span {
+    display: block;
+  }
   .active::after {
     content: "\221F";
     transform: rotate(135deg);

--- a/pages/events/right-col-content.html
+++ b/pages/events/right-col-content.html
@@ -1,6 +1,6 @@
 <h2 class="event-title">
     <img class="vector-img" src="../assets/images/hack-nights/meetings.svg" alt="" />
-    Online Project Team Meetings
+    <span><span>Online Project</span> <span>Team Meetings</span></span>
 </h2>
 <div class="mobile-dropdown">
     <div class="meetup-steps-2">


### PR DESCRIPTION
Fixes #1792 

### What changes did you make and why did you make them?

  - Added `<span>` (to keep justify space-between intact) and 2 nested `<span>` within `<h2 class='event-title'>` so I could add styling without affecting the desktop view.
  - within mobile view, I set `.event-title span span` to `display: block`. So in mobile view, "Online Project Team Meetings" would be on 2 lines.

### Screenshots of Proposed Changes Of The Website

<details>
  <summary><strong>Before Change</strong></summary>
  <br>
  <img src="https://user-images.githubusercontent.com/21162229/122883669-47981580-d2f2-11eb-8a20-243682ab6176.jpg"  alt="Before Changes in mobile view - button text on one line" />
</details>

<details>
  <summary><strong>After Changes</strong></summary>
  <br>
  <img src="https://user-images.githubusercontent.com/21162229/122885549-09035a80-d2f4-11eb-9e7c-5a4609bf6871.jpg"  alt="After Changes in mobile view - button text on two lines" />
</details>


 

