### PR TITLE
Fixed wins modal position to prevent it from penetrating menu in mobile

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -66,7 +66,7 @@
     color: $color-white;
     font-family: arial;
     position: absolute;
-    z-index: 100;
+    z-index: 1;
 }
 [data-wins]{
     font-weight: normal 


### PR DESCRIPTION
Fixes #1717 

### What changes did you make and why did you make them ?

  - Fixed z-index of modal overlay in wins page to prevent it from penetrating the fixed menu.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/24802803/124699767-4e04c080-dea0-11eb-85b3-287077970d46.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="372" alt="Screen Shot 2021-07-06 at 9 23 17 PM" src="https://user-images.githubusercontent.com/24802803/124699821-6e347f80-dea0-11eb-90b8-ba619c360641.png">


</details>
