### PR TITLE
Update to Adding Labels to Pull Request Action

### DIFF
--- a/.github/workflows/add-issue-labels-to-pr.yml
+++ b/.github/workflows/add-issue-labels-to-pr.yml
@@ -1,35 +1,30 @@
 # Name that appears on the workflow
+# Note: Below you will see ${{ github }} and the github variable used. The former is an env from GitHub actions and the latter is an object argument of the actions/github-script@v4 workflow. These two are not the same and should not be treated as such!
 name: Add Linked Issue Labels to Pull Request
 on:
-  # github actions triggered by a pull request runs with only read only context due to security and safety reasons(this is the expected behaviour),
-  # as such the event trigger `pull_request` could not be used in this action, since this action needs to make a repository edit.
-  # To bypass this github has provided the event trigger `pull_request_target`, more information regarding this can be found here
-  #       - https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-  #       - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-  pull_request_target:
+  pull_request:
     types: [opened, edited]
+    branches:
+      - 'gh-pages'
+      - 'wins-feature-1'
 jobs:
-# Adds linked issue labels to pull request
-# Step1: Reads pull request comment and return the linked issue
-# Step2: Perform a GET request to retrieve labels from linked issue
-# Step3: Perform a PUT request to apply labels to original pull request
-# Note: Step1 uses RegEx to extract linked issues. This is not the best choice, but is required as GitHub does not include linked issues in the context. If this changes in the future, please revise Step1 ASAP for a more robust code.
-# Note2: Below you will see ${{ github }} and the github variable used. The former is a context from GitHub actions and the latter is an object argument of the actions/github-script@v4 workflow. These two are not the same and should not be treated as such!
   Add-Linked-Issue-Labels-to-Pull-Request:
     runs-on: ubuntu-latest
     steps:
+      # Note: This portion uses RegEx to extract linked issues. This is not the best choice, but is required as GitHub does not include linked issues in its env. If this changes in the future, please revise this code.
       - name: Retrieve Linked Issue From Comment
         # https://github.com/actions/github-script
         uses: actions/github-script@v4
         # Escapes user input for injection attacks
         env:
           BODY: ${{ github.event.pull_request.body }}
-        id: issue-number
+          PRNUMBER: ${{ github.event.number }}
+        # Variable that stores result of script
+        id: linked-issue-result
         with:
-          result-encoding: string
           script: |
-            // Retrieve comments
-            const { BODY } = process.env
+            // Retrieve pull request body and pull request number
+            const { BODY, PRNUMBER } = process.env
             
             // Create RegEx for capturing KEYWORD #ISSUE-NUMBER syntax (i.e. resolves #1234)
             const KEYWORDS = ['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved']
@@ -40,105 +35,39 @@ jobs:
             
             // Receive and unpack matches into an Array of Array objs
             let re = new RegExp(reArr.join('|'), 'gi')
-            let match = BODY.matchAll(re)
-            match = [...match]
+            let matches = BODY.matchAll(re)
+            matches = [...matches]
             
             // If only one match is found, return the issue number. Else return false. Also console.log results.
