### PR TITLE
Change description text for CoP URL on Getting Started PAge #2268

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -100,7 +100,7 @@ permalink: /getting-started
                 <ol class="column-ol-list">
                     <div class="list-container">
                         <img class="step-img-icon-cop" src="assets/images/getting-started/proj-4.png" alt="" />
-                        <li class="g-s-list"><a href="/communities-of-practice" target="_blank">Join your Community of Practice</a> for access to announcements, meeting zoom links, and helpful resources.
+                        <li class="g-s-list"><a href="/communities-of-practice" target="_blank">Join your Community of Practice's Slack channel</a> for access to announcements, meeting zoom links, and helpful resources.
                         </li>
                     </div>
                 </br>

--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -100,7 +100,7 @@ permalink: /getting-started
                 <ol class="column-ol-list">
                     <div class="list-container">
                         <img class="step-img-icon-cop" src="assets/images/getting-started/proj-4.png" alt="" />
-                        <li class="g-s-list"><a href="/communities-of-practice" target="_blank">Join your Community of Practice's Slack channel</a> for access to announcements, meeting zoom links, and helpful resources.
+                        <li class="g-s-list"><a href="/communities-of-practice" target="_blank">Join your Community of Practice</a> for access to announcements, meeting zoom links, and helpful resources.
                         </li>
                     </div>
                 </br>


### PR DESCRIPTION
Fixes #2268

### What changes did you make and why did you make them ?

I changed the text for the getting started page for "Step 2: Join your community of Practice" section regarding the line "Join your Community of Practice's Slack channel" to "Join your Community of Practice" since it was flagged as an open good 1st issue for new on boarders like myself.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<details>
<summary>Visuals before changes are applied</summary>

![image]
<img width="693" alt="Screen Shot 2021-09-24 at 10 23 55 PM" src="https://user-images.githubusercontent.com/57651772/134759576-8d980bf7-b831-41ac-8b1a-7fddd646dade.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image]
<img width="730" alt="Screen Shot 2021-09-24 at 10 22 10 PM" src="https://user-images.githubusercontent.com/57651772/134759515-61169a33-7045-4ba0-b2af-852082a5ffdb.png">
</details>
