### PR TITLE
Add code to import Roboto font

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,6 +26,10 @@
   <link rel="shortcut icon" type="image/x-icon" href="{{ '/assets/images/favicon.ico' | absolute_url }}" />
   <script src="{{ '/assets/js/utils.js' | absolute_url }}"></script>
 
+  <!-- Import Roboto font from Google -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 
   <script>
   // Hotjar Tracking Code for www.hackforla.org 


### PR DESCRIPTION
Fixes #2170 

### What changes did you make and why did you make them ?

  - Added code to import Roboto font in the head because the site is supposed to use the Roboto font, but it's actually not implemented

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Home page before</summary>

![before-change](https://user-images.githubusercontent.com/48004150/131441649-36c28e27-3d8b-4b0d-a1f9-1156143f59bf.png)

</details>

<details>
<summary>Home page after</summary>
  
![after-change](https://user-images.githubusercontent.com/48004150/131441666-19b391ff-29d3-40c7-9166-ffeae73a1672.png)


</details>

<details>
<summary>Home page full before</summary>

![before-full](https://user-images.githubusercontent.com/48004150/131441684-48017cf9-eb82-412a-bb24-5d8a084aee8c.png)


</details>

<details>
<summary>Home page full after</summary>
  
![after-full](https://user-images.githubusercontent.com/48004150/131441707-7c92b578-6426-45f7-ae55-21cd373b32d2.png)


</details>