### PR TITLE
Update Expunge Assist Slack Link

### DIFF
--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -32,7 +32,7 @@ links:
     - name: Readme
       url: 'https://github.com/hackforla/record-clearance/blob/master/README.md'
     - name: Slack
-      url: 'https://hackforla.slack.com/messages/CDWKEBYBB'
+      url: 'https://hackforla.slack.com/messages/CN8NXTPK5'
     - name: Overview
       url: 'https://docs.google.com/document/d/1JFZGKxeEBWVak_GATgIt0Knyr9_gJ15CBirynebb4tg/preview'
 partner: NDICA


### PR DESCRIPTION
Fixes #2443

### What changes did you make and why did you make them ?

  - Updated Expunge Assist slack link.
  - Ensured that clicking the slack link on both the projects and Expunge Assist pages resolves to the new address
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
 Updated Slack link. No visual changes to the website.
