### PR TITLE
updated civic opp project github link issue #2434

### DIFF
--- a/_projects/civic-opportunity-project.md
+++ b/_projects/civic-opportunity-project.md
@@ -21,7 +21,7 @@ leadership:
     picture: https://avatars.githubusercontent.com/tan-zhou
 links:
   - name: GitHub
-    url: 'https://github.com/hackforla/civic-opportunity/projects/1'
+    url: 'https://github.com/hackforla/civic-opportunity'
   - name: Slack
     url: 'https://hackforla.slack.com/archives/C016CJZ8VTN'
   - name: Readme
@@ -43,7 +43,7 @@ location:
 # tools:
 partner: Undisclosed
 visible: true
-program-area: 
+program-area:
   - Civic Tech Infrastructure
 status: Active
 ---


### PR DESCRIPTION
Fixes #2434

### What changes did you make and why did you make them ?

  - I updated the github link from url: 'https://github.com/hackforla/civic-opportunity/projects/1' to url: 'https://github.com/hackforla/civic-opportunity' on LINE 24 of '_projects/civic-opportunity-project.md'. This ensures that the github link for civic-opportunity is correct.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
