### PR TITLE
Tooltip bug fix

### DIFF
--- a/_sass/components/_projects-page.scss
+++ b/_sass/components/_projects-page.scss
@@ -32,7 +32,7 @@
     border-radius: 16px;
     box-shadow: 0 0 8px 0 rgba($color-black, 0.2);
     margin-bottom: 24px;
-    overflow: hidden;
+    
   
     @media #{$bp-tablet-up} {
       margin-bottom: 0;

--- a/_sass/components/_projects-page.scss
+++ b/_sass/components/_projects-page.scss
@@ -32,7 +32,7 @@
     border-radius: 16px;
     box-shadow: 0 0 8px 0 rgba($color-black, 0.2);
     margin-bottom: 24px;
-    
+    overflow: hidden;
   
     @media #{$bp-tablet-up} {
       margin-bottom: 0;

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -197,12 +197,20 @@
 }
 
 //card styling
+.project-card {
+    background: $color-white;
+    border: 0 solid rgba($color-black, 0.06);
+    border-radius: 16px;
+    box-shadow: 0 0 8px 0 rgba($color-black, 0.2);
+    margin-bottom: 24px;
+}
+
 .wins-card{
     padding: 45px;
     display: flex;
     position: relative;
     flex-direction: column;
-    overflow: visible !important;
+    overflow: visible ;
 }
 .wins-card-top{
     display: flex;

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -202,7 +202,7 @@
     display: flex;
     position: relative;
     flex-direction: column;
-    overflow: visible;
+    overflow: visible !important;
 }
 .wins-card-top{
     display: flex;

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -196,21 +196,12 @@
     margin: 18px 60px;
 }
 
-//card styling
-.project-card {
-    background: $color-white;
-    border: 0 solid rgba($color-black, 0.06);
-    border-radius: 16px;
-    box-shadow: 0 0 8px 0 rgba($color-black, 0.2);
-    margin-bottom: 24px;
-}
-
 .wins-card{
     padding: 45px;
     display: flex;
     position: relative;
     flex-direction: column;
-    overflow: visible ;
+    overflow: visible !important;
 }
 .wins-card-top{
     display: flex;

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -35,6 +35,7 @@
 }
 
 .project-card.wins-card{
+    overflow: visible;
     @media #{$bp-below-desktop} {
         margin-bottom: 24px;
     }
@@ -201,7 +202,7 @@
     display: flex;
     position: relative;
     flex-direction: column;
-    overflow: visible !important;
+    overflow: visible;
 }
 .wins-card-top{
     display: flex;


### PR DESCRIPTION
Fixes #2408 

### What changes did you make and why did you make them ?
  - Instead of making a global change of '!important' on the wins-card, I went ahead and added in the '.project-card' class without the overflow style. This makes the '.wins-card' overflow style take precedence, without creating a global '!important' rule.
  - This also makes it so that this change does not effect any other page stylings using the ".project-card" or ".wins-page" attributes

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="637" alt="Screen Shot 2022-01-23 at 2 20 13 PM" src="https://user-images.githubusercontent.com/63771558/150696613-452106b8-4f55-4096-9921-7a434b52349d.png">
</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="637" alt="Screen Shot 2022-01-23 at 2 20 35 PM" src="https://user-images.githubusercontent.com/63771558/150696633-8b12e746-243d-436b-ab81-26c6dcab8493.png">
</details>
