### PR TITLE
 Changed alt text for Citizen Engagement program area - #2342 

### DIFF
--- a/_data/internal/program-areas/citizen-engagement-card.yml
+++ b/_data/internal/program-areas/citizen-engagement-card.yml
@@ -7,7 +7,7 @@ description: >
 
 image: /assets/images/program-areas/citizen-engagement.png
 
-image_alt: Two guys holding hands
+image_alt: A group discussion behind a laptop.
 
 SDG: 
   - Peace


### PR DESCRIPTION
2342: Change alt text for Citizen Engagement Program Area to A group discussion behind a laptop.

Fixes #2342

### What changes did you make and why did you make them ?

  -  modified _data/internal/program-areas/citizen-engagement-card.yml by changing image_alt from 'Two guys holding hands' to 'A group discussion behind a laptop.' for image citizen-engagement.png.
  - Ensured the corresponding Program Areas page stays the same after the change by visually checking the layout between Program Areas on the live site and the locally changed Program Areas. 


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

![website-2342_PgmAltText_before](https://user-images.githubusercontent.com/74695640/141891951-212d6b09-942f-491b-ade1-a7978ad53d61.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![website-2342_PgmAltText](https://user-images.githubusercontent.com/74695640/141891312-32a1bd51-1025-43ca-bf89-44f39eac13e2.png)

</details>


