### PR TITLE
Updating hands image credit link, changing credit name to unity and c…

### DIFF
--- a/_data/internal/credits/hands.yml
+++ b/_data/internal/credits/hands.yml
@@ -1,11 +1,11 @@
 ---
 title: Unity
-title-link: https://thenounproject.com/
+title-link: https://thenounproject.com/search/?q=unity&i=2334876
 content: Image
 used-in: Guides
 artist: Kiran Shastry
 provider: Noun Project
-provider-link: https://thenounproject.com/search/?q=unity&i=2334876
+provider-link: https://thenounproject.com/
 image-url: /assets/images/about/platform-header-elements/inclusivity.svg
 alt: 'Image of Hands'
 type: icon

--- a/_data/internal/credits/hands.yml
+++ b/_data/internal/credits/hands.yml
@@ -1,11 +1,11 @@
 ---
-title: Hands
+title: Unity
 title-link: https://thenounproject.com/
 content: Image
 used-in: Guides
-artist: Lucky Day
+artist: Kiran Shastry
 provider: Noun Project
-provider-link: https://thenounproject.com/
+provider-link: https://thenounproject.com/search/?q=unity&i=2334876
 image-url: /assets/images/about/platform-header-elements/inclusivity.svg
 alt: 'Image of Hands'
 type: icon


### PR DESCRIPTION
…hanging credit artist

Fixes #2092 

### What changes did you make and why did you make them ?

  - Replaced the generic Noun Project link for the image titled “Hands” in the credits page with this specific link - https://thenounproject.com/search/?q=unity&i=2334876 instead in the ‘Name’ category
  - Changed the credit Name of the icon from Hands to “Unity”
  - Changed the credit Artist of the icon from Lucky Day to “Kiran Shastry”
  - These changes have been made as required by the issue.



### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before](https://user-images.githubusercontent.com/843538/130336837-1851e9ed-3213-4b18-85ec-80c8644162b9.PNG)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after](https://user-images.githubusercontent.com/843538/130336859-4e79d547-a1ed-4851-a21d-25eb065facce.PNG)

</details>
