### PR TITLE
Update Open Community Survey project profile

### DIFF
--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -30,7 +30,7 @@ location:
   # - Los Angeles
   - Remote
 partner: EmpowerLA, various Neighborhood Councils (e.g., Westlake NC)
-tools: 'ArcGIS surveys, Google Docs, Zoom'
+tools: 'ArcGIS surveys, Figma, Google Docs, Zoom'
 visible: true
 program area: 'Citizen Engagement'
 status: Active

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -13,12 +13,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/UE1UG1YFP'
       github: 'https://github.com/ExperimentsInHonesty'
     picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
-  - name: Phoebe Ng
-    role: UX Researcher
-    links:
-      slack: 'https://hackforla.slack.com/team/U01GTRX0H7X'
-      github: 'https://github.com/phoebeng'
-    picture: https://avatars.githubusercontent.com/phoebeng
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/open-community-survey'

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -31,6 +31,12 @@ leadership:
       slack: 'https://hackforla.slack.com/archives/D025891DF41'
       github: 'https://github.com/AdesinaBernard'
     picture: https://avatars.githubusercontent.com/AdesinaBernard
+  - name: Kevin Wang
+    role: UX Designer
+    links:
+      slack: 'https://hackforla.slack.com/archives/D025DF0E4SJ'
+      github: 'https://github.com/kvnw2020'
+    picture: https://avatars.githubusercontent.com/kvnw2020
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/open-community-survey'

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -26,6 +26,8 @@ links:
     url: 'https://hackforla.slack.com/archives/C01H0HUDMCK'
   - name: Getting Started
     url: 'https://github.com/hackforla/community-survey-nc-websites/projects/1#card-51519391'
+technologies:
+  - Markdown
 location:
   # - Los Angeles
   - Remote

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -26,13 +26,6 @@ links:
     url: 'https://hackforla.slack.com/archives/C01H0HUDMCK'
   - name: Getting Started
     url: 'https://github.com/hackforla/community-survey-nc-websites/projects/1#card-51519391'
-looking:
-  - category: PM
-    skill: Product Manager
-  - category: PM
-    skill: Product Owner
-  - category: Data
-    skill: Data Scientists
 location:
   # - Los Angeles
   - Remote

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -13,6 +13,12 @@ leadership:
       slack: 'https://hackforla.slack.com/team/UE1UG1YFP'
       github: 'https://github.com/ExperimentsInHonesty'
     picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
+  - name: Ebele O.
+    role: Product Manager
+    links:
+      slack: 'https://hackforla.slack.com/archives/D01R3EN5DG9'
+      github: 'https://github.com/ebele-oputa'
+    picture: https://avatars.githubusercontent.com/ebele-oputa
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/open-community-survey'

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -49,7 +49,7 @@ technologies:
 location:
   # - Los Angeles
   - Remote
-partner: EmpowerLA, various Neighborhood Councils (e.g., Westlake NC)
+partner: 'LA Department of Neighborhood Empowerment (DONE), LA Neighborhood Councils (NCs), LA Department of Transportation (LADOT), LA City Planning Department (LACP)'
 tools: 'ArcGIS surveys, Figma, Google Docs, Zoom'
 visible: true
 program area: 'Citizen Engagement'

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -21,7 +21,7 @@ leadership:
     picture: https://avatars.githubusercontent.com/phoebeng
 links:
   - name: GitHub
-    url: 'https://github.com/hackforla/community-survey-nc-websites'
+    url: 'https://github.com/hackforla/open-community-survey'
   - name: Slack
     url: 'https://hackforla.slack.com/archives/C01H0HUDMCK'
   - name: Getting Started

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -25,6 +25,12 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U022B5EJFME'
       github: 'https://github.com/csdorsey'
     picture: https://avatars.githubusercontent.com/csdorsey
+  - name: Bernard Adesina
+    role: UX Designer
+    links:
+      slack: 'https://hackforla.slack.com/archives/D025891DF41'
+      github: 'https://github.com/AdesinaBernard'
+    picture: https://avatars.githubusercontent.com/AdesinaBernard
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/open-community-survey'

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -19,6 +19,12 @@ leadership:
       slack: 'https://hackforla.slack.com/archives/D01R3EN5DG9'
       github: 'https://github.com/ebele-oputa'
     picture: https://avatars.githubusercontent.com/ebele-oputa
+  - name: Chianta Dorsey
+    role: UI/UX Researcher
+    links:
+      slack: 'https://hackforla.slack.com/team/U022B5EJFME'
+      github: 'https://github.com/csdorsey'
+    picture: https://avatars.githubusercontent.com/csdorsey
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/open-community-survey'


### PR DESCRIPTION
Fixes #1851

Updated the following details on the Open Community Survey project profile due to being out of date:

- Updated project GitHub link
- Removed all open roles
- Added Figma under Tools
- Created Technologies section and added Markdown
- Replaced existing Partner list with the updated list provided
- Updated current project team with list provided

### Screenshots of Proposed Changes Of The Website

<details>
<summary>Visuals before changes are applied</summary>

<img width="908" alt="Screen Shot 2021-07-10 at 2 46 29 PM" src="https://user-images.githubusercontent.com/71858488/125177045-c7edc000-e1a6-11eb-8a5f-3f1b415a53e3.png">
<img width="906" alt="Screen Shot 2021-07-10 at 2 47 29 PM" src="https://user-images.githubusercontent.com/71858488/125177068-f1a6e700-e1a6-11eb-9267-0ae92fe06cdc.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="907" alt="Screen Shot 2021-07-10 at 2 48 39 PM" src="https://user-images.githubusercontent.com/71858488/125177082-126f3c80-e1a7-11eb-824d-b54bd02490b3.png">
<img width="820" alt="Screen Shot 2021-07-10 at 2 49 20 PM" src="https://user-images.githubusercontent.com/71858488/125177097-2b77ed80-e1a7-11eb-9855-10fe114934eb.png">

</details>
