### PR TITLE
Change Open Community Survey's program area from 'Vote / Represent…

### DIFF
--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -88,7 +88,7 @@ partner: 'LA Department of Neighborhood Empowerment (DONE), LA Neighborhood Coun
 tools: 'ArcGIS surveys, Figma, Google Docs, Zoom'
 visible: true
 program-area:
-  - Vote / Representation
+  - Citizen Engagement
 status: Active
 # citizen engagement card data
 problem: Most Neighborhood Councils do not have access or resources to hire technical experts necessary to create a citywide survey so that they can use the data to create inclusive websites targeted towards the needs of their specific communities.


### PR DESCRIPTION
…ation' to 'Citizen Engagement'

Fixes #2631

### What changes did you make and why did you make them ?

  - Revised program area information for the Open Community Survey project so that it would show up under "citizen engagement" when filtered on the site's "Projects" page
  - In open-community-survey.md, changed program-area from "Vote / Representation" to "Citizen Engagement"

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/57715733/150059826-89ea81cf-f3b8-45a3-bb34-d74623d3994e.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/57715733/150059850-b58ade37-7270-465f-8d3e-95a1cd051358.png)

</details>
