### PR TITLE
change alt text for video conference icon

### DIFF
--- a/_data/internal/credits/video-conference.yml
+++ b/_data/internal/credits/video-conference.yml
@@ -7,6 +7,6 @@ artist: Edwin PM
 provider: Noun Project
 provider-link: 'https://thenounproject.com/'
 image-url: /assets/images/getting-started/onboard-2.png
-alt: 'Image of Video Conference'
+alt: 'Video Conference Icon'
 type: icon
 ---


### PR DESCRIPTION
Fixes #1587

### What changes did you make and why did you make them?

  - Change the alt attribute value to 'Video Conference Icon'


<details>
<summary>Edit_This_To_Add_Image_Description</summary>

![Screen Shot 2021-06-29 at 4 12 14 PM](https://user-images.githubusercontent.com/74341752/123878929-dc9f9d80-d8f4-11eb-9d07-4b516cd2df1f.png)


</details>
