### PR TITLE
Update github action to comment on issues created with no labels

### DIFF
--- a/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
@@ -30,7 +30,7 @@ async function main({ g, c }, { actionResult, addedLabels, issueNum }) {
   }
 
   const instructions = makeComment(addedLabels)
-  if (instructions === false) {
+  if (instructions === null) {
     return
   }
   await postComment(issueNum, instructions)
@@ -53,11 +53,6 @@ function makeComment(labels) {
     }
     return formatComment(commentObject)
   }
-
-/*
-As per the comments at the end of PR # 2060, the action won't post a comment yet if the required labels are not added
-because of am unforeseen use case. A new issue will be opened to decide the wanted behavior for that particular use case.
-This part can be revisited and fixed afterwards.
  
   // Replace the issue creator placeholder first
   const commentObject = {
@@ -76,8 +71,7 @@ This part can be revisited and fixed afterwards.
     filePathToFormat: null,
     textToFormat: commentWithIssueCreator
   }
-  return formatComment(labelsCommentObject) */
-  return false
+  return formatComment(labelsCommentObject)
 }
 
 /**


### PR DESCRIPTION
Fixes #2127

### What changes did you make and why did you make them ?

  - Now, when an issue is created without any of the proper labels, the bot will also comment to let the user know
