### PR TITLE
Removed link issue 2437

### DIFF
--- a/_projects/spare.md
+++ b/_projects/spare.md
@@ -9,8 +9,7 @@ alt-hero: ''
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/spare'
-  - name: Site
-    url: 'http://whatcanyouspare.org'
+
 looking: 
   - category: Development
     skill: Front-end development 


### PR DESCRIPTION
Fixes #replace_this_text_with_the_issue_number

### What changes did you make and why did you make them ?

 I have deleted the spare.md link as requested.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
The Site link is currently not changed.

![image](https://user-images.githubusercontent.com/38971729/153073037-80501128-a316-4852-a5f0-176c8d434f4d.png)

</details>

<details>
Removed the Site link per below
  
![image](https://user-images.githubusercontent.com/38971729/153074491-7dcfca80-9bc1-4bd7-a8db-5531144234ca.png)

</details>
