### PR TITLE
Updated Diversity link in Credit page-2094

### DIFF
--- a/_data/internal/credits/diversity.yml
+++ b/_data/internal/credits/diversity.yml
@@ -1,11 +1,11 @@
 ---
 title: Diversity
-title-link: https://thenounproject.com/
+title-link: https://thenounproject.com/icon/diversity-1923175/
 content: Image
 used-in: About
 artist: Sasicreatives
 provider: Noun Project
-provider-link: https://thenounproject.com/
+provider-link: https://thenounproject.com/icon/diversity-1923175/
 image-url: /assets/images/about/platform-header-elements/diversity.svg
 alt: 'Image of Diversity'
 type: icon

--- a/_data/internal/credits/diversity.yml
+++ b/_data/internal/credits/diversity.yml
@@ -5,7 +5,7 @@ content: Image
 used-in: About
 artist: Sasicreatives
 provider: Noun Project
-provider-link: https://thenounproject.com/icon/diversity-1923175/
+provider-link: 'https://thenounproject.com/'
 image-url: /assets/images/about/platform-header-elements/diversity.svg
 alt: 'Image of Diversity'
 type: icon


### PR DESCRIPTION
Fixes #2094

### What changes did you make and why did you make them ?

  -Deleted the incorrect link Title-link replaced it to https://thenounproject.com/icon/diversity-1923175/.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

Changed Diversity Credit Link to the correct URL. No visual changes to the website.


