### PR TITLE
Update link to Public Tree Map project page

### DIFF
--- a/pages/events/our-locations-content.html
+++ b/pages/events/our-locations-content.html
@@ -45,7 +45,7 @@
           <div class="img-dis">
             <img id="mini-img" src="../assets/images/projects/public-tree-map.png" alt="Public Tree Map Project" />
             <div class="proj-desc">
-              <a href="">Public Tree Map</a>
+              <a href="https://www.hackforla.org/projects/public-tree-map">Public Tree Map</a>
             </div>
           </div>
 


### PR DESCRIPTION
Fixes #1524

Replace missing href attribute to Public Tree Map project page with active link. 