### PR TITLE
Revert pr 2724 and pr 2672 to fix proj profile page bug

### DIFF
--- a/_sass/components/_project-filter.scss
+++ b/_sass/components/_project-filter.scss
@@ -7,9 +7,10 @@ a.filter-item {
 //filter container
 ul.filter-list {
   background: $color-pink;
-  padding-left: 0;
-  list-style: none;
   display: grid;
+  list-style: none;
+  padding-left: 0;
+  grid-auto-flow: column;
   grid-column-gap: 20px;
   // grid-template-columns: repeat(4, 1fr);
   // ^ See issue #1997 for more info on why this is commented out and changed to 3
@@ -164,36 +165,6 @@ a.clear-filter-tags {
   ul.filter-list li ul {
     width: 105%;
     padding: 15px;
-    overflow: auto;
-  }
-}
-// tablet down
-@media #{$bp-below-tablet} {
-  #technologies {
-    height: 370px;
-    overflow: auto;
-  }
-}
-
-// tablet up
-@media #{$bp-tablet-up} {
-  #technologies {
-    display: grid;
-    grid-auto-flow: column; // flows the data from top to bottom rather than left to right
-    grid-template-rows: repeat(16, 1fr); // ensures the list is 16 rows
-    list-style: none;
-    left: -17em;
-    width: 718px;
-    height: 380px;
-    overflow: auto;
-  }
-}
-
-// iPad Air to Desktop
-@media #{$bp-desktop-up} {
-  #technologies {
-    left: -18em;
-    width: 768px;
   }
 }
 

--- a/_sass/variables/_layout.scss
+++ b/_sass/variables/_layout.scss
@@ -12,16 +12,24 @@ $screen-mobile: 480px;
  * Breakpoint Start and End Declaration
  *
  * These are generally used for declaring media queries.
- * As an example, if a developer wants to make a media query for   
- * anything above a tablet, use the variable $bp-tablet-up. For  
+ * As an example, if a developer wants to make a media query for
+ * anything above a tablet, use the variable $bp-tablet-up. For
  * anything below a tablet, use $bp-below-tablet.
  */
+
+// Desktop Large
 $bp-desktop-large-up: '(min-width: #{$screen-desktop-large})';
 $bp-below-desktop-large: '(max-width: #{$screen-desktop-large - 1})';
+
+// Desktop
 $bp-desktop-up: '(min-width: #{$screen-desktop})';
 $bp-below-desktop: '(max-width: #{$screen-desktop - 1})';
+
+// Tablets
 $bp-tablet-up: '(min-width: #{$screen-tablet})';
 $bp-below-tablet: '(max-width: #{$screen-tablet - 1})';
+
+// Mobile
 $bp-mobile-up: '(min-width: #{$screen-mobile})';
 $bp-below-mobile: '(max-width: #{$screen-mobile - 1})';
 

--- a/_sass/variables/_layout.scss
+++ b/_sass/variables/_layout.scss
@@ -12,24 +12,16 @@ $screen-mobile: 480px;
  * Breakpoint Start and End Declaration
  *
  * These are generally used for declaring media queries.
- * As an example, if a developer wants to make a media query for
- * anything above a tablet, use the variable $bp-tablet-up. For
+ * As an example, if a developer wants to make a media query for   
+ * anything above a tablet, use the variable $bp-tablet-up. For  
  * anything below a tablet, use $bp-below-tablet.
  */
-
-// Desktop Large
 $bp-desktop-large-up: '(min-width: #{$screen-desktop-large})';
 $bp-below-desktop-large: '(max-width: #{$screen-desktop-large - 1})';
-
-// Desktop
 $bp-desktop-up: '(min-width: #{$screen-desktop})';
 $bp-below-desktop: '(max-width: #{$screen-desktop - 1})';
-
-// Tablets
 $bp-tablet-up: '(min-width: #{$screen-tablet})';
 $bp-below-tablet: '(max-width: #{$screen-tablet - 1})';
-
-// Mobile
 $bp-mobile-up: '(min-width: #{$screen-mobile})';
 $bp-below-mobile: '(max-width: #{$screen-mobile - 1})';
 


### PR DESCRIPTION
Fixes #2754 

### What changes did you make and why did you make them?
Reverted pr #2724 and pr #2672 to fix the issue with the technologies field not being wrapped on the detail project profile page. This was caused by `id="technologies"` being used by both the Languages/Technologies dropdown and the technologies field on the detail project profile page. However, this is only a temporary fix and the issue with the id="technologies" would still need to be addressed.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<details>
<summary>Visuals before changes are applied</summary>

Mobile view of Languages/Technologies dropdown
![before-mobile-dropdown](https://user-images.githubusercontent.com/31293603/153130060-c63374ac-340c-4a91-97e7-0cf77a3115f2.png)

Desktop view of Languages/Technologies dropdown
![before-dropdown](https://user-images.githubusercontent.com/31293603/153128026-21226030-6d28-46f2-98e4-fd03d27705d1.png)

Desktop view of 311 Data project page
![before-311-data](https://user-images.githubusercontent.com/31293603/153130595-49bfe796-e873-4882-825d-06aab9245944.png)

Desktop view of Civic Tech Jobs project page
![before-civic-tech-jobs](https://user-images.githubusercontent.com/31293603/153130612-0bd9fa3a-fb5f-4b95-9a64-252b3a46283b.png)

Desktop view of Civic Tech Index project page
![before-civic-tech-index](https://user-images.githubusercontent.com/31293603/153130634-1bc28de1-ab16-470c-a83d-7a601655f4f6.png)

Desktop view of Food Oasis project page
![before-food-oasis](https://user-images.githubusercontent.com/31293603/153130694-a7f40667-66f3-4781-985f-5bade8107968.png)


</details>

<details>
<summary>Visuals after changes are applied</summary>

Mobile view of Languages/Technologies dropdown
![after-mobile-dropdown](https://user-images.githubusercontent.com/31293603/153133516-907a8d84-1eaf-492e-bdff-b8f158e1bde3.png)

Desktop view of Languages/Technologies dropdown
![after-tech-dropdown-desktop](https://user-images.githubusercontent.com/31293603/153133711-580ebf2c-eace-4bfb-908c-993fb6f2fc91.jpg)

Desktop view of 311 Data project page
![after-311-data](https://user-images.githubusercontent.com/31293603/153133725-8704936b-f55d-418d-9834-3b669f374d55.png)

Desktop view of Civic Tech Jobs project page
![after-civic-tech-jobs](https://user-images.githubusercontent.com/31293603/153133751-ef03e2d8-ed5c-43f3-924d-cd838491273d.png)

Desktop view of Civic Tech Index project page
![after-civic-tech-index](https://user-images.githubusercontent.com/31293603/153133778-38fa4c3f-18cc-44bc-af40-45cf56e97c45.png)

Desktop view of Food Oasis project page
![after-food-oasis](https://user-images.githubusercontent.com/31293603/153133793-5affc52b-6850-4fae-87c2-52bc867c9949.png)

</details>
