### PR TITLE
Revert "2404: Tooltip with long text cuts off when hovering over wins icons #2408"

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -92,7 +92,6 @@
     color: $color-white;
     font-family: arial;
     position: absolute;
-    bottom: 50px;
     z-index: 1;
 }
 [data-wins]{
@@ -105,10 +104,10 @@
     position: absolute;
     border-left: 10px solid $color-black;
     border-right: 10px solid transparent;
-    transform: rotate(225deg);
+    transform: rotate(45deg);
     border-bottom: 10px solid transparent;
-    right: 47%;
-    bottom: 0;
+    right: 40%;
+    top: 0;
 }
 
 .wins-badge-icon {


### PR DESCRIPTION
Reverts hackforla/website#2594
We missed to look at the changes in responsive design mode which has some errors, so reverting.