### PR TITLE
Update HelloGov Slack Link

### DIFF
--- a/_projects/hellogov.md
+++ b/_projects/hellogov.md
@@ -30,7 +30,7 @@ links:
   - name: Readme
     url: 'https://github.com/helloGov/webapp/blob/master/README.md'
   - name: Slack
-    url: 'https://hackforla.slack.com/archives/CMER3R1RD'
+    url: 'https://hackforla.slack.com/messages/CDA23KHKP'
 looking:
 location: 
   # - Santa Monica


### PR DESCRIPTION
Fixes #2444

### What changes did you make and why did you make them ?

  - Updated projects/hellogov slack link to url: 'https://hackforla.slack.com/messages/CDA23KHKP' because the previous link was out of date.

### Screenshots of Proposed Changes Of The Website 
Updated a redirect link, no visual changes.