-            if (match.length == 1) {
-              const linkedIssue = match[0][0]
-              const issueNumber = match[0][0].match(/\d+/)
-              console.log(`Issue number found for PR #${context.payload.number}. Issue #${issueNumber}`)
-              return issueNumber[0]
+            if (matches.length == 1) {
+              const issueNumber = matches[0][0].match(/\d+/)
+              console.log(`Issue number found for PR #${PRNUMBER}. Issue #${issueNumber}`)
+              return JSON.stringify({ prNumber: PRNUMBER, issueNumber: issueNumber[0] })
             } else {
-              console.log('Make sure there is only one issue!')
+              console.log(`Make sure there is only one issue on PR#${PRNUMBER}!`)
               return false
             }
             
             
-      # https://docs.github.com/en/rest/reference/issues#list-labels-for-an-issue
-      - name: Get Labels from Linked Issue
-        uses: actions/github-script@v4
-        id: linked-labels
-        with:
-          script: |
-            // Retrieve issue number from previous step.
-            const issueNum = ${{ steps.issue-number.outputs.result }}
-            if (!issueNum) {
-              return false
-            }
-            
-            // GET request to retrieve data from results of request
-            // https://octokit.github.io/rest.js/v18#issues-list-labels-on-issue
-            let data;
-            try {
-              const results = await github.issues.listLabelsOnIssue({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNum,
-              });
-              data = results.data
-            }
-            catch(err) {
-              console.log('Error with GET Request to get labels')
-              console.log(err)
-              return false
-            }
-            
-            // Gather all label names into an array of strings and return the array
-            let labelNameArray = []
-            for (const label of data) {
-              labelNameArray.push(label.name)
-            }
-            console.log(`Labels found on Issue #${issueNum}: ${labelNameArray.join(', ')}`)
-            return labelNameArray
-            
-            
-      # https://docs.github.com/en/rest/reference/issues#set-labels-for-an-issue
-      - name: Put Labels to Pull Request
-        uses: actions/github-script@v4
-        id: final-result
-        with:
-          github-token: ${{ secrets.GH_BOT_TOKEN_1 }}
-          script: |
-            // Retrieve labels from previous step
-            const arrayOfLabels = ${{ steps.linked-labels.outputs.result }}
-            if (!arrayOfLabels) {
-              return false
-            }
-            
-            // PUT request to apply labels to pull request
-            // https://octokit.github.io/rest.js/v18#issues-add-labels
-            let results;
-            try {
-              results = await github.issues.setLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: ${{ github.event.number }},
-                labels: arrayOfLabels,
-              })
-            }
-            catch(err) {
-              console.log('Error with PUT Request to edit labels')
-              console.log(err)
-              return false
-            }
-            
-            // Log result of script
-            console.log(results)
-            if (results.status == 200) {
-              return true
-            } else {
-              return false
-            }
-            
-            
-      # For use if there are follow-up actions following script success or failure.
+      # Returns loudly if previous step failed.
       - name: Return Failure
-        if: steps.final-result.outputs.result == 'false'
+        if: steps.linked-issue-result.outputs.result == 'false'
         run: |
           echo "Please expand above outputs for errors."
           exit 1
-      - name: Return Success
+            
+          
+      # Create an artifact with the results of the script
+      - name: Create Artifacts
+        # Escapes user input for injection attacks
+        env:
+          ARTIFACT: ${{ steps.linked-issue-result.outputs.result }}
         run: |
-          echo "${{ steps.final-result.outputs.result }}"
-          echo "Success"
+          mkdir -p addingLabelsAction/artifact
+          echo ${{ env.ARTIFACT }} > addingLabelsAction/artifact/artifact.txt
+          
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: adding-labels-action-artifact
+          path: addingLabelsAction/artifact/

