### PR TITLE
Remove HackForLA newsletter sign-up form from home page

### DIFF
--- a/_includes/forms/contact-us.html
+++ b/_includes/forms/contact-us.html
@@ -2,16 +2,6 @@
 <section class="content-section">
   <!-- <h2 class="page-contain">Get in Touch</h2><br> -->
 
-  <div class="page-card card-secondary page-card-md page-card--home">
-    <h3>Sign up for our newsletter</h3>
-    <form class="hero-signup" name="Quick Signup Form">
-      <input id="hero-signup" class="form-input" type="email" name="email" placeholder="Enter your email address"
-        aria-label="Enter your email address" required />
-      <button id="hero-signup-btn" type="submit" class="btn btn-primary btn-md btn--home-subscribe">Subscribe</button>
-    </form>
-    <div class="form-confirmation"><strong></strong></div>
-  </div><br>
-
   <div class="page-card card-secondary page-card-md page-card--home page-card--home-volunteer">
     <h3>Volunteer with us</h3>
     <div class="row-1">


### PR DESCRIPTION
Fixes #1910

Removed the HackForLA newsletter sign-up form from the home page because no newsletters are currently being sent out. Copied the removed code and included it in issue #1934 for reference when sign-up form is to be re-implemented.

<details>
<summary>Visuals before changes are applied</summary>


<img width="757" alt="Screen Shot 2021-07-12 at 7 40 33 PM" src="https://user-images.githubusercontent.com/71858488/125392408-20be8380-e374-11eb-97c5-2ac107598df4.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="760" alt="Screen Shot 2021-07-12 at 9 48 08 PM" src="https://user-images.githubusercontent.com/71858488/125392452-30d66300-e374-11eb-89b5-b729dcf21f69.png">

</details>
