### PR TITLE
 Tooltip with long text cuts off when hovering over wins icons #2408 

### DIFF
--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -92,6 +92,7 @@
     color: $color-white;
     font-family: arial;
     position: absolute;
+    bottom: 50px;
     z-index: 1;
 }
 [data-wins]{
@@ -104,10 +105,10 @@
     position: absolute;
     border-left: 10px solid $color-black;
     border-right: 10px solid transparent;
-    transform: rotate(45deg);
+    transform: rotate(225deg);
     border-bottom: 10px solid transparent;
-    right: 40%;
-    top: 0;
+    right: 47%;
+    bottom: 0;
 }
 
 .wins-badge-icon {
@@ -490,6 +491,7 @@
             text-align: left;
             position: relative;
             left: 0;
+            bottom: 0px;
             padding: 0;
             background: inherit;
             color: $color-black;


### PR DESCRIPTION
Fixes #2408

### What changes did you make and why did you make them ?

The text bubble was appearing below the WINS badge icon and the text was getting off when the badge description had multiple lines. The solution was to have the bubble appear above the WINS badge icon. The changes were made in `_sass\components\_wins-page.scss`
- `.wins-text-bubble` : added `bottom: 50px`; to the declaration at line 95. `bottom: 50px` causes the bottom of the bubble to appear 50px above the bottom of the icon container. 50px give a small gap between the bubble and the icon.
- `.wins-text-bubble:before` (lines 108, 110-111): This is the css for the little triangle 'arrow'.
  - line 108: Transform was changed from `transform: rotate(45deg)` to `transform: rotate(225deg)`. 45deg had the triangle pointing up (apex on top) ![2408_0-Before-arrow](https://user-images.githubusercontent.com/74695640/147712784-50bf4bd3-4b23-48a6-984c-9eaa382eabfc.png) which worked when the bubble was *below* the WINS icon with the 'arrow' pointing up at the icon. Since the bubble is now above the icon, the 'arrow' needs to point down at the icon ![2408_1-After-arrow](https://user-images.githubusercontent.com/74695640/147712832-3362dfd8-1db8-4e66-bd63-21934a15a9ab.png) via the 225deg rotation.
  - `right: 40%` was changed to `right: 47%`. This positions the 'arrow' close to the horizontal center of the WINS icon.
  - `top: 0` was changed to `bottom: 0` because the 'arrow' needs to appear at the bottom of the bubble.
- `.wins-table > .wins-test-bubble` in `@media #{$bp-below-desktop}`: line 494 **NEW** - issue was reopened because on smaller width devices, the text for the WINS was vertically shifted 50px because for smaller device widths, the WINS card expands vertically to show all the WINS badges (instead of the modal window) when a badge is clicked.

I am not sure if having the text bubble temporarily appear over existing text is an acceptable practice. Altering the padding for the WINS card would have affected the appearance of the page by created too much negative space on the bottom of the card.

The changes were tested with browser window sizes > 960px, < 960px, ~380px, and Responsive modes for mobile devices and tablets to ensure the display is correct. The only anomaly (and it exists on the current production site) is when the window is exactly 960px wide. The WINS card expands and the WINS badges are in 2 columns but without the text. 960px is the minimum desktop width and changing `variables/_layout.scss` to fix this anomaly may cause display issues in other code. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

![2408_0-Before_WINS](https://user-images.githubusercontent.com/74695640/147713105-f37d6403-1342-49aa-a3fc-87d4a0544a4c.png)

Shifted text in the expanded WINS card (initial push of this fix, the production site does NOT look like this)
![2408_2-BeforeReopen_WINS](https://user-images.githubusercontent.com/74695640/147713117-67216055-5cc5-4d56-a2ff-600af2ab9ce0.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![2408_1-After_WINS](https://user-images.githubusercontent.com/74695640/147713131-6aaf0e6e-efe9-4134-9285-d3821fd64a23.png)

![2408_2-After_WINS](https://user-images.githubusercontent.com/74695640/147713135-e066e044-2583-4b37-a8fd-2d8fa343900d.png)

</details>