--- a/.github/workflows/wr-add-issues-labels-to-pr.yml
+++ b/.github/workflows/wr-add-issues-labels-to-pr.yml
@@ -1,0 +1,138 @@
+# Name that appears on the workflow
+# Note: This workflow runs once Add Linked Issue Labels to Pull Request is completed
+name: WR Add Linked Issue Labels to Pull Request
+on:
+  workflow_run:
+    workflows: ["Add Linked Issue Labels to Pull Request"]
+    types: [completed]
+
+jobs:
+  Last-Workflow-Success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v4
+        with:
+          script: |
+            // Retrieve metadata about the artifacts of the last workflow
+            // https://octokit.github.io/rest.js/v18#actions-list-workflow-run-artifacts
+            const artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            const artifactData = artifacts.data.artifacts[0]
+            
+            // Download artifact with GET API
+            // https://octokit.github.io/rest.js/v18#actions-download-artifact
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: artifactData.id,
+               archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/artifact.zip', Buffer.from(download.data));
+      - run: unzip artifact.zip
+          
+    
+      - name: Get Labels from Linked Issue
+        uses: actions/github-script@v4
+        # Variable that stores result of script
+        id: labels-result
+        with:
+          script: |
+            // Retrieve pull request and issue number from downloaded artifact
+            const fs = require('fs')
+            const artifact = fs.readFileSync('artifact.txt')
+            const artifactJSON = JSON.parse(artifact)
+            const issueNum = artifactJSON.issueNumber
+            const prNumber = artifactJSON.prNumber
+            
+            // GET request to retrieve data from results of request
+            // https://octokit.github.io/rest.js/v18#issues-list-labels-on-issue
+            let data
+            try {
+              const results = await github.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNum,
+              });
+              data = results.data
+            }
+            catch(err) {
+              console.log('Error with GET Request to get labels')
+              console.log(err)
+              return false
+            }
+            // Gather all label names into an array of strings and return the array
+            let labelNameArray = []
+            for (const label of data) {
+                labelNameArray.push(label.name)
+            }
+            console.log(`Labels found on Issue #${issueNum}: ${labelNameArray.join(', ')}`)
+            return { prNumber: prNumber, labelNameArray: labelNameArray }
+      
+          
+      - name: Put Labels to Pull Request
+        uses: actions/github-script@v4
+        # Variable that stores result of script
+        id: final-result
+        with:
+          script: |
+            let prNumber
+            let labelNameArray
+            
+            // Retrieve pull request number and labels from previous step
+            const labelsResult = ${{ steps.labels-result.outputs.result }}
+            if (labelsResult) {
+              prNumber = labelsResult.prNumber
+              labelNameArray = labelsResult.labelNameArray
+            } else {
+              return false
+            }
+            
+            // PUT request to apply labels to pull request
+            // https://octokit.github.io/rest.js/v18#issues-add-labels
+            let results;
+            try {
+              results = await github.issues.setLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: labelNameArray,
+              })
+            }
+            catch(err) {
+              console.log('Error with PUT Request to edit labels')
+              console.log(err)
+              return false
+            }
+            
+            // Log result of script
+            console.log(results)
+            if (results.status == 200) {
+              return true
+            } else {
+              return false
+            }
+            
+            
+      # For use if there are follow-up actions following script success or failure.
+      - name: Return Failure
+        if: steps.final-result.outputs.result == 'false'
+        run: |
+          echo "Please expand above outputs for errors."
+          exit 1
+      - name: Return Success
+        run: |
+          echo "${{ steps.final-result.outputs.result }}"
+          echo "Success"
+          
+  Last-Workflow-Failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Failed Run
+        run: echo "The previous GitHub Action failed. Please check the logs for the previous action."


### PR DESCRIPTION
Fixes #1787 

### What changes did you make and why did you make them?

- Removed pull_request_target in favor of workflow_run for better security. (Please see pros and cons below)
- Removed repository secret, since workflow_run now runs within its own repo context (please confirm)
- Patched action such that it should work on the wins-feature-1 branch
- Slight changes to code diction and comments for better readability

#### pull_request_target vs workflow_run:

pull_request_target grants permission to write into the "into" repo. The purpose of granting this permission is to allow the action to label pull requests or make comments. However, if the action instead runs the code from the pull request, this code is now granted write permission to our repository, potentially leaking sensitive information, such as secrets. That said, this concern might not be relevant for this specific action, or this repo.

workflow_run grants write permission, but the action is not run within the context of the pull request. Rather, workflow_run happens in two steps. In the first step, information is taken from the pull request, sanitized, and stored. Then, in the second step, this information is read and used by the workflow_run. The weakness of workflow_run is that the code itself requires much overhead (and 2 files!), and improperly storing information in the first step could also cause sensitive information to leak. workflow_run is generally recommended when a checkout of the code in the "from" branch is required.

For the files in this pull request workflow_run is used since it is overall safer, but reviewers can decide which action trigger is preferred.

#### about wins-feature-1

From personal testing, it appears that GitHub actions are "branch"-specific, meaning that it runs the action files that are in that specific branch. For the action in this pull request to run in wins-feature-1, the file in this pull request must be copied in the wins-featue-1 branch.

#### about testing

Testing the updated action might require the files to be merged first, since workflow_run runs within its own repo context.