### PR TITLE
updated alt string

### DIFF
--- a/pages/credits.html
+++ b/pages/credits.html
@@ -24,7 +24,7 @@ permalink: /credits/
                           <!-- originally class="project-card-inner" -->
                         <div class="credits-item">
                           <div class="icon-left">
-                            <img src={{ item[1].image-url | absolute_url }} alt={{item[1].alt}}/>
+                            <img src={{ item[1].image-url | absolute_url }} alt="{{ item[1].alt }}"/>
                           </div>
                           <div class="icon-info">
                             {%- if item[1].title -%}


### PR DESCRIPTION
Fixes #1970

### What changes did you make and why did you make them ?

  - Changed the alt text that encompasses the liquid template in credits.html. 
  - The credits page alt next now shows correctly.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/62368440/130306459-436fc92c-2308-492a-9c64-bf568053f550.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/62368440/130306465-225433a9-e2df-499c-adcd-567dc91c6d06.png)

</details>

Note: I have decided to fix this for a couple of reasons:
1. The accessibility issues is difficult to review since they seem improperly formed in the inspector as a result of this fix not implemented.
2. While testing TravisCI as a part of #2014, the build broke when I included HTMLProofer, a [Jekyll recommended tool ](https://jekyllrb.com/docs/continuous-integration/travis-ci/)for testing builds. I have decided that if we want to discuss an accessibility auditing tool, this would need to be resolved first.