### PR TITLE
 Update the images on the credits page so they're all the same width #2456 

### DIFF
--- a/_sass/components/_credit-items.scss
+++ b/_sass/components/_credit-items.scss
@@ -35,7 +35,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-between;
+  justify-content: space-evenly;
   
   @media #{$bp-below-mobile} {
     margin: 5px;
@@ -88,4 +88,8 @@
   p {
     margin: 0;
   }
+}
+
+.icon-left-image {
+  width: 100%;
 }

--- a/pages/credits.html
+++ b/pages/credits.html
@@ -27,7 +27,7 @@ permalink: /credits/
                     <!-- originally class="project-card-inner" -->
                   <div class="credits-item">
                     <div class="icon-left">
-                      <img src={{ item[1].image-url | absolute_url }} alt="{{ item[1].alt }}"/>
+                      <img class="icon-left-image" src={{ item[1].image-url | absolute_url }} alt="{{ item[1].alt }}"/>
                     </div>
                     <div class="icon-info">
                       {%- if item[1].title -%}


### PR DESCRIPTION
Fixes #2456

### What changes did you make and why did you make them ?
1. Added 
```
.icon-left-image {
  width: 100%;
}
```
to `_sass/components/_credit-items.scss`. Without `width: 100%`, img default css is `max-wdith: 100%`. `max-width` does not upsize an image when it is smaller than the container. It only ensures the image will not overflow the container.
 
2. Changed `justify-content` for `.credits-item` in `_sass/components/_credit-items.scss` from `space-between` to `space-evenly`. Aesthetics. Images and descriptions appear center-justified with `space-evenly`. When `space-between` was used, the images were left-justified, then a decent gap, then the description.

3. Added `class="icon-left-image"` to the `img` element on line 30 of `pages/credits.html` because we need to use the width specified in the css file.

4. Changes were verified on desktop with browser window widths greater than 960px and less than 960px.  Response mode was also checked. Image width did not require adjustment for the smaller screen sizes because the `<div class="icon-left">` changes from 100px to 60px on the smaller devices via code already in the css.

**NOTE** - images were not physically changed, only the CSS. The graphic does increase on the changed page but some graphics may not have the same width as other graphics. Some images have negative space to the right and left of the actual graphic and when the image is up-scaled, the scaling amount is based on the file pixel size, not the pixel size of the graphic in the file. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

#### BEFORE: Desktop, width > 960px
![2456_0-Before_ImageSize-desktop](https://user-images.githubusercontent.com/74695640/147797935-b6141568-8205-483e-a725-fc9dbb950d14.png)

#### BEFORE: Responsive mobile, width = 340px
![2456_0-Before_ImageSize-mobile](https://user-images.githubusercontent.com/74695640/147797936-7dc5fa7d-b88e-47c6-8ea6-cf9c6be146fc.png)

#### BEFORE: Desktop width < 960 and mobile responsive to show `justify-content: space-between`. Note the gap between the image and the description.
![2456_0-Before_space-between](https://user-images.githubusercontent.com/74695640/147797955-c8c74d05-abe6-41c2-8c3b-17d8948d65e5.png)

#### BEFORE: Desktop width > 960 with temporary borders to help visualize image sizes
![2456_2-Before_ImageSize-desktop-borders](https://user-images.githubusercontent.com/74695640/147797908-b2e4942e-cbb5-4103-940f-6d7faa378212.png)



</details>

<details>
<summary>Visuals after changes are applied</summary>

#### AFTER: Desktop, width > 960px
![2456_1-After_ImageSize-desktop](https://user-images.githubusercontent.com/74695640/147797947-f3b57b9f-d209-4c8d-9189-4a0669ca8c14.png)

#### AFTER: Responsive mobile, width = 340px
![2456_1-After_ImageSize-mobile](https://user-images.githubusercontent.com/74695640/147797948-60f70875-696d-414b-bf8a-e2afcebbdceb.png)

#### AFTER: Desktop width < 960 and mobile responsive to show `justify-content: space-between` with the image sizes changes in place.
![2456_1-After_space-between](https://user-images.githubusercontent.com/74695640/147797968-448c0f62-fcd4-4720-8826-7c530e5e3aaa.png)

#### AFTER: Desktop width < 960 and mobile responsive to show `justify-content: space-evenly` (the new setting) with the image sizes changes in place. Note the reduced spacing between the image and the description.
![2456_1-After_space-evenly](https://user-images.githubusercontent.com/74695640/147797969-2e7c512f-eb44-4bb4-8f03-92e8e26dac8d.png)

#### AFTER: Desktop width > 960 with temporary borders to help visualize image sizes. Images now have the same width. 
![2456_2-After_ImageSize-desktop-borders](https://user-images.githubusercontent.com/74695640/147797920-507951ce-82ba-4339-be91-0091945ebfc4.png)


</details>
