### PR TITLE
Fix Wins Tablet Icon Styling

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -530,7 +530,6 @@
 //tablet view mode media query
 @media screen and (max-width: $screen-tablet) and (min-width: $screen-mobile){
     .wins-tablet{
-        margin-left: 0em;
         display: grid;
         grid-template-columns: 50% 50%;
 

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -527,7 +527,7 @@
 
 
 //tablet view mode media query
-@media screen and (max-width: $screen-tablet) and (min-width: $screen-mobile){
+@media screen and (max-width: $screen-desktop) and (min-width: $screen-mobile){
     .wins-tablet{
         align-items: flex-start;
         display: grid;

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -229,7 +229,6 @@
 .wins-card-content{
     display: flex;
     flex-direction: column;
-    margin-left: 20px;
     width: 100%;
     position: relative;
     overflow: hidden;

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -529,6 +529,7 @@
 //tablet view mode media query
 @media screen and (max-width: $screen-tablet) and (min-width: $screen-mobile){
     .wins-tablet{
+        align-items: flex-start;
         display: grid;
         grid-template-columns: 50% 50%;
 

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -525,3 +525,17 @@
     }
 }
 //wins page filter override section end
+
+
+//tablet view mode media query
+@media screen and (max-width: $screen-tablet) and (min-width: $screen-mobile){
+    .wins-tablet{
+        margin-left: 0em;
+        display: grid;
+        grid-template-columns: 50% 50%;
+
+        .wins-text-bubble{
+            width: 70%;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2176 

### What changes did you make and why did you make them ?
  - Created a media query for a max with of $screen-tablet and a min-width of $screen-mobile because this is the view of tablets.
  - Added grid to the .wins-tablet class with 2 columns at 50% each.
  - increased the width of the wins text bubble to 70% to make the text less clunky.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/77212035/136145819-a5d64ea6-5105-4e53-bda9-fafbcc0f8f0f.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/77212035/136145701-6bcd96d7-cf04-46d8-a050-f0c5d8d44c13.png)


</details>
