### PR TITLE
Wins Spacing, between text and badge icons #1551

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -56,6 +56,7 @@
     justify-content: start;
 }
 .wins-item-container{
+    margin-top: .8rem;
     display: inline-block;
     position: relative;
 }

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -56,7 +56,7 @@
     justify-content: start;
 }
 .wins-item-container{
-    margin-top: .8rem;
+    margin-top: .95rem;
     display: inline-block;
     position: relative;
 }

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -34,7 +34,7 @@
 
 .wins-card-text {
 	margin-top: 40px;
-	height: 88px;
+	max-height: 88px;
 	overflow: hidden;
 	position: relative;
     &.relative {
@@ -54,7 +54,7 @@
     flex-wrap: wrap;
     align-items: center;
     justify-content: start;
-    margin: 1em 0 0 6.5rem;
+    // margin: 1em 0 0 6.5rem;
 }
 .wins-item-container{
     display: inline-block;
@@ -254,7 +254,7 @@
     }
 
     .wins-card-text{
-        height: 81px;
+        max-height: 81px;
         position: inherit;
     }
 
@@ -283,7 +283,7 @@
 
 @media #{$bp-below-mobile} {
     .wins-card-text{
-        height: 80px;
+        max-height: 80px;
         margin-top: 16px;
     }
     .wins-card{
@@ -412,6 +412,7 @@
         display: none;
     }
     .expanded{
+        max-height: none;
         height: auto;
         .wins-see-more-div {
             z-index: 10;
@@ -449,7 +450,7 @@
         margin-left: 0em;
 
         .wins-icon-container{
-            margin: 1.5em 0 0 6.5rem;
+            // margin: 1.5em 0 0 6.5rem;
             display: block;
         }
         .wins-item-container{
@@ -483,9 +484,9 @@
 }
 
 @media #{$bp-below-mobile} {
-    .wins-icon-container{
-        margin-left: 3.5em
-    }
+    // .wins-icon-container{
+    //     // margin-left: 3.5em
+    // }
     .wins-tablet {
         .wins-item-container{
             margin-left: 0;

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -475,7 +475,6 @@
             display: flex;
             justify-content: start;
             align-items: start;
-            margin-left: 6.5em;
             margin-bottom: 1em;
         }
         .wins-badge-icon{

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -54,7 +54,6 @@
     flex-wrap: wrap;
     align-items: center;
     justify-content: start;
-    // margin: 1em 0 0 6.5rem;
 }
 .wins-item-container{
     display: inline-block;
@@ -450,7 +449,6 @@
         margin-left: 0em;
 
         .wins-icon-container{
-            // margin: 1.5em 0 0 6.5rem;
             display: block;
         }
         .wins-item-container{
@@ -484,9 +482,6 @@
 }
 
 @media #{$bp-below-mobile} {
-    // .wins-icon-container{
-    //     // margin-left: 3.5em
-    // }
     .wins-tablet {
         .wins-item-container{
             margin-left: 0;

--- a/pages/wins/wins-card-template.html
+++ b/pages/wins/wins-card-template.html
@@ -16,10 +16,13 @@
     </div>
     <div class="wins-card-bottom">
       <img class="wins-card-big-quote" />
-      <div class="project-inner wins-card-text">
-        <p class="wins-card-overview"></p>
-        <div class="wins-see-more-div">
-          <span id="0" onclick="seeMore(id)" expandable class="see-more-div">...see more</span>
+      <div class="wins-card-info-container">
+        <div class="project-inner wins-card-text">
+          <p class="wins-card-overview"></p>
+          <div class="wins-see-more-div">
+            <span id="0" onclick="seeMore(id)" expandable class="see-more-div">...see more</span>
+          </div>
+          <!-- <div class="wins-icon-container" id="icons-0"></div> -->
         </div>
         <div class="wins-icon-container" id="icons-0"></div>
       </div>

--- a/pages/wins/wins-card-template.html
+++ b/pages/wins/wins-card-template.html
@@ -24,8 +24,8 @@
             <span id="0" onclick="seeMore(id)" expandable class="see-more-div">...see more</span>
           </div>
         </div>
+        <div class="wins-icon-container"></div>
       </div>
     </div>
-    <div class="wins-icon-container"></div>
   </li>
 </template>


### PR DESCRIPTION
Fixes #1551 

### What changes did you make and why did you make them ?

  - remove extra spacing between the wins-text and wins-badge icons, as it was inconsistent between wins cards
  - refer to Danielle's screenshots in #1551 

### Screenshots of Proposed Changes Of The Website 

<details>
<summary>Visuals before changes are applied</summary>

<img width="938" alt="Screen Shot 2021-07-17 at 1 33 02 PM" src="https://user-images.githubusercontent.com/67438372/126048751-7c18c992-f28b-4320-acc9-c2239d64ff82.png">

<img width="362" alt="Screen Shot 2021-07-17 at 1 32 55 PM" src="https://user-images.githubusercontent.com/67438372/126048753-fc252753-a190-403d-8f89-b61e37629a43.png">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1295" alt="Screen Shot 2021-07-17 at 1 31 35 PM" src="https://user-images.githubusercontent.com/67438372/126048720-70e86624-6b38-4fb5-959f-db2bb02ac288.png">

<img width="356" alt="Screen Shot 2021-07-17 at 1 31 47 PM" src="https://user-images.githubusercontent.com/67438372/126048722-417d5d42-a284-44e9-9642-4a6e8d6cae40.png">


</details>
