### PR TITLE
fix header image width for mobile screens

### DIFF
--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -64,14 +64,14 @@
     width: auto;
     height: 240px;
 
-    @media #{$bp-below-desktop} {
+    @media #{$bp-below-tablet} {
       height: auto;
       max-width: 500px;
       width: 80%;
     }
 }
 
-@media(max-width: 850px) {
+@media(max-width: 960px) {
     .program-areas-header {
         flex-flow: column;
 

--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -66,7 +66,8 @@
 
     @media #{$bp-below-desktop} {
       height: auto;
-      max-width: 16rem;
+      max-width: 500px;
+      width: 80%;
     }
 }
 


### PR DESCRIPTION
Fixes #1596 

  - changed image "width" + "max-width" to match other pages - mobile screen only

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="423" alt="Screen Shot 2021-07-15 at 6 54 11 PM" src="https://user-images.githubusercontent.com/67209686/125879718-a55ba408-04ee-45ad-ab50-776e63b552fb.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="418" alt="Screen Shot 2021-07-15 at 6 54 59 PM" src="https://user-images.githubusercontent.com/67209686/125879768-b0b1964f-4724-49ef-9f3e-1d9c5247a709.png">


</details>
