### PR TITLE
corrected link for the credit of scale image

### DIFF
--- a/_data/internal/credits/scale.yml
+++ b/_data/internal/credits/scale.yml
@@ -1,6 +1,6 @@
 ---
 title: Scale
-title-link: https://thenounproject.com/
+title-link: https://thenounproject.com/search/?q=scale&i=2954648
 content: Image
 used-in: About
 artist: Shuai Tawf


### PR DESCRIPTION
Fixes #2047 

### What changes did you make and why did you make them ?

  - Changed credit title-link for scale image from https://thenounproject.com/ 
to https://thenounproject.com/search/?q=scale&i=2954648

### Screenshots of Proposed Changes Of The Website
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![2047-original](https://user-images.githubusercontent.com/71417295/133339075-6f026414-f0e1-420c-b8de-94b9adabe7f5.JPG)

</details>

<details>
<summary>Visuals after changes are applied</summary>
 
![2047-changes](https://user-images.githubusercontent.com/71417295/133339149-6bb07099-c37e-43ec-b0c5-b81af975ada4.JPG)

</details>
