### PR TITLE
Fix CoP page header image size

### DIFF
--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -14,11 +14,11 @@ permalink: /communities-of-practice
             If you'd like to join one of the Communities of Practice that has a regular meeting time, join their Slack channel and look for the meeting details, usually pinned or in the description. Otherwise, see the "How to get started" sections below.
         </p>
             <div class="header-self-invite--communities">
-                <object data="/assets/images/communities-of-practice/slack-self-invite.svg" type="image/svg+xml" class="self-invite-img" /></object>
+                <img class="self-invite-img" src="/assets/images/communities-of-practice/slack-self-invite.svg" alt="slack icon" />
                 <p class="alert--communities">To join the Slack channels below, you first need to be a member of our Hack for LA Slack Community – you can self-invite <a href="https://hackforla-slack.herokuapp.com" target="_blank">here</a>.
             </p></div>
     </div>
-    <object data="/assets/images/communities-of-practice/comm-prac-header.svg" type="image/svg+xml" class="header-img--communities" /> </object>
+    <img class="header-img--communities" src="/assets/images/communities-of-practice/comm-prac-header.svg" alt="commmunity of practice header" />
 </section>
 <section class="content-section content--communities">
     {% assign sorted_communities = site.data.internal.communities | sort %}


### PR DESCRIPTION
Fixes #1793 

Looks like the issue occurs only on chrome and edge. Firefox did not have the issue. If you just keep on refreshing on chrome or edge, the image would randomly become smaller or the normal size. Firefox would stay the same on each render.

There are two possible solutions for the issue (as mentioned in my comment in 1793). I went with option 2 since no other pages are using object tags for SVGs, and this keeps me from messing with the CSS and other possible media query adjustments.

### What changes did you make and why did you make them ?

  - Changed the object tag to img tag for the community of practice header image to fix the sizing issue + be consistent across the site
  - Changed the object tag to img tag for the slack icon to be consistent with the above + rest of the site

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>CoP header image before</summary>

![before-fix](https://user-images.githubusercontent.com/48004150/126408942-66db0b1c-fcd8-47bb-a47d-26a7a337b805.gif)


</details>

<details>
<summary>CoP header image after</summary>
  
![after-fix](https://user-images.githubusercontent.com/48004150/126408957-3407b688-0c81-4f9c-b10c-15ab48455e34.gif)


</details>

<details>
<summary> Image responsiveness after fix</summary>

![responsiveness](https://user-images.githubusercontent.com/48004150/126409094-2d799b06-d51e-4dc7-95b5-9f4b8afb13ab.gif)


</details>



<details>
<summary> Full page after fix</summary>

![chrome-full-after-fix](https://user-images.githubusercontent.com/48004150/126409125-e94c302d-0e93-4be0-ab83-4d1302434e6d.png)



</details>