### PR TITLE
Changed alt text for security icon

### DIFF
--- a/_data/internal/credits/security.yml
+++ b/_data/internal/credits/security.yml
@@ -7,6 +7,6 @@ artist: Graphik Designz
 provider: Noun Project
 provider-link: 'https://thenounproject.com/'
 image-url: /assets/images/getting-started/adopt-1.png
-alt: 'Image of Security'
+alt: 'Security Icon'
 type: icon
 ---


### PR DESCRIPTION
Fixes #1585
### What changes did you make and why did you make them ?
  - Alt text changed in file '_data/internal/credits/security.yml' from 'Image of Security' to 'Security Icon'

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="550" alt="Screen Shot 2021-09-12 at 10 41 43 PM" src="https://user-images.githubusercontent.com/63771558/133021452-b57c6b67-0b6b-4666-b052-11cb084644a2.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
 
<img width="547" alt="Screen Shot 2021-09-12 at 10 48 25 PM" src="https://user-images.githubusercontent.com/63771558/133021610-76aed3ed-77a0-41e4-859f-b239de4ed530.png">

</details>
