### PR TITLE
New color variables

### DIFF
--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -547,7 +547,7 @@
 /* The below styles were moved from _hack-nights.scss, which has been deleted along with it's page namesake. 
     They have been saved because they are still being used in other places on the site. */
     .section-hack-nights {
-      background: $color-blue-dark;
+      background: $color-darkblue;
       color: $color-white;
     }
 
@@ -561,7 +561,7 @@ or overriding .content-section. See Issue #1609. If this comment is no longer re
 }
 
 .events-page, .content-section--events {
-  background: $color-blue-dark;
+  background: $color-darkblue;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -1,5 +1,5 @@
 .main-footer {
-  background: $color-blue-dark;
+  background: $color-darkblue;
   color: $color-white;
   padding: 42px 25px 20px;
 

--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -14,7 +14,7 @@
 }
 
 .getting-started-page {
-  background: $color-blue-dark;
+  background: $color-darkblue;
   min-height: 100vh;
   display: flex;
   flex-direction: column;

--- a/_sass/components/_guide-pages.scss
+++ b/_sass/components/_guide-pages.scss
@@ -20,8 +20,8 @@
       right: 0;
       background: linear-gradient(
         to bottom,
-        rgba($color-blue-dark, 0.3) 0%,
-        rgba($color-blue-dark, 1) 100%
+        rgba($color-darkblue, 0.3) 0%,
+        rgba($color-darkblue, 1) 100%
       );
       content: "";
       display: block;
@@ -30,8 +30,8 @@
       @media #{$bp-tablet-up} {
         background: linear-gradient(
           to bottom,
-          rgba($color-blue-dark, 0) 30%,
-          rgba($color-blue-dark, 1) 100%
+          rgba($color-darkblue, 0) 30%,
+          rgba($color-darkblue, 1) 100%
         );
         opacity: 1;
       }

--- a/_sass/components/_home.scss
+++ b/_sass/components/_home.scss
@@ -61,7 +61,7 @@
 
 //hero************************************************************************************************** 
 .hero {
-  background: $color-blue-dark url($absolute_url + "/assets/images/hero/hacknight-women.jpg") center
+  background: $color-darkblue url($absolute_url + "/assets/images/hero/hacknight-women.jpg") center
     center no-repeat;
   background-size: cover;
   display: flex;
@@ -85,8 +85,8 @@
     right: 0;
     background: linear-gradient(
       to bottom,
-      rgba($color-blue-dark, 0.3) 0%,
-      rgba($color-blue-dark, 1) 100%
+      rgba($color-darkblue, 0.3) 0%,
+      rgba($color-darkblue, 1) 100%
     );
     content: "";
     display: block;
@@ -95,8 +95,8 @@
     @media #{$bp-tablet-up} {
       background: linear-gradient(
         to bottom,
-        rgba($color-blue-dark, 0) 30%,
-        rgba($color-blue-dark, 1) 100%
+        rgba($color-darkblue, 0) 30%,
+        rgba($color-darkblue, 1) 100%
       );
       opacity: 1;
     }
@@ -180,7 +180,7 @@
 }
 .cal-item {
   background: $color-white;
-  border-top: 1px solid $color-grey-med;
+  border-top: 1px solid $color-mediumgrey;
   color: $color-black;
   margin: 0;
   padding: 10px;

--- a/_sass/components/_project-page.scss
+++ b/_sass/components/_project-page.scss
@@ -20,8 +20,8 @@
     right: 0;
     background: linear-gradient(
       to bottom,
-      rgba($color-blue-dark, 0.3) 0%,
-      rgba($color-blue-dark, 1) 100%
+      rgba($color-darkblue, 0.3) 0%,
+      rgba($color-darkblue, 1) 100%
     );
     content: "";
     display: block;
@@ -30,8 +30,8 @@
     @media #{$bp-tablet-up} {
       background: linear-gradient(
         to bottom,
-        rgba($color-blue-dark, 0) 30%,
-        rgba($color-blue-dark, 1) 100%
+        rgba($color-darkblue, 0) 30%,
+        rgba($color-darkblue, 1) 100%
       );
       opacity: 1;
     }

