### PR TITLE
issue 1570, change email alt text

### DIFF
--- a/_data/internal/credits/email.yml
+++ b/_data/internal/credits/email.yml
@@ -7,6 +7,6 @@ artist: Hadi Sucipto
 provider: Noun Project
 provider-link: 'https://thenounproject.com/'
 image-url: /assets/images/getting-started/join-1.png
-alt: 'Image of Email'
+alt: 'Email (at) icon'
 type: icon
 ---


### PR DESCRIPTION
Fixes #1570 

### What changes did you make and why did you make them ?

 - Change the alt attribute value to 'Email (at) icon'
 - alt: 'Image of Email'
 - alt: 'Email (at) icon'

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
none
