### PR TITLE
Update 'Contact Us' image credit link

### DIFF
--- a/_data/internal/credits/contact-us.yml
+++ b/_data/internal/credits/contact-us.yml
@@ -1,6 +1,6 @@
 ---
 title: Contact Us
-title-link: https://www.freepik.com/
+title-link: https://www.freepik.com/free-vector/contact-us-concept-landing-page_4661525.htm
 content: Image
 used-in: About
 artist: Jonathan Larenas


### PR DESCRIPTION
Fixes #1873

### What changes did you make and why did you make them ?

  - Updated the image credit link for the 'Contact Us' image so it leads to the correct Freepik page
<details>
<summary>Change</summary>
Clicking the link :

![edited](https://user-images.githubusercontent.com/48004150/124338353-4f5e8200-db5c-11eb-99ee-a4832d34b7dd.png)

Now leads to:
![target](https://user-images.githubusercontent.com/48004150/124338279-c5161e00-db5b-11eb-98eb-bb8a6d285f10.PNG)
</details>