### PR TITLE
Update slack link for Food Oasis

### DIFF
--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -51,7 +51,7 @@ links:
   - name: Readme
     url: "https://github.com/hackforla/food-oasis/blob/master/README.md"
   - name: Slack
-    url: "https://hackforla.slack.com/archives/C6JBH478W"
+    url: "https://hackforla.slack.com/archives/CMER3R1RD"
   - name: Test Site
     url: "https://devla.foodoasis.net/"
 looking:


### PR DESCRIPTION
Fixes #2445

### What changes did you make and why did you make them ?

  - Updated slack link for food oasis
  - Clicked the slack link on both the Projects and Food Oasis page to ensure link changed
  
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No visual changes to the website.
 

