### PR TITLE
Add media query to .leader-description

### DIFF
--- a/_sass/components/_project-page.scss
+++ b/_sass/components/_project-page.scss
@@ -327,6 +327,16 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+
+  @media #{$bp-below-mobile} {
+    min-width: 70%;
+    display: flex;
+    flex-direction: column;
+    width: 70%;
+    justify-content: center;
+    align-content: center;
+    align-items: flex-start;
+  }
 }
 
 .leader-description-field {


### PR DESCRIPTION
Fixes #1830 

### What changes did you make and why did you make them ?

  - Add media query to `.leadership-description` class (`_project-page.scss`) to accommodate the situation when a leader role description is too long (doesn't center as the other shorter ones do)
  - set `width = 70%` and `align-items: flex-start`

### Screenshots of Proposed Changes Of The Website 

<details>
<summary>After (mobile view)</summary>

<img width="353" alt="image" src="https://user-images.githubusercontent.com/72854605/123716486-89afe280-d82f-11eb-9949-af34c0a29551.png">

</details>
