### PR TITLE
Added documentation for unseen changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,22 +212,6 @@ the source files and rebuilds and refreshes the site automatically in your brows
    ```bash
    docker-compose up
    ```
-
-### Can't see your changes locally?
-
-  <details>
-  <summary>If you are having trouble viewing your changes locally after running docker, click here to see instructions on how to resolve this issue</summary>
-  
-  1. The first thing to do if you do not see your changes while starting docker or live reloading, stop docker from running. 
-  2. Next, go into the files and look for the '_site' folder and delete this folder.
-  3. Next, look for a file called '.jekyll-metadata' and delete this file.
-  4. Finally, try running docker again and you should see your changes.
-
-  - If the above steps did not resolve your issue, run through the first three steps again, but try resetting your browser's cache before restarting docker (you can also try running http://localhost:4000 in another browser).
-  - If you still do not see your changes after trying these steps, please feel free to reach out to the team in the [#hfla-site](https://hackforla.slack.com/archives/C4UM52W93) slack channel, or bring up your issue in a dev meeting.
-
-  </details>
-
 # Working on an issue and making a pull request
 
 ## Working on an issue
@@ -273,6 +257,21 @@ Create a new branch for each issue you work on. Doing all your work on topic bra
    <sub>*No law of physics will break if you don't adhere to this scheme, but laws of git will break if you add spaces.*</sub>
 
    When you've finished working on your issue, follow the steps below to prepare your changes to push to your repository. 
+
+   ### Can't see your changes locally?
+
+   <details>
+   <summary>If you are having trouble viewing your changes locally after running docker, click here to see instructions on how to resolve this issue</summary>
+   
+   1. The first thing to do if you do not see your changes while starting docker or live reloading, stop docker from running. 
+   2. Next, go into the files and look for the '_site' folder and delete this folder.
+   3. Next, look for a file called '.jekyll-metadata' and delete this file.
+   4. Finally, try running docker again and you should see your changes.
+
+   - If the above steps did not resolve your issue, run through the first three steps again, but try resetting your browser's cache before restarting docker (you can also try running http://localhost:4000 in another browser).
+   - If you still do not see your changes after trying these steps, please feel free to reach out to the team in the [#hfla-site](https://hackforla.slack.com/archives/C4UM52W93) slack channel, or bring up your issue in a dev meeting.
+
+   </details>
 
 3. ### Prepare your changes to push to your repository
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,11 +219,11 @@ the source files and rebuilds and refreshes the site automatically in your brows
   <summary>If you are having trouble viewing your changes locally after running docker, click here to see instructions on how to resolve this issue</summary>
   
   1. The first thing to do if you do not see your changes while starting docker or live reloading, stop docker from running. 
-  2. Next, go into the files and look for the _site folder and delete this folder.
+  2. Next, go into the files and look for the '_site' folder and delete this folder.
   3. Next, look for a file called '.jekyll-metadata' and delete this file.
   4. Finally, try running docker again and you should see your changes.
 
-  - If the above steps did not resolve your issue, run through the first three steps again, but try resetting your browserss cache before restarting docker (you can also try running localhost:4000 in another browser).
+  - If the above steps did not resolve your issue, run through the first three steps again, but try resetting your browser's cache before restarting docker (you can also try running http://localhost:4000 in another browser).
   - If you still do not see your changes after trying these steps, please feel free to reach out to the team in the [#hfla-site](https://hackforla.slack.com/archives/C4UM52W93) slack channel, or bring up your issue in a dev meeting.
 
   </details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,21 @@ the source files and rebuilds and refreshes the site automatically in your brows
    docker-compose up
    ```
 
+### Can't see your changes locally?
+
+  <details>
+  <summary>If you are having trouble viewing your changes locally after running docker, click here to see instructions on how to resolve this issue</summary>
+  
+  1. The first thing to do if you do not see your changes while starting docker or live reloading, stop docker from running. 
+  2. Next, go into the files and look for the _site folder and delete this folder.
+  3. Next, look for a file called '.jekyll-metadata' and delete this file.
+  4. Finally, try running docker again and you should see your changes.
+
+  - If the above steps did not resolve your issue, run through the first three steps again, but try resetting your browserss cache before restarting docker (you can also try running localhost:4000 in another browser).
+  - If you still do not see your changes after trying these steps, please feel free to reach out to the team in the [#hfla-site](https://hackforla.slack.com/archives/C4UM52W93) slack channel, or bring up your issue in a dev meeting.
+
+  </details>
+
 # Working on an issue and making a pull request
 
 ## Working on an issue


### PR DESCRIPTION
Fixes #1477 

### What changes did you make and why did you make them?

There has been an issue with developers seeing changes made on their local machines. This typically occurs when changing .md or .yml files. A lot of these issues where people are not seeing their changes are on good first and second issues which is why I added documentation on how to fix this problem.

  - In order to help remedy this issue, I added a small section under Part 2 of Working on an Issue in CONTRIBUITNg.md about how to fix this problem.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Changes</summary>
This is where I added the changes I made:

![image](https://user-images.githubusercontent.com/10714770/123716183-ce874980-d82e-11eb-8b92-75e717577d1c.png)

Here are the changes:

![image](https://user-images.githubusercontent.com/10714770/123550047-6d715000-d720-11eb-8ac1-d9fba2c083a3.png)

</details>
