### PR TITLE
Changed alt attribute for meetings icon on credit page

### DIFF
--- a/_data/internal/credits/meetings.yml
+++ b/_data/internal/credits/meetings.yml
@@ -7,6 +7,6 @@ artist: IconMarketPK
 provider: Iconfinder
 provider-link: 'https://www.iconfinder.com/'
 image-url: /assets/images/hack-nights/meetings.svg
-alt: 'Image of Meetings'
+alt: 'Meeting Icon'
 type: icon
 ---


### PR DESCRIPTION
Fixes #1573

### What changes did you make and why did you make them ?

  -  Change the alt attribute value to 'Meeting Icon'

### Screenshots of Proposed Changes Of The Website 

<details>
<summary>Image of code change</summary>

![Capture](https://user-images.githubusercontent.com/48004150/123888745-019e0b80-d909-11eb-8ff2-24624d36c691.PNG)

</details>
