### PR TITLE
Change alt text for Business Image on Credit Page

### DIFF
--- a/_data/internal/credits/business.yml
+++ b/_data/internal/credits/business.yml
@@ -7,6 +7,6 @@ artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/getting-started/step1.png
-alt: 'Image of Business'
+alt: 'One-on-one video conference concept illustration'
 type: icon
 ---

--- a/pages/credits.html
+++ b/pages/credits.html
@@ -24,7 +24,7 @@ permalink: /credits/
                           <!-- originally class="project-card-inner" -->
                         <div class="credits-item">
                           <div class="icon-left">
-                            <img src={{ item[1].image-url | absolute_url }} alt={{item[1].alt}}/>
+                            <img src={{ item[1].image-url | absolute_url }} alt="{{item[1].alt}}"/>
                           </div>
                           <div class="icon-info">
                             {%- if item[1].title -%}

--- a/pages/credits.html
+++ b/pages/credits.html
@@ -24,7 +24,7 @@ permalink: /credits/
                           <!-- originally class="project-card-inner" -->
                         <div class="credits-item">
                           <div class="icon-left">
-                            <img src={{ item[1].image-url | absolute_url }} alt="{{item[1].alt}}"/>
+                            <img src={{ item[1].image-url | absolute_url }} alt={{item[1].alt}}/>
                           </div>
                           <div class="icon-info">
                             {%- if item[1].title -%}


### PR DESCRIPTION
Fixes #1561

### What changes did you make and why did you make them ?

  -  Changes the alt attribute value in business.yml to 'One-on-one video conference concept illustration'

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Alt text before</summary>
<br>
<img width="520" alt="Screen Shot 2021-07-26 at 11 22 41 AM" src="https://user-images.githubusercontent.com/62186905/127039197-dedc2796-8d42-4a19-9d24-e99dc79604b8.png">
</details>
<details>
<summary>Alt text after</summary>
<br>
<img width="520" alt="Screen Shot 2021-07-26 at 11 19 50 AM" src="https://user-images.githubusercontent.com/62186905/127038932-2c7d6db4-d573-4f2c-9e58-f62614618ae0.png">
</details>