### PR TITLE
added credits for all badge icons on the wins page

### DIFF
--- a/_data/internal/credits/avatar.yml
+++ b/_data/internal/credits/avatar.yml
@@ -1,0 +1,12 @@
+---
+title: Avatar
+title-link: https://thenounproject.com/search/?q=avatar&i=2309777
+content: icon
+used-in: Wins Page
+artist: Nawicon
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/avatar-default.svg
+alt: 'Avatar Icon'
+type: icon
+---

--- a/_data/internal/credits/center.yml
+++ b/_data/internal/credits/center.yml
@@ -1,0 +1,12 @@
+---
+title: Center
+title-link: https://thenounproject.com/search/?creator=300606&q=center&i=2300961
+content: icon
+used-in: Wins Page
+artist: Daniel Llamas Soto
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/enterprise.svg
+alt: 'Center Icon'
+type: icon
+---

--- a/_data/internal/credits/code.yml
+++ b/_data/internal/credits/code.yml
@@ -1,0 +1,12 @@
+---
+title: Code
+title-link: https://thenounproject.com/search/?creator=1859235&q=code&i=975308
+content: icon
+used-in: Wins Page
+artist: Numero Uno
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/code.svg
+alt: 'Code Icon'
+type: icon
+---

--- a/_data/internal/credits/community.yml
+++ b/_data/internal/credits/community.yml
@@ -1,0 +1,12 @@
+---
+title: Community
+title-link: https://thenounproject.com/term/community/2429183/
+content: icon
+used-in: Wins Page
+artist: Fahmi
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/community.svg
+alt: 'Community Icon'
+type: icon
+---

--- a/_data/internal/credits/deliver-on-date.yml
+++ b/_data/internal/credits/deliver-on-date.yml
@@ -1,0 +1,12 @@
+---
+title: Deliver on Date
+title-link: https://thenounproject.com/search/?creator=64420&q=deliver+on+date&i=816560
+content: icon
+used-in: Wins Page
+artist: Ben Davis
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/deliverable.svg
+alt: 'Calendar with Check Icon'
+type: icon
+---

--- a/_data/internal/credits/external-mentor.yml
+++ b/_data/internal/credits/external-mentor.yml
@@ -1,0 +1,12 @@
+---
+title: External Mentor
+title-link: https://thenounproject.com/term/coaching/2717883/
+content: icon
+used-in: Wins Page
+artist: Vectors Point
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/mentor-external.svg
+alt: 'External Mentor Icon'
+type: icon
+---

--- a/_data/internal/credits/folder.yml
+++ b/_data/internal/credits/folder.yml
@@ -1,0 +1,12 @@
+---
+title: Folder
+title-link: https://thenounproject.com/term/folder/1869199/
+content: icon
+used-in: Wins Page
+artist: Icons Fest
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/file.svg
+alt: 'Briefcase Icon'
+type: icon
+---

--- a/_data/internal/credits/give-love.yml
+++ b/_data/internal/credits/give-love.yml
@@ -1,0 +1,12 @@
+---
+title: Give Love
+title-link: https://thenounproject.com/search/?creator=3244932&q=give+love&i=1580506
+content: icon
+used-in: Wins Page
+artist: BGBOXXX
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/giving.svg
+alt: 'Giving Love Icon'
+type: icon
+---

--- a/_data/internal/credits/global-wins.yml
+++ b/_data/internal/credits/global-wins.yml
@@ -1,0 +1,12 @@
+---
+title: Global
+title-link: https://thenounproject.com/term/globe/2051593/
+content: icon
+used-in: Wins Page
+artist: Lnhi
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/launch.svg
+alt: 'Globe Icon'
+type: icon
+---

--- a/_data/internal/credits/hammer.yml
+++ b/_data/internal/credits/hammer.yml
@@ -1,0 +1,12 @@
+---
+title: Hammer
+title-link: https://thenounproject.com/search/?q=hammer&i=3147241
+content: icon
+used-in: Wins Page
+artist: Vectors Point
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/hammers.svg
+alt: 'Hammers Icon'
+type: icon
+---

--- a/_data/internal/credits/job.yml
+++ b/_data/internal/credits/job.yml
@@ -1,0 +1,12 @@
+---
+title: Job
+title-link: https://thenounproject.com/search/?creator=1145943&q=job&i=2043818
+content: icon
+used-in: Wins Page
+artist: Adrien Coquet
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/briefcase.svg
+alt: 'Briefcase Icon'
+type: icon
+---

--- a/_data/internal/credits/mentor.yml
+++ b/_data/internal/credits/mentor.yml
@@ -1,0 +1,12 @@
+---
+title: Mentor
+title-link: https://thenounproject.com/search/?creator=3555590&q=mentor&i=2717883
+content: icon
+used-in: Wins Page
+artist: Vectors Point
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/mentor.svg
+alt: 'Mentor Icon'
+type: icon
+---

--- a/_data/internal/credits/star.yml
+++ b/_data/internal/credits/star.yml
@@ -1,0 +1,12 @@
+---
+title: Star
+title-link: https://thenounproject.com/search/?q=star&i=4132324
+content: icon
+used-in: Wins Page
+artist: IcoMoon
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/star.svg
+alt: 'Star Icon'
+type: icon
+---

--- a/_data/internal/credits/team.yml
+++ b/_data/internal/credits/team.yml
@@ -1,0 +1,12 @@
+---
+title: Team
+title-link: https://thenounproject.com/search/?creator=638256&q=team&i=1092053
+content: icon
+used-in: Wins Page
+artist: Creative Stall
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/team.svg
+alt: 'Team Icon'
+type: icon
+---

--- a/_data/internal/credits/twofa.yml
+++ b/_data/internal/credits/twofa.yml
@@ -1,0 +1,12 @@
+---
+title: Secured
+title-link: https://thenounproject.com/search/?q=secured&i=3008506
+content: icon
+used-in: Wins Page
+artist: Vectorstall
+provider: Noun Project 
+provider-link: https://thenounproject.com/
+image-url: /assets/images/wins-page/wins-badges/twofa.svg
+alt: 'Secured Icon'
+type: icon
+---


### PR DESCRIPTION
Fixes #2078
### What changes did you make and why did you make them ?

  -Added credits for all the Wins page badge icons
  -Did not add first mentor and avatar credits because they are not used in the Wins page

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/28831668/133341123-e6d2cfa4-1141-4651-a2cd-3a09f7742fd1.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/28831668/133341155-1b68095d-92e5-4675-8ad1-8671b85bc842.png)

</details>
