### PR TITLE
2404: Tooltip with long text cuts off when hovering over wins icons #2408

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -92,6 +92,7 @@
     color: $color-white;
     font-family: arial;
     position: absolute;
+    bottom: 50px;
     z-index: 1;
 }
 [data-wins]{
@@ -104,10 +105,10 @@
     position: absolute;
     border-left: 10px solid $color-black;
     border-right: 10px solid transparent;
-    transform: rotate(45deg);
+    transform: rotate(225deg);
     border-bottom: 10px solid transparent;
-    right: 40%;
-    top: 0;
+    right: 47%;
+    bottom: 0;
 }
 
 .wins-badge-icon {


### PR DESCRIPTION
Fixes #2408

### What changes did you make and why did you make them ?

The text bubble was appearing below the WINS badge icon and the text was getting off when the badge description had multiple lines. The solution was to have the bubble appear above the WINS badge icon. The changes were made in `_sass\components\_wins-page.scss`.
  - `.wins-text-bubble` : added `bottom: 50px;` to the declaration. `bottom: 50px` causes the bottom of the bubble to appear 50px above the bottom of the icon container. 50px give a small gap between the bubble and the icon.
  - `.wins-text-bubble:before`: This declaration is for the little triangle 'arrow'. 
    - Transform was changed from ...(45deg) to `transform: rotate(225deg);`. 45deg had the triangle pointing up (apex on top) ![2408_0-Before-arrow](https://user-images.githubusercontent.com/74695640/146473065-c6f37154-d2b8-49d9-a1a5-dee6708c2bfb.png) which worked when the bubble was below the WINS icon with the 'arrow' pointing up at the icon. Since the bubble is now above the icon, the 'arrow' needs to point down at the icon ![2408_1-After-arrow](https://user-images.githubusercontent.com/74695640/146473166-73daaca2-fe5d-4125-be12-c994de31ee08.png). 
    - `right: 40%;` was changed to `right: 47%;`. This positions the triangle close to the horizontal center of the WINS icon.
  - `top: 0;` was changed to `bottom: 0;` because the triangle needs to appear at the bottom of the bubble. 

I am not sure if having the bubble temporarily appear over existing text is an acceptable practice. Altering the padding for the WINS card would have affected the appearance of the page by created too much negative space on the bottom of the card.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![2408_0-Before_WINS](https://user-images.githubusercontent.com/74695640/146469284-71ce5275-3ee9-40b9-98ec-fb21164c31b0.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![2408_1-After_WINS](https://user-images.githubusercontent.com/74695640/146469350-434705e2-8ec8-4f81-92b0-fe5690cd1aa1.png)

</details>