--- a/_sass/components/_wins-form.scss
+++ b/_sass/components/_wins-form.scss
@@ -73,7 +73,7 @@
   .form-control:focus {
     outline: none;
     border-bottom: 2px solid $color-blue; //need to change color
-    background-color: $color-lightgrey;
+    background-color: $color-lightergrey;
   }
   .container-fluid {
     width: 100%;

--- a/_sass/components/_wins-form.scss
+++ b/_sass/components/_wins-form.scss
@@ -73,7 +73,7 @@
   .form-control:focus {
     outline: none;
     border-bottom: 2px solid $color-blue; //need to change color
-    background-color: $color-lightergrey;
+    background-color: $color-whitesmoke;
   }
   .container-fluid {
     width: 100%;

--- a/_sass/components/_wins-form.scss
+++ b/_sass/components/_wins-form.scss
@@ -2,7 +2,7 @@
   min-height: calc(100vh - 223px);
   display: flex;
   align-items: center;
-  background: $color-blue-dark;
+  background: $color-darkblue;
   .wins-form-title {
     font-size: 35px;
     font-weight: 400;
@@ -73,7 +73,7 @@
   .form-control:focus {
     outline: none;
     border-bottom: 2px solid $color-blue; //need to change color
-    background-color: $color-grey-light;
+    background-color: $color-lightgrey;
   }
   .container-fluid {
     width: 100%;

--- a/_sass/elements/_color-styles.scss
+++ b/_sass/elements/_color-styles.scss
@@ -54,5 +54,5 @@
 .color-mediumgrey { color: $color-mediumgrey; }
 .color-lightgrey { color: $color-lightgrey; }
 .color-pink { color: $color-pink; }
-.color-lightgrey { color: $color-lightgrey; }
+.color-lightergrey { color: $color-lightergrey; }
 .color-white { color: $color-white; }

--- a/_sass/elements/_color-styles.scss
+++ b/_sass/elements/_color-styles.scss
@@ -1,36 +1,58 @@
-.color-dodgerblue {
-    color: $color-dodgerblue; 
-}
+/**
+ * Colors
+ */
 
-.color-lightseagreen {
-    color: $color-lightseagreen;
-}
+// Reds
+.color-red { color: $color-red; }
+.color-firebrick { color: $color-firebrick; }
+.color-mediumvioletred { color: $color-mediumvioletred; }
+.color-deeppink { color: $color-deeppink; }
+.color-orangered { color: $color-orangered; }
+.color-salmon { color: $color-salmon; }
 
-.color-orange {
-    color: $color-orange;
-}
+// Oranges
+.color-chocolate { color: $color-chocolate; }
+.color-lightorange { color: $color-lightorange; }
+.color-orange { color: $color-orange; }
+.color-gold { color: $color-gold; }
 
-.color-chocolate {
-    color: $color-chocolate; 
-}
+// Yellows
+.color-mustard { color: $color-mustard; }
+.color-lightyellow { color: $color-lightyellow; }
+.color-papayawhip { color: $color-papayawhip; }
 
-.color-firebrick {
-    color: $color-firebrick; 
-}
+// Greens
+.color-forestgreen { color: $color-forestgreen; }
+.color-darkolive { color: $color-darkolive; }
+.color-teal { color: $color-teal; }
+.color-lightseagreen { color: $color-lightseagreen; }
+.color-lightgreen { color: $color-lightgreen; }
 
-.color-deeppink {
-    color: $color-deeppink;
-}
+// Blues
+.color-midnightblue { color: $color-midnightblue; }
+.color-darkroyalblue { color: $color-darkroyalblue; }
+.color-blue { color: $color-blue; }
+.color-royalblue { color: $color-royalblue; }
+.color-brightblue { color: $color-brightblue; }
+.color-azure { color: $color-azure; }
+.color-dodgerblue { color: $color-dodgerblue; }
+.color-babyblue { color: $color-babyblue; }
+.color-skyblue { color: $color-skyblue; }
 
-.color-mediumvioletred {
-    color: $color-mediumvioletred; 
-}
+// Violets
+.color-blueviolet { color: $color-blueviolet; }
+.color-redpurple { color: $color-redpurple; }
+.color-darkorchid { color: $color-darkorchid; }
 
-.color-darkorchid {
-    color: $color-darkorchid; 
-}
+// Browns
 
-.color-blueviolet {
-    color: $color-blueviolet; 
-}
-
+// Blacks, Greys, White
+.color-black { color: $color-black; }
+.color-darkblue { color: $color-darkblue; }
+.color-darkgrey { color: $color-darkgrey; }
+.color-cement { color: $color-cement; }
+.color-mediumgrey { color: $color-mediumgrey; }
+.color-lightgrey { color: $color-lightgrey; }
+.color-pink { color: $color-pink; }
+.color-lightgrey { color: $color-lightgrey; }
+.color-white { color: $color-white; }

--- a/_sass/elements/_color-styles.scss
+++ b/_sass/elements/_color-styles.scss
@@ -54,5 +54,5 @@
 .color-mediumgrey { color: $color-mediumgrey; }
 .color-lightgrey { color: $color-lightgrey; }
 .color-pink { color: $color-pink; }
-.color-lightergrey { color: $color-lightergrey; }
+.color-whitesmoke { color: $color-whitesmoke; }
 .color-white { color: $color-white; }

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -54,5 +54,5 @@ $color-cement: #767676;
 $color-mediumgrey: #ccc;
 $color-lightgrey: #ededed;
 $color-pink: #f7f5f5;
-$color-lightergrey: #f6f6f6;
+$color-whitesmoke: #f6f6f6;
 $color-white: #fff;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -29,7 +29,8 @@ $color-lightseagreen: #0DC583;
 $color-lightgreen: #bbffbb;
 
 // Blues
-$color-dark-royalblue: #01548a;
+$color-midnightblue: #173567;
+$color-darkroyalblue: #01548a;
 $color-blue: #046afa;
 $color-royalblue: #4169e1;
 $color-brightblue: #0000ff;
@@ -40,19 +41,18 @@ $color-skyblue: #89cff0;
 
 // Violets
 $color-blueviolet: #571DD1;
+$color-redpurple: #8e1737;
 $color-darkorchid: #981DD1;
 
 // Browns
-$color-redpurple: #8e1737;
 
 // Blacks, Greys, White
 $color-black: #333;
-$color-blue-dark: #030d2d;
+$color-darkblue: #030d2d;
 $color-darkgrey: #464646;
-$color-midnightblue: #173567;
 $color-cement: #767676;
-$color-grey-med: #ccc;
+$color-mediumgrey: #ccc;
 $color-lightgrey: #ededed;
 $color-pink: #f7f5f5;
-$color-grey-light: #f6f6f6;
+$color-lightgrey: #f6f6f6;
 $color-white: #fff;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -54,5 +54,5 @@ $color-cement: #767676;
 $color-mediumgrey: #ccc;
 $color-lightgrey: #ededed;
 $color-pink: #f7f5f5;
-$color-lightgrey: #f6f6f6;
+$color-lightergrey: #f6f6f6;
 $color-white: #fff;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -1,44 +1,58 @@
 /**
  * Colors
  */
-$color-black: #333;
-$color-blue: #046afa;
-$color-blue-dark: #030d2d;
+
+// Reds
 $color-red: #fa114f;
-$color-teal: #32ddb1;
-$color-white: #fff;
+$color-firebrick: #D7261B;
+$color-mediumvioletred: #D11D69; 
+$color-deeppink: #FA207C;
+$color-orangered: #ee412a;
+$color-salmon: #ffadad;
 
-$color-grey-light: #f6f6f6;
-$color-grey-med: #ccc;
-$color-papayawhip: #ffefd5;
-$color-royalblue: #4169e1;
-$color-pink: #f7f5f5;
-
-$color-dodgerblue: #1587FF;
-$color-lightseagreen: #0DC583;  
+// Oranges
+$color-chocolate: #F16618;
+$color-lightorange: #fa9c25;
 $color-orange: #F9B400;
 $color-gold: #F2C94D;
-$color-chocolate: #F16618;
-$color-firebrick: #D7261B;
-$color-deeppink: #FA207C;
-$color-mediumvioletred: #D11D69; 
-$color-darkorchid: #981DD1;
-$color-blueviolet: #571DD1;
-$color-lightyellow: #ffff97;
-$color-lightgreen: #bbffbb;
-$color-babyblue: #a4d5ff;
-$color-salmon: #ffadad;
-$color-darkgrey: #464646;
-$color-skyblue: #89cff0;
-$color-brightblue: #0000ff;
-$color-lightgrey: #ededed;
+
+// Yellows
 $color-mustard: #d49f28;
-$color-orangered: #ee412a;
-$color-redpurple: #8e1737;
-$color-lightorange: #fa9c25;
+$color-lightyellow: #ffff97;
+$color-papayawhip: #ffefd5;
+
+// Greens
+$color-forestgreen: #58915b;
 $color-darkolive: #48763e;
+$color-teal: #32ddb1;
+$color-lightseagreen: #0DC583;
+$color-lightgreen: #bbffbb;
+
+// Blues
 $color-dark-royalblue: #01548a;
+$color-blue: #046afa;
+$color-royalblue: #4169e1;
+$color-brightblue: #0000ff;
+$color-azure: #407BFF;
+$color-dodgerblue: #1587FF;
+$color-babyblue: #a4d5ff;
+$color-skyblue: #89cff0;
+
+// Violets
+$color-blueviolet: #571DD1;
+$color-darkorchid: #981DD1;
+
+// Browns
+$color-redpurple: #8e1737;
+
+// Blacks, Greys, White
+$color-black: #333;
+$color-blue-dark: #030d2d;
+$color-darkgrey: #464646;
 $color-midnightblue: #173567;
 $color-cement: #767676;
-$color-forestgreen: #58915b;
-$color-azure: #407BFF; 
+$color-grey-med: #ccc;
+$color-lightgrey: #ededed;
+$color-pink: #f7f5f5;
+$color-grey-light: #f6f6f6;
+$color-white: #fff;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -24,5 +24,21 @@ $color-deeppink: #FA207C;
 $color-mediumvioletred: #D11D69; 
 $color-darkorchid: #981DD1;
 $color-blueviolet: #571DD1;
-
-
+$color-lightyellow: #ffff97;
+$color-lightgreen: #bbffbb;
+$color-babyblue: #a4d5ff;
+$color-salmon: #ffadad;
+$color-darkgrey: #464646;
+$color-skyblue: #89cff0;
+$color-brightblue: #0000ff;
+$color-lightgrey: #ededed;
+$color-mustard: #d49f28;
+$color-orangered: #ee412a;
+$color-redpurple: #8e1737;
+$color-lightorange: #fa9c25;
+$color-darkolive: #48763e;
+$color-dark-royalblue: #01548a;
+$color-midnightblue: #173567;
+$color-cement: #767676;
+$color-forestgreen: #58915b;
+$color-azure: #407BFF; 


### PR DESCRIPTION
Partially Fixes #1378

### What changes did you make and why did you make them ?

  - Salvaged the usable code from #1917 
  - Grouped color variables according to Western (?) color sequencing

### TODO after merging

Note: I have decided that the original issue is too large to be considered a medium issue. When testing the code from #1917, the website breaks in many areas (because of the order our scss is being read). To account for this, we must transition to color variables at a slower pace.

- [x] Create new issues pertaining to auditing the website for hard-coded colors, and changing them into one of the variables in this fork.
  - [x] 1 issue for reds and oranges (medium)
  - [x] 1 issue for yellows and greens (medium)
  - [x] 1 issue for blue and purples (medium)
  - [x] 1 issue for the rest (medium)
  - [x] 1 follow-up audit for any remaining hard-coded colors (medium/large) 
  - [x] Note: If any of the variables in this PR is not found elsewhere in our codebase, they should be deleted by the assignee of the above issues.

