### PR TITLE
Pull instructions restore

### DIFF
--- a/.github/workflows/pr-instructions.yml
+++ b/.github/workflows/pr-instructions.yml
@@ -1,0 +1,16 @@
+name: Add Pull Request Instructions
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  Add-Pull-Request-Instructions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            const script = require('./github-actions/pr-instructions/pr-instructions.js')
+            console.log(await script({g: github, c: context}))

--- a/.github/workflows/pr-instructions.yml
+++ b/.github/workflows/pr-instructions.yml
@@ -2,7 +2,7 @@ name: Add Pull Request Instructions
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, edited]
 
 jobs:
   Add-Pull-Request-Instructions:

--- a/github-actions/pr-instructions/pr-instructions-template.md
+++ b/github-actions/pr-instructions/pr-instructions-template.md
@@ -1,0 +1,7 @@
+<!-- Note: Commandline instructions are added into where the placeholder string first appears --->
+
+From your project repository, check out a new branch and test the changes.
+
+```
+${commandlineInstructions}
+```

--- a/github-actions/pr-instructions/pr-instructions.js
+++ b/github-actions/pr-instructions/pr-instructions.js
@@ -22,7 +22,7 @@ async function postComment() {
             issue_number: context.payload.number,
             body: body,
         });
-    } catch(err) {
+    } catch (err) {
         throw new Error(err);
     }
 
@@ -36,8 +36,22 @@ function createMessage() {
     const cloneURL = context.payload.pull_request.head.repo.clone_url;
 
     const instructionString =
-`git checkout -b ${nameOfCollaborator}-${nameOfFromBranch} ${nameOfIntoBranch}
+        `git checkout -b ${nameOfCollaborator}-${nameOfFromBranch} ${nameOfIntoBranch}
 git pull ${cloneURL} ${nameOfFromBranch}`
+
+
+    const path = './'
+    fs.readdir(path, function (err, files) {
+        //handling error
+        if (err) {
+            return console.log('Unable to scan directory: ' + err);
+        }
+        //listing all files using forEach
+        files.forEach(function (file) {
+            // Do whatever you want to do with the file
+            console.log(file);
+        });
+    });
 
     const text = fs.readFileSync("./github-actions/pr-instructions/pr-instructions-template.md.md").toString('utf-8');
     const completedInstuctions = text.replace('${commandlineInstructions}', instructionString)

--- a/github-actions/pr-instructions/pr-instructions.js
+++ b/github-actions/pr-instructions/pr-instructions.js
@@ -40,7 +40,7 @@ function createMessage() {
 git pull ${cloneURL} ${nameOfFromBranch}`
 
 
-    const path = './'
+    const path = './github-actions/pr-instructions'
     fs.readdir(path, function (err, files) {
         //handling error
         if (err) {

--- a/github-actions/pr-instructions/pr-instructions.js
+++ b/github-actions/pr-instructions/pr-instructions.js
@@ -40,20 +40,8 @@ function createMessage() {
 git pull ${cloneURL} ${nameOfFromBranch}`
 
 
-    const path = './github-actions/pr-instructions'
-    fs.readdir(path, function (err, files) {
-        //handling error
-        if (err) {
-            return console.log('Unable to scan directory: ' + err);
-        }
-        //listing all files using forEach
-        files.forEach(function (file) {
-            // Do whatever you want to do with the file
-            console.log(file);
-        });
-    });
-
-    const text = fs.readFileSync("./github-actions/pr-instructions/pr-instructions-template.md.md").toString('utf-8');
+    const path = './github-actions/pr-instructions/pr-instructions-template.md'
+    const text = fs.readFileSync(path).toString('utf-8');
     const completedInstuctions = text.replace('${commandlineInstructions}', instructionString)
 
     return completedInstuctions

--- a/github-actions/pr-instructions/pr-instructions.js
+++ b/github-actions/pr-instructions/pr-instructions.js
@@ -39,7 +39,7 @@ function createMessage() {
 `git checkout -b ${nameOfCollaborator}-${nameOfFromBranch} ${nameOfIntoBranch}
 git pull ${cloneURL} ${nameOfFromBranch}`
 
-    const text = fs.readFileSync("./pr-instructions-template.md").toString('utf-8');
+    const text = fs.readFileSync("./github-actions/pr-instructions/pr-instructions-template.md.md").toString('utf-8');
     const completedInstuctions = text.replace('${commandlineInstructions}', instructionString)
 
     return completedInstuctions

--- a/github-actions/pr-instructions/pr-instructions.js
+++ b/github-actions/pr-instructions/pr-instructions.js
@@ -1,0 +1,48 @@
+// Importing modules
+var fs = require("fs");
+
+// Global variables
+var github;
+var context;
+
+async function main({ g, c }) {
+    github = g;
+    context = c;
+    postComment();
+    return true;
+}
+
+async function postComment() {
+    const body = createMessage()
+    let results;
+    try {
+        results = await github.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.number,
+            body: body,
+        });
+    } catch(err) {
+        throw new Error(err);
+    }
+
+    console.log(JSON.stringify(results));
+}
+
+function createMessage() {
+    const nameOfCollaborator = context.payload.pull_request.head.repo.owner.login;
+    const nameOfFromBranch = context.payload.pull_request.head.ref;
+    const nameOfIntoBranch = context.payload.pull_request.base.ref;
+    const cloneURL = context.payload.pull_request.head.repo.clone_url;
+
+    const instructionString =
+`git checkout -b ${nameOfCollaborator}-${nameOfFromBranch} ${nameOfIntoBranch}
+git pull ${cloneURL} ${nameOfFromBranch}`
+
+    const text = fs.readFileSync("./pr-instructions-template.md").toString('utf-8');
+    const completedInstuctions = text.replace('${commandlineInstructions}', instructionString)
+
+    return completedInstuctions
+}
+
+module.exports = main


### PR DESCRIPTION
Removed linking

### What changes did you make and why did you make them ?

  - Created a GitHub action bot that posts the commandline instructions after a pull request is created.
  - Formatting of the instructions is done in an md file, for ease of edits.
  - Separated logic from the .github/workflow script into an external .js file for a neater structure.

### Tests to run

- [x] After merging, create a test pull request. The instructions should appear soon in a comment in the below format. If the tests fail, revert the merge.

<details>
<summary>Format</summary>
<br>

```
git checkout -b [nameOfCollaborator]-[nameOfFromBranch] [nameOfIntoBranch]
git pull https://github.com/[nameOfCollaborator]/website.git [nameOfFromBranch]
```

<br>
</details>

Note: Since the action uses ```pull_request``` as the trigger, there might be a need for either a token or an alternative ```workflow_run``` trigger.
