### PR TITLE
Fixed ‘Delegate’ image credit: name, link, and artist

### DIFF
--- a/_data/internal/credits/delegate.yml
+++ b/_data/internal/credits/delegate.yml
@@ -1,9 +1,9 @@
 ---
-title: Delegate
-title-link: https://thenounproject.com/
+title: People Network
+title-link: https://thenounproject.com/search/?q=people+network&i=2228897
 content: icon
 used-in: Join Us
-artist: Vectors Market
+artist: Sérgio Filipe Cardoso Pires, PT
 provider: Noun Project
 provider-link: https://thenounproject.com/
 image-url: /assets/images/join-us/advice-us-icon.svg


### PR DESCRIPTION
Fixes #2045 

### What changes did you make and why did you make them ?
 - Corrected information for Delegate element on Credits page 
 -  Replaced the generic Noun Project link for the image titled “Delegate” with the correct link in the ‘Name’ category
 - In the ‘Name’ category, changed the name from "Delegate" to the correct one: “People Network”
 - In the ‘Artist’ category, changed the artist to the correct one: “Sérgio Filipe Cardoso Pires, PT”
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img src = "https://user-images.githubusercontent.com/60215488/132760480-17393c33-8b65-42b6-a677-6fb418273c10.jpg" width="650" height="300">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img src = "https://user-images.githubusercontent.com/60215488/132760336-fcfdacb9-b7bb-4ef8-8dd2-ab5062c72751.jpg" height="300" width="650">

</details>