### PR TITLE
Swap wins from using wins-data to _wins-data

### DIFF
--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -19,23 +19,6 @@
   const overview = "Give us a brief overview"
   const display = "Display?"
 
-	const dataKeys = [
-			"Timestamp",
-			"Email Address",
-			"Full name",
-			"Linkedin URL (optional)",
-			"Could we use your Linkedin profile picture next to your story?",
-			"Github URL (optional)",
-			"Could we use your Github profile picture next to your story?",
-			"Select the team(s) you're on",
-			"Select your role(s) on the team",
-			"What is/was your specific role? (optional)",
-			"When did you join Hack for LA? (optional)",
-			"What do you want to celebrate (select all that apply)?",
-			"Give us a brief overview",
-			"Could we use your Linkedin profile picture next to your story?",
-			"Display?"
-		]
   const otherIcon = `star.svg`
   const badgeIcons = {
 		"I got a new job": `briefcase.svg`,
@@ -56,27 +39,12 @@
 	}
 
   function main() {
-	{% assign localData = site.data.external.wins-data %}
-	  // Escapes JSON for injections. See: #2134. If this is no longer the case, perform necessary edits, and remove this comment.
-	  let localData = JSON.parse(decodeURIComponent("{{ localData | jsonify | uri_escape }}"));
-	  localData.unshift(dataKeys)
-	  const rawData = localData;
-	  
-  	//creates an array of objects where each question is the key and the answer is the value
-  	//cardData[index][question_str] = answer_str
-  	let cardData = []
-  	const keys = rawData[0]
-  	rawData.slice(1).forEach(data => {
-  		let cardObj = {}
-  		for (let i = 0; i < keys.length; i++) {
-  			cardObj[keys[i]] = data[i];
-  		}
-  		cardData.push(cardObj)
-  	})
-
-  	window.localStorage.setItem('data', JSON.stringify(cardData));
-  	makeCards(cardData);
-  	ifPageEmpty();
+    {% assign localData = site.data.external._wins-data %}
+    // Escapes JSON for injections. See: #2134. If this is no longer the case, perform necessary edits, and remove this comment
+    const cardData = JSON.parse(decodeURIComponent("{{ localData | jsonify | uri_escape }}"));
+    window.localStorage.setItem('data', JSON.stringify(cardData));
+    makeCards(cardData);
+    ifPageEmpty();
   }
 
 


### PR DESCRIPTION
Fixes #2146

### What changes did you make and why did you make them ?

  - The JS file for showing the wins entry data now uses _wins-data.json instead of wins-data.json

### Screenshots to show wins page still looks the same

<details>
<summary>Visuals before changes are applied</summary>

![wins-before](https://user-images.githubusercontent.com/48004150/138038314-c54f11d5-648d-4415-b9fe-97d22d1fbeed.png)


</details>

<details>
<summary>Visuals after changes are applied (no change)</summary>
 
![wins-after](https://user-images.githubusercontent.com/48004150/138038325-34790dff-51db-417e-bdf5-d27ed3f21c27.png)

</details>
