### PR TITLE
Adjust location card image height

### DIFF
--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -238,13 +238,31 @@
 .meetings-message {
   text-align: center;
 }
-.location-image {
-  margin: -5px;
-  border-radius: 5px;
-  max-width: 372px;
 
+.location-img-pos {
+  flex: 0 0 auto;
+  width: 372px;
+  overflow: hidden;
+  margin: -5px;
+
+  @media #{$bp-below-tablet} {
+    margin: 0;
+    width: 100%;
+    height: 40vh;
+  }
   @media #{$bp-below-mobile} {
-    height: auto;
+    height: 231px;
+  }
+}
+
+.location-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+
+  @media #{$bp-below-tablet} {
+    /* Positions image so location text is visible */
+    object-position: center 80%;
   }
 }
 
@@ -264,11 +282,14 @@
   @media #{$bp-below-tablet} {
     padding: 16px 16px;
   }
+  @media #{$bp-below-mobile} {
+    margin: 45px 16px;
+  }
 }
 
 .locations-1 {
   display: flex;
-  height: 388px ;
+  height: 388px;
   margin: -17px;
 
   @media #{$bp-below-tablet} {
@@ -461,6 +482,7 @@
   @media #{$bp-below-tablet} {
     display: none;
     background: $color-gold;
+    width: 100vw;
   }
 }
 


### PR DESCRIPTION
Fixes #1920

### What changes did you make and why did you make them ?

  - Adjusted the location cards' image height for mobile
  - Aligned image so text was still visible in mobile view
  - Adjusted container so images displayed correctly

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Below mobile breakpoint before </summary>

<img width="391" alt="Screen Shot 2021-08-20 at 11 53 22 AM" src="https://user-images.githubusercontent.com/62186905/130288532-356c300e-7a23-4338-8166-7792cc1b4c58.png">

</details>

<details>
<summary>Below tablet breakpoint before </summary>

<img width="663" alt="Screen Shot 2021-08-20 at 1 08 13 PM" src="https://user-images.githubusercontent.com/62186905/130288612-beb66644-ce41-4250-88f9-873ec80472f1.png">

</details>

<details>
<summary>Below mobile breakpoint after </summary>

<img width="387" alt="Screen Shot 2021-08-20 at 11 49 09 AM" src="https://user-images.githubusercontent.com/62186905/130288792-4d3f1eb3-d2a2-4a0c-a90f-65c49d2cceb4.png">

</details>

<details>
<summary>Below tablet breakpoint after </summary>

<img width="663" alt="Screen Shot 2021-08-20 at 1 10 21 PM" src="https://user-images.githubusercontent.com/62186905/130288916-2b532aa5-664f-4c3a-89a7-c0f8c723c309.png">

</details>
