### PR TITLE
Standardized credits page header in mobile

### DIFF
--- a/_sass/components/_credit-items.scss
+++ b/_sass/components/_credit-items.scss
@@ -46,12 +46,20 @@
   h1 {
     font-size: 48px;
   }
+  @media #{$bp-below-tablet}{
+    h1 {
+      font-size: 40px;
+    }
+  }
   @media #{$bp-below-mobile} {
     margin: auto;
     margin-bottom: 36px;
     h1 {
-      font-size: 24px;
-      margin-bottom: 20px;
+      font-size: 2rem;
+      margin-bottom: 28px;
+    }
+    p {
+      padding: 0px;
     }
   }
 }

--- a/_sass/components/_credit-items.scss
+++ b/_sass/components/_credit-items.scss
@@ -48,7 +48,7 @@
   }
   @media #{$bp-below-tablet}{
     h1 {
-      font-size: 40px;
+      font-size: 2.5rem;
     }
   }
   @media #{$bp-below-mobile} {


### PR DESCRIPTION
Fixes #1598 

### What changes did you make and why did you make them ?

  - I changed the padding and margin to the header in the Credits page in mobile to make it consistent with other pages and our design system.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="286" alt="Screen Shot 2021-07-06 at 5 39 55 PM" src="https://user-images.githubusercontent.com/24802803/124683144-3ff37780-de81-11eb-9dbe-d1ffaddb0b44.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="285" alt="Screen Shot 2021-07-06 at 5 41 02 PM" src="https://user-images.githubusercontent.com/24802803/124683225-64e7ea80-de81-11eb-9740-fe7944af1399.png">

</details>
