### PR TITLE
Update link in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -612,7 +612,7 @@ From https://github.com/hackforla/website
 ```
 
 
-**Note:** You can safely ignore changes in other issue branches, such as `bonnie` above. But if you see changes in gh-pages, as in `5773ebe..0c86ecd  gh-pages   -> hackforla/gh-pages`, you should incorporate those changes into your repository before merging or rebasing your issue branch. Use the [instructions below](#incorporating-changes-from-upstream) to bring your fork up to date with the main repository.
+**Note:** You can safely ignore changes in other issue branches, such as `bonnie` above. But if you see changes in gh-pages, as in `5773ebe..0c86ecd  gh-pages   -> hackforla/gh-pages`, you should incorporate those changes into your repository before merging or rebasing your issue branch. Use the [instructions below](#27e-working-on-an-issue-5-incorporating-changes-from-upstream) to bring your fork up to date with the main repository.
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 


### PR DESCRIPTION
Fixes #2591 

### What changes did you make and why did you make them?

  - On line 615 in CONTRIBUTING.md change
```
[instructions below](#incorporating-changes-from-upstream)
```
was updated to
```
[instructions below](#27e-working-on-an-issue-5-incorporating-changes-from-upstream)
```