### PR TITLE
Updated Getting Started page header text

### DIFF
--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -3,7 +3,7 @@
 }
 
 .header-bold-p {
-  font-size: 17px;
+  font-size: 16px;
   font-weight: 700;
   padding-top: 20px;
   font-family: "Roboto"sans-serif;
@@ -14,7 +14,7 @@
   }
 }
 .header-p {
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 500;
   display: flex;
   max-width: 580px;


### PR DESCRIPTION
Fixes #2417

### What changes did you make and why did you make them ?
  - In the _getting-started-page.scss, I set the font-size property to 16px for the `.header-bold-p` and `- .header-p` classes. I made these changes because it was requested in the issue.
  -
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![getting-started-header-text-current](https://user-images.githubusercontent.com/31293603/145706990-7078e2a1-7a59-4268-8d4d-483e642a79ae.JPG)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![getting-started-header-text-16px](https://user-images.githubusercontent.com/31293603/145707001-a86eb133-6dfa-445f-a646-cb481d1b4491.JPG)

</details>
