### PR TITLE
Standardize Program Areas for Mobile

### DIFF
--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -57,6 +57,12 @@
     height: 240px;
 }
 
+@media #{$bp-mobile-up} {
+.program-areas-hero-svg {
+    width: 75%;
+    height: 240px;
+}
+}
 @media(max-width: 850px) {
     .program-areas-header {
         flex-flow: column;

--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -53,16 +53,10 @@
 }
 
 .program-areas-hero-svg {
-    width: auto;
+    width: 100%;
     height: 240px;
 }
 
-@media #{$bp-mobile-up} {
-.program-areas-hero-svg {
-    width: 75%;
-    height: 240px;
-}
-}
 @media(max-width: 850px) {
     .program-areas-header {
         flex-flow: column;

--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -56,8 +56,8 @@
     width: auto;
     height: 240px;
 
-    @media #{$bp-below-mobile} {
-      width: 300px;
+    @media #{$bp-below-tablet} {
+      max-width: 300px;
       height: 180.17px;
     }
 }
@@ -176,7 +176,7 @@
       flex-wrap: wrap;
       padding-inline-start: 0px;
 
-      @media #{$bp-below-mobile} {
+      @media #{$bp-below-tablet} {
         padding-inline-start: 58px;
       }
     }

--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -53,8 +53,13 @@
 }
 
 .program-areas-hero-svg {
-    width: 100%;
+    width: auto;
     height: 240px;
+
+    @media #{$bp-below-mobile} {
+      width: 300px;
+      height: 180.17px;
+    }
 }
 
 @media(max-width: 850px) {

--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -169,7 +169,7 @@
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
-      padding-inline-start: 0px;
+      padding-inline-start: 15px;
     }
 
 }

--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -169,7 +169,11 @@
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
-      padding-inline-start: 50px;
-    }
+      padding-inline-start: 0px;
 
+      @media #{$bp-below-mobile} {
+        padding-inline-start: 58px;
+      }
+    }
+    
 }

--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -169,7 +169,7 @@
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
-      padding-inline-start: 15px;
+      padding-inline-start: 50px;
     }
 
 }


### PR DESCRIPTION
Fixes #1825
### What changes did you make and why did you make them ?

  -Added a mobile media query that sets the .program-areas-hero-svg max width to 300px and its height at 180.17px as per the figma mockup. This was done to resize the image to fit on the mobile page.
  -Added a mobile media query that sets padding-inline-start to 58px for &-list-alignment as per the figma mockup. This was done to center the mini project cards instead of having them left aligned.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
-Before
![IMG-1414](https://user-images.githubusercontent.com/85966467/123896829-2bf6c580-d917-11eb-895a-d9ad8cf8d284.jpg)
![IMG-1415](https://user-images.githubusercontent.com/85966467/123896848-344f0080-d917-11eb-9ada-b6fc2e03355e.jpg)
-After
![IMG-1412](https://user-images.githubusercontent.com/85966467/123896862-3ca73b80-d917-11eb-9c70-3b444c7670e4.jpg)
![IMG-1413](https://user-images.githubusercontent.com/85966467/123896883-4466e000-d917-11eb-9f87-f9b0edae0e3f.jpg)

