### PR TITLE
Update Icon Alignment Step Cards

### DIFF
--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -233,7 +233,7 @@
   margin-right: 1em;
   width: 2.1em;
   float: left;
-  align-self: center;
+  align-self: flex-start;
 }
 
 .step-img-icon-board {
@@ -250,14 +250,14 @@
   margin-right: 1em;
   width: 2.3em;
   float: left;
-  align-self: center;
+  align-self: flex-start;
 }
 
 .step-img-icon-cop-small {
     margin-left: -2.1em;
     margin-right: 1.7em;
     float: left;
-    align-self: center;
+    align-self: flex-start;
     width: 1.6em;
     position: relative;
     left: 7px;

--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -294,14 +294,14 @@
     margin-right: .9em;
     width: 2.3em;
     float: left;
-    align-self: center;
+    align-self: flex-start;
 }
 
 .step-img-icon-join {
   margin-left: -1.4em;
   margin-right: 1.1em;
   float: left;
-  align-self: center;
+  align-self: flex-start;
   width: 1.7em;
 }
 

--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -285,7 +285,7 @@
     margin-right: .9em;
     width: 2.3em;
     float: left;
-    align-self: center;
+    align-self: flex-start;
     margin-top: .4em;
 }
 

--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -267,7 +267,7 @@
   margin-left: -1.4em;
   margin-right: 1.1em;
   float: left;
-  align-self: center;
+  align-self: flex-start;
   width: 1.7em;
 }
 


### PR DESCRIPTION
Fixes #2396

### What changes did you make and why did you make them ?

  - update substep icon classes align-self to flex-start to align to the top of respective substep

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/75542938/145626309-7096af7d-683e-4cda-b69e-cf6368fe5df2.png)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/75542938/145625986-5b7156f7-c443-4d6e-83fb-330c5650cc61.png)

</details>
