### PR TITLE
Fix alignment news section about page 1498

### DIFF
--- a/_data/internal/credits/employees.yml
+++ b/_data/internal/credits/employees.yml
@@ -1,6 +1,6 @@
 ---
 title: Employees
-title-link: https://thenounproject.com/
+title-link: https://thenounproject.com/search/?creator=1145943&q=employees&i=3201878
 content: Image
 used-in: About
 artist: Adrien Coquet

--- a/_data/internal/credits/employees.yml
+++ b/_data/internal/credits/employees.yml
@@ -1,6 +1,6 @@
 ---
 title: Employees
-title-link: https://thenounproject.com/search/?creator=1145943&q=employees&i=3201878
+title-link: https://thenounproject.com/
 content: Image
 used-in: About
 artist: Adrien Coquet

--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -587,18 +587,11 @@ a.anchor {
   
 }
 
-// .more-padding {
-//   padding-top: 40px;
-//   margin: 0 20px 0 20px;
-//   padding-bottom: 10px;
-// }
-
 .news-images {
   height: 150px;
   width: 150px;
   object-fit:contain;
 }
-
 
 .news-cells p {
   padding-top: 40px;

--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -580,25 +580,34 @@ a.anchor {
 
 .news-cells {
   display: flex;
-  // flex-flow: column nowrap;
   flex-direction: column;
   justify-content: center;
+  align-items: flex-start;
   padding: 25px 0 15px 0;
-  align-items: center;
+  
+}
+
+// .more-padding {
+//   padding-top: 40px;
+//   margin: 0 20px 0 20px;
+//   padding-bottom: 10px;
+// }
+
+.news-images {
+  height: 150px;
+  width: 150px;
+  object-fit:contain;
+}
+
+
+.news-cells p {
+  padding-top: 40px;
+  margin: 0 20px 0 20px;
 }
 
 .more-padding {
-  padding-top: 40px;
-  margin: 0 20px 0 20px;
-  padding-bottom: 10px;
+  padding-top: 10px;
 }
-
-.news-images {
-  height: 100px;
-  width: 70%;
-  object-fit: contain;
-}
-
 
 /* Below are the breakpoints and adjustments for different size monitors */
 
@@ -617,6 +626,10 @@ a.anchor {
   .page-content-container-grid {
     margin-top: 0; 
   }
+  .news-cells {
+    align-items: center;
+  }
+  
 } // End below tablet
 
 // Bigger than mobile - 480px
@@ -626,6 +639,9 @@ a.anchor {
 
 // Bigger than tablet - 768px
 @media #{$bp-tablet-up} {
+  .news-cells {
+    align-items: center;
+  }
 
 }
 
@@ -969,4 +985,5 @@ a.anchor {
   .sticky-nav-content-container {
     margin-left: 0px;
   }
+   
 }

--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -580,20 +580,25 @@ a.anchor {
 
 .news-cells {
   display: flex;
-  flex-flow: column nowrap;
+  // flex-flow: column nowrap;
+  flex-direction: column;
   justify-content: center;
   padding: 25px 0 15px 0;
   align-items: center;
 }
 
-.news-cells p {
+.more-padding {
   padding-top: 40px;
   margin: 0 20px 0 20px;
+  padding-bottom: 10px;
 }
 
-.more-padding {
-  padding-top: 10px;
+.news-images {
+  height: 100px;
+  width: 70%;
+  object-fit: contain;
 }
+
 
 /* Below are the breakpoints and adjustments for different size monitors */
 

--- a/pages/about/about-card-news.html
+++ b/pages/about/about-card-news.html
@@ -4,7 +4,7 @@
         <div class="flex-container">
             {% for item in site.data.internal.press %}
                 <div class="news-cells">
-                    <img src="{{item[1].image}}" alt="{{item[1].image_alt}}" />
+                    <img class="news-images" src="{{item[1].image}}" alt="{{item[1].image_alt}}" />
                     <p class="more-padding"><a href="{{item[1].link_url}}" target="_blank" rel="noopener noreferrer">{{item[1].title}}</a></p>
                 </div>
             {% endfor %}


### PR DESCRIPTION
Fixes #1498 

### What changes did you make and why did you make them ?

  -added a class for news images to make it easier to resize and have the same height
  -for the news-cells class, commented out column nowrap property as it didn't do anything 
  -for the more-padding class, added a padding-bottom to align paragraphs better

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->
<img width="891" alt="Screen Shot 2021-07-25 at 12 17 05 AM" src="https://user-images.githubusercontent.com/52294389/127034183-05da585a-461c-4bf0-a481-fa84bba808eb.png">


<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)
<img width="793" alt="Screen Shot 2021-07-26 at 11 10 34 PM" src="https://user-images.githubusercontent.com/52294389/127104645-368bf0b9-e51e-4d64-9443-9d80778ca6e2.png">


</details>
I had trouble lining up paragraphs so all three are at the same level horizontally (top baseline). I would handle it better if the images and paragraphs are not dynamic. I'm continuing searching for the better solution to align paragraphs perfectly. But as for now, I'd like to submit my draft for comments and feedback.
<details>

