### PR TITLE
Adjust header-container class margin

### DIFF
--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -3,9 +3,7 @@
   flex-flow: row;
   justify-content: center;
   background: #fff;
-  padding: 64px;
   height: fit-content;
-  margin: 37px auto 0;
   font-family: "Roboto", sans-serif;
   font-style: normal;
   font-weight: normal;

--- a/_sass/components/_credit-items.scss
+++ b/_sass/components/_credit-items.scss
@@ -15,7 +15,6 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
-  padding: 64px;
 
   img {
     max-height: 240px;

--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -1,5 +1,5 @@
 .content-hack-night {
-  margin: 83px 0px;
+  margin: 40px 0px 83px 0px;
   padding: 25px;
   @media #{$bp-below-tablet} {
     margin-top: 52px;

--- a/_sass/elements/_containers.scss
+++ b/_sass/elements/_containers.scss
@@ -2,7 +2,7 @@
     background: #fff;
     padding: 40px;
     height: fit-content;
-    margin: 37px auto 0;
+    margin: 61px auto 0;
     font-family: "Roboto"sans-serif;
     font-style: normal;
     font-weight: normal;


### PR DESCRIPTION
Fixes #1791 

### What changes did you make and why did you make them ?
  - Changed top margin of .header-container to 61px to move most pages header farther away from nav as discussed in original issue
  - Removed or made minor changes to a few pages top margins and padding to accommodate the change to .header-container or to match it if the page doesn't use .header-container

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)


<details>
<summary>Toolkit page before</summary>

![Screen Shot 2021-06-28 at 12 44 20 PM](https://user-images.githubusercontent.com/40401149/123696995-4181c780-d811-11eb-90d7-7aed9c153a6b.png)

</details>

<details>
<summary>Toolkit page after</summary>

![Screen Shot 2021-06-28 at 12 43 45 PM](https://user-images.githubusercontent.com/40401149/123697394-b6ed9800-d811-11eb-97b3-5e07f2123a07.png)

</details>
