### PR TITLE
Updated the makeIcon function in wins.js file #2267

### DIFF
--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -423,6 +423,7 @@ function seeMore(id){
   function makeIcon(href, parent, className, src) {
 		let icon = makeElement('a', parent, 'wins-card-icon');
 		icon.setAttribute("href", href);
+		icon.setAttribute("target", "_blank");
 		let iconImg = makeElement('img', icon, className);
 		iconImg.setAttribute("src", src);
 	}


### PR DESCRIPTION
Fixes #2267  

### What changes did you make and why did you make them ?

  -Updated the makeIcon function in wins.js file
  - Added the line of code-` icon.setAttribute("target", "_blank");`
  - You will have to click on the _**see more**_ link on an individual wins card. After doing so, the modal view will open. Currently, when you click on the cards Github or LinkedIn Icon. You will be redirected to that user Github or LinkedIn. My solution will open a new tab to the link. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No images to be added