### PR TITLE
updated the access the data profile section

### DIFF
--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -14,7 +14,7 @@ leadership:
     role: Agile Coach
     links:
       slack: 'https://hackforla.slack.com/team/UE1UG1YFP'
-      linkedin: 'https://linkedin.com/linkedin-username'
+      github: 'https://github.com/experimentsinhonesty'
     picture: https://avatars.githubusercontent.com/experimentsinhonesty
   - name: Sarah Nabelsi
     role: Project Manager
@@ -26,31 +26,31 @@ leadership:
     role: Product Manager
     links:
       slack: 'https://hackforla.slack.com/team/U025WJ8CHFC'
-      linkedin: 'https://linkedin.com/linkedin-username'
+      github: 'https://github.com/lrchang2'
     picture: https://avatars.githubusercontent.com/lrchang2
   - name: Alyssa Bryant
     role: Product Manager
     links:
       slack: 'https://hackforla.slack.com/team/U026DETL43B'
-      linkedin: 'https://linkedin.com/linkedin-username'
+      github: 'https://github.com/abryant35'
     picture: https://avatars.githubusercontent.com/abryant35
   - name: Jeremy DeCarvalho
     role: Data Analyst
     links:
       slack: 'https://hackforla.slack.com/team/UFDG06RJQ'
-      linkedin: 'https://linkedin.com/linkedin-username'
+      github: 'https://github.com/Jeremy-D'
     picture: https://avatars.githubusercontent.com/Jeremy-D
   - name: Assel Abilova
     role: UX/UI Designer
     links:
       slack: 'https://hackforla.slack.com/team/U026G6WV49K'
-      linkedin: 'https://linkedin.com/linkedin-username'
+      github: 'https://github.com/asselabilova'
     picture: https://avatars.githubusercontent.com/asselabilova
   - name: Malak Hmimy
     role: Data Analyst
     links:
       slack: 'https://hackforla.slack.com/team/U01TL5WE7G8'
-      linkedin: 'https://linkedin.com/linkedin-username'
+      github: 'https://github.com/MalakH21'
     picture: https://avatars.githubusercontent.com/MalakH21
 links: 
   - name: Github

--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -75,8 +75,6 @@ looking:
   - category: Data
     skill: Data (research, topic identification, and workshop material development)
   - category: UI/UX
-    skill: UX Lead to build surveys  
-  - category: UI/UX
     skill: Instructional Designer
   - category: UI/UX
     skill: Logo and Design System

--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -10,18 +10,48 @@ alt: 'description of the card image'
 image-hero: /assets/images/projects/access-the-data-hero.png
 alt-hero: 'description of the hero image'
 leadership:
-  - name: Sarah Nabelsi
-    role: Product Manager
-    links:
-      slack: 'https://hackforla.slack.com/team/U01J9V1H63F'
-      github: 'https://github.com/snooravi'
-    picture: https://avatars.githubusercontent.com/snooravi
   - name: Bonnie Wolfe
     role: Agile Coach
     links:
       slack: 'https://hackforla.slack.com/team/UE1UG1YFP'
       linkedin: 'https://linkedin.com/linkedin-username'
     picture: https://avatars.githubusercontent.com/experimentsinhonesty
+  - name: Sarah Nabelsi
+    role: Product Manager
+    links:
+      slack: 'https://hackforla.slack.com/team/U01J9V1H63F'
+      github: 'https://github.com/snooravi'
+    picture: https://avatars.githubusercontent.com/snooravi
+  - name: Lucy Chang
+    role: Product Manager
+    links:
+      slack: 'https://hackforla.slack.com/team/U025WJ8CHFC'
+      linkedin: 'https://linkedin.com/linkedin-username'
+    picture: https://avatars.githubusercontent.com/lrchang2
+  - name: Alyssa Bryant
+    role: Product Manager
+    links:
+      slack: 'https://hackforla.slack.com/team/U026DETL43B'
+      linkedin: 'https://linkedin.com/linkedin-username'
+    picture: https://avatars.githubusercontent.com/abryant35
+  - name: Jeremy DeCarvalho
+    role: Data Analyst
+    links:
+      slack: 'https://hackforla.slack.com/team/UFDG06RJQ'
+      linkedin: 'https://linkedin.com/linkedin-username'
+    picture: https://avatars.githubusercontent.com/Jeremy-D
+  - name: Assel Abilova
+    role: UX/UI Designer
+    links:
+      slack: 'https://hackforla.slack.com/team/U026G6WV49K'
+      linkedin: 'https://linkedin.com/linkedin-username'
+    picture: https://avatars.githubusercontent.com/asselabilova
+  - name: Malak Hmimy
+    role: Data Analyst
+    links:
+      slack: 'https://hackforla.slack.com/team/U01TL5WE7G8'
+      linkedin: 'https://linkedin.com/linkedin-username'
+    picture: https://avatars.githubusercontent.com/MalakH21
 links: 
   - name: Github
     url: 'https://github.com/hackforla/access-the-data/'

--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -17,7 +17,7 @@ leadership:
       linkedin: 'https://linkedin.com/linkedin-username'
     picture: https://avatars.githubusercontent.com/experimentsinhonesty
   - name: Sarah Nabelsi
-    role: Product Manager
+    role: Project Manager
     links:
       slack: 'https://hackforla.slack.com/team/U01J9V1H63F'
       github: 'https://github.com/snooravi'


### PR DESCRIPTION
Fixes #2007 

### What changes did you make and why did you make them ?

  - updated the profile/ current project team section for the Access the Data project according to profiles provided in the issue comment
  - Removed looking - UX Lead to build surveys (on line 47 and 48 in the original file)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>


<img width="785" src="https://user-images.githubusercontent.com/63900848/130182791-ac20b9c4-ce77-48cc-b116-330ab3a85b3a.png" alt="Access the Data Profile Before Pic">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="785" src="https://user-images.githubusercontent.com/63900848/130182805-89dc9536-9689-40f4-b29e-27e19bb9505e.png" alt="Access the Data Profile After Pic" >

</details>
