### PR TITLE
updated employee icon title link

### DIFF
--- a/_data/internal/credits/employees.yml
+++ b/_data/internal/credits/employees.yml
@@ -1,6 +1,6 @@
 ---
 title: Employees
-title-link: https://thenounproject.com/
+title-link: https://thenounproject.com/search/?creator=1145943&q=employees&i=3201878
 content: Image
 used-in: About
 artist: Adrien Coquet


### PR DESCRIPTION
Fixes #1876
[<img width="1797" alt="Screen Shot 2021-07-15 at 3 27 42 PM" src="https://user-images.githubusercontent.com/52294389/125865936-4dc30587-e5ac-48ba-95e2-04a7aaa2a554.png">]([url](url))) 

### What changes did you make and why did you make them ?

  -updated the employee image title link as instructed 
 -the screenshot shows my local server correctly showing the correct link after 
-fixed annotation error for "Fixes#1876"
 
 

