### PR TITLE
Setting up GitHub Action for CSS and future linting

### DIFF
--- a/.github/workflows/lint-scss.yml
+++ b/.github/workflows/lint-scss.yml
@@ -1,12 +1,14 @@
-name: Lint Code Base
+name: Lint SCSS
 
 on:
   pull_request:
     branches: [gh-pages]
+  push:
+    branches: [gh-pages]
 
 jobs:
   build:
-    name: Lint Code Base
+    name: Lint SCSS
     runs-on: ubuntu-latest
 
     steps:
@@ -16,7 +18,7 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
-      - name: Lint Code Base
+      - name: Lint SCSS
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,29 @@
+name: Lint Code Base
+
+on:
+  pull_request:
+    branches: [gh-pages]
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: gh-pages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+          LINTER_RULES_PATH: /
+          CSS_FILE_NAME: .stylelintrc.json
+          VALIDATE_CSS: true

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,12 @@
     "color-no-invalid-hex": true,
     "unit-no-unknown": true,
     "property-no-unknown": true,
-    "declaration-block-no-duplicate-properties": true,
+    "declaration-block-no-duplicate-properties": [
+      true,
+      {
+        "ignore": ["consecutive-duplicates-with-different-values"]
+      }
+    ],
     "declaration-block-no-shorthand-property-overrides": true,
     "block-no-empty": true,
     "selector-pseudo-class-no-unknown": true,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,6 @@
 {
   "rules": {
     "color-no-invalid-hex": true,
-    "named-grid-areas-no-invalid": true,
     "unit-no-unknown": true,
     "property-no-unknown": true,
     "declaration-block-no-duplicate-properties": true,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,17 @@
+{
+  "rules": {
+    "color-no-invalid-hex": true,
+    "named-grid-areas-no-invalid": true,
+    "unit-no-unknown": true,
+    "property-no-unknown": true,
+    "declaration-block-no-duplicate-properties": true,
+    "declaration-block-no-shorthand-property-overrides": true,
+    "block-no-empty": true,
+    "selector-pseudo-class-no-unknown": true,
+    "selector-pseudo-element-no-unknown": true,
+    "selector-type-no-unknown": true,
+    "comment-no-empty": true,
+    "no-duplicate-selectors": true,
+    "no-extra-semicolons": true
+  }
+}


### PR DESCRIPTION
Fixes #1441 

### What changes did you make and why did you make them?
 - I created a new file in .github/workflows called linter.yml, to make a new GitHub action for the website repo to act as a code linter.
 - This specific issue is dealing with setting up CSS linting for our repo, but this same GitHub action can be used for JavaScript linting as well.
 - I also added a stylelintrc.json file in the root of the project which is a configuration file for the CSS linting rules we want the GitHub action to run.
 - Here is a link to a pull request I made on my forked repo showing the linting message for an example of what the messages will look like: https://github.com/averdin2/website/pull/1/checks?check_run_id=3032527940

### Resources Used
 - The specific resource I used for the GitHub action is called [SuperLinter](https://github.com/marketplace/actions/super-linter). It is an official GitHub action for linting code made by Github themselves.
 - A list of the stylelint rules (including the ones in the .stylelintrc.json file) can be found [here](https://stylelint.io/user-guide/rules/list/).

### Review Steps
1. Run the GitHub action on your own repo. To do so, you will need to make a pull request with changes to a SCSS file. You will also need to change the specified branch that the GitHub action checks in the linter.yml file on lines 5 and 23 to the branch you are making the test pull request. I recommend making an intentional linting error. The easiest way to do this is to make a duplicate class, but you can also test out one of the other errors (See .stylelintrc file for rules implemented, and [here](https://stylelint.io/user-guide/rules/list/) for list of rules and what they do).
2. Intentionally cause a linting failure from the GitHub action on a Pull Request. Then, fix the changes and commit and push your changes to the PR's branch. See if the GitHub action updates to show no errors.
3. Now, make another error and check if the GitHub action catches the errors (try this with a different file than step 2).
4. If everything works well, repeat the above steps, but on the website repo.

### Notes
 - In the linter.yml file, on line 22 the `VALIDATE_ALL_CODEBASE: false` means that the GitHub action only checks committed files to the repo. The reason why I am not checking the entire codebase is that I do not believe it is necessary to run a check on the entire codebase for every pull request. I made issue #1958 to deal with all the errors that are in the current codebase as a result of running `VALIDATE_ALL_CODEBASE: true`. I believe after fixing these issues, only checking the files in new pull requests should be sufficient for linting the codebase.
 - The types of rules I implemented are only those whose failure would likely result in actual style errors like not enacting the proper styles. I did not add any rules that limit features or require more strict enforcement of particular code formatting rules. If linting rules like these wanted to be added in the future, we can do this by adding rules to the .stylelintrc.json file.
 - To add linting for another language (like JavaScript), we can use the same GitHub action to do so. (See [here](https://github.com/github/super-linter/blob/master/docs/using-rules-files.md))


