### PR TITLE
Update Wins About page,1835

### DIFF
--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -473,10 +473,9 @@ a.anchor {
 }
 
 .accomplishment-wins {
-  color: $color-red;
+  color: #333;
   text-decoration: none;
   margin: 25px 0 10px 0;
-  align-items: flex-start;
   display: flex;
   justify-content: center;
   font-size: 24px;

--- a/pages/about/about-card-accomplishments.html
+++ b/pages/about/about-card-accomplishments.html
@@ -23,7 +23,7 @@
             <div class="top-left-column wins-column-width-left">
                 <div class="accomplishment-wins"><img src="/assets/images/about/wins-cup.svg">Wins</div>
                 <div>Check out what our team members have said about their experiences.</div>
-                <p class="eliptical align-left coming-soon">Coming soon....</p>
+                <p class="eliptical align-left coming-soon"><a href="https://hackforla.org/wins">View Volunteer Wins</a></p>
             </div>
             <div class="bottom-right-column wins-column-width-right">
                 <div class="wins-card-mobile"><a href="https://hackforla.org/wins" target="_blank" rel="noopener noreferrer"><img src="/assets/images/about/wins-card-mobile.svg" alt="The wins card displays the contributer's name, their teams and roles, and testimonials of their accomplishments." /></div>


### PR DESCRIPTION
Fixes #1835 

### What changes did you make and why did you make them ?

  - Remove 'coming soon' in the Wins section and replace it with a link to the Wins page (see image below)
  - Change the Wins title to black (use the variable for black # 333, and keep the icon pink) because user testing in the past showed hfLA users confuse pink titles for links
  - Evenly align the Wins title and the icon- see image below for reference and/or
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/86015625/124064557-e1924900-d9e9-11eb-8064-18fbb4ad2017.png)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/86015625/124064516-caebf200-d9e9-11eb-9b13-c5c3b8fbc1a1.png)

</details>
