### PR TITLE
Fixing CoP links and removing localStorage saving on events page

### DIFF
--- a/pages/events/right-col-content.html
+++ b/pages/events/right-col-content.html
@@ -38,69 +38,16 @@
     */
     (async function main(){
 
-        //Runs only if storedDate exists in users localStorage
-        if(localStorage.getItem('storedDate')) {
-            const storedData = JSON.parse(localStorage.getItem('storedData'));
+        const response_data = await sendGetRequest(API_ENDPOINT);
+        let filteredData = filterDataFromApi(response_data);
+        let sortedData = sortData(filteredData);
 
-            //Displays/Inserts event schedule to DOM
-            document.addEventListener('DOMContentLoaded', insertEventSchedule(storedData));
-            //Displays/Inserts the user's time zone in the DOM
-            document.querySelector('#userTimeZone').insertAdjacentHTML('afterbegin', timeZoneText());
+        //Displays/Inserts event schedule to DOM
+        document.addEventListener('DOMContentLoaded', insertEventSchedule(sortedData));
+        //Displays/Inserts the user's time zone in the DOM
+        document.querySelector('#userTimeZone').insertAdjacentHTML('afterbegin', timeZoneText());
 
-            //After storedData is rendered, checks if API has been updated
-            const response_data = await sendGetRequest(API_ENDPOINT);
-            compareDates(response_data);
-        } else {
-            //Initial fetch to render data
-            const response_data = await sendGetRequest(API_ENDPOINT);
-            let filteredData = filterDataFromApi(response_data);
-            let sortedData = sortData(filteredData);
-
-            //Displays/Inserts event schedule to DOM
-            document.addEventListener('DOMContentLoaded', insertEventSchedule(sortedData));
-            //Displays/Inserts the user's time zone in the DOM
-            document.querySelector('#userTimeZone').insertAdjacentHTML('afterbegin', timeZoneText());
-
-            //Initial store of data to users localStorage
-            storeData(sortedData);
-        }
     })()   
-
-    /**
-     * Stores data and users date-time locally
-     * @param {Object} sortedData — 2 key : value pairs in localStorage
-    */
-     function storeData(sortedData){
-        const dataString = JSON.stringify(sortedData);
-        const userDate = new Date().toISOString(Date()); 
-        
-        localStorage.setItem('storedDate', `${userDate}`)
-        localStorage.setItem('storedData', `${dataString}`)
-    }
-
-    /**
-     * Compares users storedDate to all updatedDates in the API
-     * @param {Object} responseData — will update localStorage and page with new data, if found
-    */
-    function compareDates(responseData){
-        let updatedDates = responseData.map(data => (data.updatedDate));
-        const userDate = localStorage.getItem('storedDate');
-        
-        for(const date of updatedDates){
-            if(date > userDate){
-                let filteredData = filterDataFromApi(parseData)
-                let sortedData = sortData(filteredData);
-                
-                //Displays/Inserts event schedule to DOM
-                document.addEventListener('DOMContentLoaded', insertEventSchedule(sortedData));
-                //Displays/Inserts the user's time zone in the DOM
-                document.querySelector('#userTimeZone').insertAdjacentHTML('afterbegin', timeZoneText());
-
-                //Updates users storedData and storedDate locally
-                storeData(sortedData)
-            }
-        }
-    }
 
     /**
      * Retrieves data from the wins excel sheet provided a valid excel url


### PR DESCRIPTION
Fixes #1836 

  - Requested VRMS team to fix CoP links in the API: https://github.com/hackforla/VRMS/issues/605
  - Removed `localStorage` saving so all event data is always requested from the VRMS API per Akib's suggestion. This is due to the original code updating localStorage info only when the `updatedDate` API property is newer than the `updatedDate` in `localStorage`. This property does not always change in the API when something is updated, like when the CoP links were changed.

Please note that I only requested CoP links to be fixed. There are other broken links, like Expunge Assist, that need to be fixed as well. On the same note, I tested a couple days worth of events and all seem to be working as normal, but please double check.

<details>
<summary>Example of old link</summary>

![image](https://user-images.githubusercontent.com/77088922/123900903-cf97a400-d91e-11eb-8530-265f35a26a95.png)

</details>


<details>
<summary>Example of new link</summary>

![image](https://user-images.githubusercontent.com/77088922/123900876-c1e21e80-d91e-11eb-8efc-cb3413c29559.png)


</details>
