### PR TITLE
Updated technologies and leadership sections in website.md

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -19,18 +19,18 @@ leadership:
       slack: 'https://hackforla.slack.com/team/USBB18YDR'
       github: 'https://github.com/cnk'
     picture: https://avatars.githubusercontent.com/cnk
-  - name: Tomas Gonzalez
-    role: Technical Lead
-    links:
-      slack: 'https://hackforla.slack.com/team/U02DF1PPQUA'
-      github: 'https://github.com/R-Tomas-Gonzalez'
-    picture: https://avatars.githubusercontent.com/R-Tomas-Gonzalez
   - name: Saumil Dhankar
     role: Technical Lead
     links:
       slack: 'https://hackforla.slack.com/team/U02AG2K2BB3'
       github: 'https://github.com/SAUMILDHANKAR'
     picture: https://avatars.githubusercontent.com/SAUMILDHANKAR
+  - name: Jessica Cheng
+    role: Technical Lead
+    links:
+      slack: 'https://hackforla.slack.com/team/U02NWK24H3N'
+      github: 'https://github.com/JessicaLucindaCheng'
+    picture: https://avatars.githubusercontent.com/JessicaLucindaCheng  
   - name: Isaac Cruz
     role: UX Design Lead
     links:
@@ -43,6 +43,12 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U0260MKR5EJ'
       github: 'https://github.com/sacamp'
     picture: https://avatars.githubusercontent.com/sacamp
+  - name: Providence Onyenekwe
+    role: Product Manager
+    links:
+      slack: 'https://hackforla.slack.com/team/U02TECJJ3R7'
+      github: 'https://github.com/Providence-o'
+    picture: https://avatars.githubusercontent.com/Providence-o    
 links:
   - name: Wiki
     url: 'https://github.com/hackforla/website/wiki'
@@ -67,6 +73,9 @@ technologies:
   - GitHub Pages
   - Jekyll
   - Docker
+  - Google Apps Script
+  - GitHub Actions
+  - VRMS API
 tools: Figma, Google Drive, Zoom, Google Analytics
 location:
   # - Santa Monica


### PR DESCRIPTION
Fixes #2731

### What changes did you make and why did you make them?

  - I updated the leadership in website.md because it was out of date. In particular, I removed the information for Tomas Gonzalez, and added Jessica Cheng as a Technical Lead and Providence Onyenekwe as a Product Manager.
  - Also, to website.md, I added the technologies: Google Apps Script, GitHub Actions, and VRMS API. The reason is those technologies were missing from the technologies section even though the Hack for LA Website Team uses them. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<details>
<summary>Visuals before changes are applied</summary>

![hfla-website-project-card-cropped-for-pr](https://user-images.githubusercontent.com/31293603/152288626-a186b0f9-697d-4692-8ca4-5ddd47ad8f22.png)

![hfla-website-proj-detail-page-cropped-for-pr](https://user-images.githubusercontent.com/31293603/152288636-1c813216-5896-4da7-87b0-31658cd2f3ed.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![updated-proj-card-for-pr](https://user-images.githubusercontent.com/31293603/152288686-1bd4040e-8d78-4cba-baca-1caba76940b2.png)

![updated-proj-detail-pages-cropped-for-pr](https://user-images.githubusercontent.com/31293603/152288703-86f83247-0f07-457b-bb99-345f5c4e85a6.png)

</details>
