### PR TITLE
Adding design system heading classes to Sitemap page

### DIFF
--- a/_sass/components/_sitemap.scss
+++ b/_sass/components/_sitemap.scss
@@ -37,17 +37,10 @@
     margin-top: 8px;
     text-align: left;
   }
-  h1 {
-    font-size: 48px;
-    @media #{$bp-tablet-up} {
-      font-size: 40px;
-    }
-  }
   @include mobile {
     margin: auto;
     margin-bottom: 36px;
-    h1 {
-      font-size: 32px;
+    .title1 {
       margin-bottom: 20px;
     }
   }
@@ -61,8 +54,7 @@
   justify-content: center;
   text-align: center;
 
-  h3 {
-    font-size: 24px;
+  .title4 {
     margin-bottom: 32px;
   }
   p {
@@ -72,9 +64,6 @@
     margin-bottom: 40px;
   }
   @include mobile {
-    h3 {
-      font-size: 20px;
-    }
     p {
       font-size: 16px;
       max-width: 300px;
@@ -112,7 +101,7 @@
       display: none;
     }
     @include mobile {
-      h3 {
+      .title4 {
         text-align: center;
       }
       .card-desktop-icon {

--- a/pages/sitemap.html
+++ b/pages/sitemap.html
@@ -7,7 +7,7 @@ permalink: /sitemap/
 
 <div class="header-container header-container--sitemap">
     <div class="header-text-margin--sitemap">
-        <h1>Site Map</h1>
+        <h1 class="title1">Site Map</h1>
         <p>
             The Hack for LA website is growing. We started with a one page
             website and we have been steadily adding content and features
@@ -22,7 +22,7 @@ permalink: /sitemap/
 <div class="sitemap-page content-section">
     <div class="page-card card-primary page-card-lg page-card--sitemap">
         <div>
-            <h3>Sitemap as of 10/22/20</h3>
+            <h3 class="title4">Sitemap as of 10/22/20</h3>
             <a href="https://www.hackforla.org/assets/images/sitemap/sitemap.jpg" target="_blank">
                 <img src="/assets/images/sitemap/sitemap.jpg">
 
@@ -33,7 +33,7 @@ permalink: /sitemap/
     <div class="page-card card-primary page-card-lg page-card--sitemap page-card--sitemap-flex page-card card-body card-width">
         <img class="card-desktop-icon" src="/assets/images/sitemap/lightbulb.svg">
         <div>
-            <h3>Suggest Site Content</h3>
+            <h3 class="title4">Suggest Site Content</h3>
             <img class="card-mobile-icon" src="/assets/images/sitemap/lightbulb.svg">
             <p>
                 Have you thought of something that you wish was on
@@ -54,7 +54,7 @@ permalink: /sitemap/
     <div class="page-card card-primary page-card-lg page-card--sitemap page-card--sitemap-flex page-card card-body card-width">
         <img class="card-desktop-icon" src="/assets/images/sitemap/site.svg">
         <div>
-            <h3>Help Us Add Sections to the Website</h3>
+            <h3 class="title4">Help Us Add Sections to the Website</h3>
             <img class="card-mobile-icon" src="/assets/images/sitemap/site.svg">
             <p>
                 We are looking for volunteers across all


### PR DESCRIPTION
Fixes #1877 


  - Added header classes `title1` and `title4` to headers `h1` and `h3`, respectively, on Sitemap page per [figma](https://www.figma.com/file/0RRPy1Ph7HafI3qOITg0Mr/Hack-for-LA-Website?node-id=3164%3A18). The classes were made in https://github.com/hackforla/website/pull/1814
  - Replaced header tags with their respective classes on sitemap.scss to make header selection more specific. Can be changed back to their original `h1` and `h3` if needed.
  - Removed any `font-size` changes for headers on sitemap.scss so they do not overwrite the design system heading class font sizes.


<details>
<summary>Figma screenshot</summary>

![image](https://user-images.githubusercontent.com/77088922/125191369-df549980-e1f6-11eb-91b8-c2fb99ddab64.png) 

</details> 


<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/77088922/125191616-3870fd00-e1f8-11eb-8e35-9b0a0b5f15a1.png)
![image](https://user-images.githubusercontent.com/77088922/125191621-3f980b00-e1f8-11eb-8b3d-893cc19e0193.png)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/77088922/125191582-11b2c680-e1f8-11eb-8036-f4703d583ca6.png)
![image](https://user-images.githubusercontent.com/77088922/125191597-242d0000-e1f8-11eb-923a-e72c44576b41.png)


</details>

Please note that the original desktop font size for the `h1` is 40px whereas the design system heading class `title1` font size is 48px. This explains the discrepancies for the main title.
