### PR TITLE
Fixed redirect_to link

### DIFF
--- a/redirections/donate.md
+++ b/redirections/donate.md
@@ -3,5 +3,5 @@
 layout: redirect
 title: Donate
 permalink: /donate/
-redirect_to: https://www.codeforamerica.org/donate
+redirect_to: https://www.hackforla.org/donate
 ---


### PR DESCRIPTION
Fixes # 2203

### What changes did you make and why did you make them ?

donate link was changed from https://www.codeforamerica.org/donate to https://www.hackforla.org/donate


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
