### PR TITLE
refactored the lines for button styling in join-us page

### DIFF
--- a/_sass/elements/_buttons.scss
+++ b/_sass/elements/_buttons.scss
@@ -25,7 +25,6 @@
 
 ---------------------------*/
 
-
 .btn {
   border: 0;
   box-shadow: 0 0 8px 0 rgba($color-black, 0.2);
@@ -36,6 +35,12 @@
   white-space: nowrap;
 }
 
+.btn--default {
+  align-items: center;
+  display: flex; 
+  justify-content: center;
+  margin: 5px 0;
+}
 
 /*---------------------------
 

--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -61,9 +61,10 @@ permalink: /join
           something, growing their experiences, portfolios and ability to work on
           inter-disciplinary teams.
         </p>
-        <a href="https://www.hackforla.org/getting-started" target="_blank"><button
+        <!-- <a href="https://www.hackforla.org/getting-started" target="_blank"><button
             class="btn btn-primary btn-md">Project
-            Volunteer</button></a>
+            Volunteer</button></a> -->
+        <a href="https://www.hackforla.org/getting-started" class="btn btn-primary btn-md btn--defualt" target="_blank">Project Volunteer</a>
       </div>
     </div>
 
@@ -75,12 +76,15 @@ permalink: /join
           The more you tell us about yourself, the better we can match you with
           the right resources.
         </p>
-        <a href="./survey4" target="_blank"><button
-            class="btn btn-primary btn-md btn-partner-with-us">Government</button></a>
-        <a href="./survey3" target="_blank"><button
-            class="btn btn-primary btn-md btn-partner-with-us">Non-Profit</button></a>
-        <a href="./survey6" target="_blank"><button
-            class="btn btn-primary btn-md btn-partner-with-us">Other</button></a>
+        <!-- <a href="./survey4" target="_blank"><button
+            class="btn btn-primary btn-md btn-partner-with-us">Government</button></a> -->
+        <a href="./survey4" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--defualt" title="Government Contact Form">Government</a>
+        <!-- <a href="./survey3" target="_blank"><button
+            class="btn btn-primary btn-md btn-partner-with-us">Non-Profit</button></a> -->
+        <a href="./survey3" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--defualt" title="Non-profit Contact Form">Non-Profit</a>
+        <!-- <a href="./survey6" target="_blank"><button
+            class="btn btn-primary btn-md btn-partner-with-us">Other</button></a> -->
+        <a href="./survey6" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--defualt" title="General Contact Form">Other</a>
       </div>
     </div>
 

--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -61,9 +61,6 @@ permalink: /join
           something, growing their experiences, portfolios and ability to work on
           inter-disciplinary teams.
         </p>
-        <!-- <a href="https://www.hackforla.org/getting-started" target="_blank"><button
-            class="btn btn-primary btn-md">Project
-            Volunteer</button></a> -->
         <a href="https://www.hackforla.org/getting-started" class="btn btn-primary btn-md btn--defualt" target="_blank">Project Volunteer</a>
       </div>
     </div>
@@ -76,14 +73,8 @@ permalink: /join
           The more you tell us about yourself, the better we can match you with
           the right resources.
         </p>
-        <!-- <a href="./survey4" target="_blank"><button
-            class="btn btn-primary btn-md btn-partner-with-us">Government</button></a> -->
         <a href="./survey4" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--defualt" title="Government Contact Form">Government</a>
-        <!-- <a href="./survey3" target="_blank"><button
-            class="btn btn-primary btn-md btn-partner-with-us">Non-Profit</button></a> -->
         <a href="./survey3" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--defualt" title="Non-profit Contact Form">Non-Profit</a>
-        <!-- <a href="./survey6" target="_blank"><button
-            class="btn btn-primary btn-md btn-partner-with-us">Other</button></a> -->
         <a href="./survey6" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--defualt" title="General Contact Form">Other</a>
       </div>
     </div>

--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -61,7 +61,7 @@ permalink: /join
           something, growing their experiences, portfolios and ability to work on
           inter-disciplinary teams.
         </p>
-        <a href="https://www.hackforla.org/getting-started" class="btn btn-primary btn-md btn--defualt" target="_blank">Project Volunteer</a>
+        <a href="https://www.hackforla.org/getting-started" class="btn btn-primary btn-md btn--default" target="_blank">Project Volunteer</a>
       </div>
     </div>
 
@@ -73,9 +73,9 @@ permalink: /join
           The more you tell us about yourself, the better we can match you with
           the right resources.
         </p>
-        <a href="./survey4" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--defualt" title="Government Contact Form">Government</a>
-        <a href="./survey3" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--defualt" title="Non-profit Contact Form">Non-Profit</a>
-        <a href="./survey6" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--defualt" title="General Contact Form">Other</a>
+        <a href="./survey4" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Government Contact Form">Government</a>
+        <a href="./survey3" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Non-profit Contact Form">Non-Profit</a>
+        <a href="./survey6" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="General Contact Form">Other</a>
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #2165 

### What changes did you make and why did you make them ?

  - I refactored the lines that are stated in the issue 
  - Added an additional variable, `.btn--default` on `_buttons.scss` from `website/_sass/elements` after inquiring @abuna1985 
  - Note: After refactoring, the buttons did not appear as they were originally on my browser. I would attach the screenshot under the section of "visuals after change". I had reached out to @abuna1985 with my concerns. It appeared the refactoring did not make the drastic change on Adam's browser like on my browser -- as in the newly added variable on scss did not show up in my inspect. It might just be a minor issue on my end.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your ![Screen Shot 2021-08-28 at 12 48 17](https://user-images.githubusercontent.com/63900848/131229385-0fe4b9e9-f322-46fd-a20d-175056ae28fe.png)es are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Join Us Page Before Refactoring](https://user-images.githubusercontent.com/63900848/131229385-0fe4b9e9-f322-46fd-a20d-175056ae28fe.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Join Us Page after Refactoring on my browser](https://user-images.githubusercontent.com/63900848/131229405-6ef67a4f-aef0-4a62-a06e-562ac14a7f6f.png)

</details>
