### PR TITLE
updated alt text of redo icon on credit page

### DIFF
--- a/_data/internal/credits/redo.yml
+++ b/_data/internal/credits/redo.yml
@@ -7,6 +7,6 @@ artist: Numero Uno
 provider: Noun Project
 provider-link: 'https://thenounproject.com/'
 image-url: /assets/images/getting-started/onboard-4.png
-alt: 'Image of Redo'
+alt: 'Redo Icon'
 type: icon
 ---


### PR DESCRIPTION
Fixes #1581 

### What changes did you make and why did you make them ?

-Changed alt text to 'Redo Icon' as instructed
- Saw changes on the github branch I created 
<img width="1546" alt="Screen Shot 2021-07-13 at 11 31 38 PM" src="https://user-images.githubusercontent.com/52294389/125574402-9b105bb3-e335-4ea6-b0fa-c6042e70c076.png">

-The screenshot shows the alt text is  '"Image" of Redo' which is different than the original text "Image of Redo". The quotation mark is at the end of "Image" not "Icon", which is totally different than my change ("Redo Icon").
-However, on my server, I didn't see the changes. I wonder what caused it. 
  
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
