### PR TITLE
fixed-page-and-leader-pages

### DIFF
--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -112,7 +112,7 @@
     object-fit: cover;
   
     @media #{$bp-below-tablet} {
-      height: auto;
+      height: 231px;
     /*  width: 100%;
       max-height: 40vh;
       overflow: hidden;*/

--- a/_sass/components/_project-page.scss
+++ b/_sass/components/_project-page.scss
@@ -331,7 +331,7 @@
     min-width: 70%;
     display: flex;
     flex-direction: column;
-    width: 70%;
+    
     justify-content: center;
     align-content: center;
     align-items: flex-start;

--- a/_sass/components/_project-page.scss
+++ b/_sass/components/_project-page.scss
@@ -331,7 +331,6 @@
     min-width: 70%;
     display: flex;
     flex-direction: column;
-    
     justify-content: center;
     align-content: center;
     align-items: flex-start;


### PR DESCRIPTION
Fixes #1919 

### What changes did you make and why did you make them ?

  - I deleted line: "width: 70%;" in "_sass/components/_projects-page.scss/leader-description/{} @media #{$bp-below-mobile}" because it caused the wrap around of the leader page names.
  - With Bonnie, I changed height of page cards of UI/UX and Ops to make sure they match the height of the rest on "_sass/components/_projects-page.scss/.leader-img--communities"
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Before:

![Screen Shot 2021-07-23 at 9 21 17 PM](https://user-images.githubusercontent.com/86503503/126857140-22189a2f-ffa6-41fc-b3bf-54d1df691e89.png)
![Screen Shot 2021-07-23 at 9 21 05 PM](https://user-images.githubusercontent.com/86503503/126857049-eae5c525-7a83-46fd-94ea-6ae1d3173710.png)
![Screen Shot 2021-07-23 at 9 20 59 PM](https://user-images.githubusercontent.com/86503503/126857050-4eafc88b-230d-480f-8612-655a367ec81f.png)
![Screen Shot 2021-07-23 at 9 20 50 PM](https://user-images.githubusercontent.com/86503503/126857052-f80c5f3c-1b1d-4cc3-906a-29d27416bec6.png)
![Screen Shot 2021-07-23 at 9 20 42 PM](https://user-images.githubusercontent.com/86503503/126857054-1f3f898e-0f6f-4555-8bad-716e47d9d0c9.png)
![Screen Shot 2021-07-23 at 9 21 10 PM](https://user-images.githubusercontent.com/86503503/126857048-7676cafc-66fe-4510-a085-899d33dfa76e.png)




After:

![Screen Shot 2021-07-23 at 9 15 24 PM](https://user-images.githubusercontent.com/86503503/126856927-327e9e8d-8180-41b7-8745-ed1c5b4e743c.png)
![Screen Shot 2021-07-23 at 9 15 16 PM](https://user-images.githubusercontent.com/86503503/126856931-85cd12e9-f7ae-4ccd-b5e2-be398be489f3.png)
![Screen Shot 2021-07-23 at 9 15 06 PM](https://user-images.githubusercontent.com/86503503/126856933-ba394c0c-771f-4a4e-8590-5650719cd4db.png)
![Screen Shot 2021-07-23 at 9 14 47 PM](https://user-images.githubusercontent.com/86503503/126856934-98c84c00-af9d-47f5-a8cc-ad3320ef4638.png)
![Screen Shot 2021-07-23 at 9 17 59 PM](https://user-images.githubusercontent.com/86503503/126856968-3736c4bf-2efd-4f5a-80c5-68c738cc863d.png)
