### PR TITLE
removed max height property so all getting started cards were visible

### DIFF
--- a/_sass/components/_project-page.scss
+++ b/_sass/components/_project-page.scss
@@ -170,7 +170,6 @@
 }
 
 #getting-started-section {
-  max-height: 294px;
   padding: 30px;
   transition: max-height 1s, padding 1s;
   margin-top: 28px;


### PR DESCRIPTION
Fixes #1829

What changes did you make and why did you make them ?

 - Removed max-height property in the #getting-started-section in the project page because it was cutting off the cards in the mobile view. I figured I would remove the property completely instead of adding a media query for mobile on the off-chance more cards are added to the getting started section and it starts cutting off on the desktop view as well.


<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/28831668/123713939-51f26c00-d82a-11eb-88a9-f09375665468.jpg" alt="image of bug"/>

</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/28831668/123713771-faec9700-d829-11eb-9f3c-2e90db05f53a.jpg" alt="image of bug fixed"/>


</details>
