### PR TITLE
Fixes SCSS #technologies

### DIFF
--- a/_sass/components/_project-filter.scss
+++ b/_sass/components/_project-filter.scss
@@ -168,7 +168,7 @@ a.clear-filter-tags {
     overflow: auto;
   }
 
-  // Adds scrollbar and limits height
+  // Adds scrollbar and limits height for Languages/Technologies dropdown
   ul.dropdown#technologies {
     height: 370px;
     overflow: auto;
@@ -177,11 +177,11 @@ a.clear-filter-tags {
 
 // Tablet size and up
 @media #{$bp-tablet-up} {
-  // Adds scrollbar and makes dropdown four columns
+  // Adds scrollbar and makes Languages/Technologies dropdown three columns
   ul.dropdown#technologies {
     display: grid;
     grid-auto-flow: column; // flows the data from top to bottom rather than left to right
-    grid-template-rows: repeat(16, 1fr); // ensures the list is 16 rows
+    grid-template-rows: repeat(23, 1fr); // ensures the list is 23 rows
     list-style: none;
     left: -17em;
     width: 718px;
@@ -192,7 +192,7 @@ a.clear-filter-tags {
 
 // Desktop size and up
 @media #{$bp-desktop-up} {
-  // Adjusts placement of dropdown and increases dropdown width
+  // Adjusts placement of Languages/Technologies dropdown and adjusts dropdown width
   ul.dropdown#technologies {
     left: -18em;
     width: 768px;

--- a/_sass/components/_project-filter.scss
+++ b/_sass/components/_project-filter.scss
@@ -7,10 +7,9 @@ a.filter-item {
 //filter container
 ul.filter-list {
   background: $color-pink;
-  display: grid;
-  list-style: none;
   padding-left: 0;
-  grid-auto-flow: column;
+  list-style: none;
+  display: grid;
   grid-column-gap: 20px;
   // grid-template-columns: repeat(4, 1fr);
   // ^ See issue #1997 for more info on why this is commented out and changed to 3
@@ -165,6 +164,36 @@ a.clear-filter-tags {
   ul.filter-list li ul {
     width: 105%;
     padding: 15px;
+    overflow: auto;
+  }
+}
+// tablet down
+@media #{$bp-below-tablet} {
+  #technologies {
+    height: 370px;
+    overflow: auto;
+  }
+}
+
+// tablet up
+@media #{$bp-tablet-up} {
+  #technologies {
+    display: grid;
+    grid-auto-flow: column; // flows the data from top to bottom rather than left to right
+    grid-template-rows: repeat(16, 1fr); // ensures the list is 16 rows
+    list-style: none;
+    left: -17em;
+    width: 718px;
+    height: 380px;
+    overflow: auto;
+  }
+}
+
+// iPad Air to Desktop
+@media #{$bp-desktop-up} {
+  #technologies {
+    left: -18em;
+    width: 768px;
   }
 }
 

--- a/_sass/components/_project-filter.scss
+++ b/_sass/components/_project-filter.scss
@@ -161,13 +161,14 @@ a.clear-filter-tags {
 
 // Below tablet size, including mobile size
 @media #{$bp-below-tablet} {
-  //resize dropdown on tablet and mobile view
+  // Resize dropdown
   ul.filter-list li ul {
     width: 105%;
     padding: 15px;
     overflow: auto;
   }
 
+  // Adds scrollbar and limits height
   ul.dropdown#technologies {
     height: 370px;
     overflow: auto;
@@ -176,6 +177,7 @@ a.clear-filter-tags {
 
 // Tablet size and up
 @media #{$bp-tablet-up} {
+  // Adds scrollbar and makes dropdown four columns
   ul.dropdown#technologies {
     display: grid;
     grid-auto-flow: column; // flows the data from top to bottom rather than left to right
@@ -190,6 +192,7 @@ a.clear-filter-tags {
 
 // Desktop size and up
 @media #{$bp-desktop-up} {
+  // Adjusts placement of dropdown and increases dropdown width
   ul.dropdown#technologies {
     left: -18em;
     width: 768px;

--- a/_sass/components/_project-filter.scss
+++ b/_sass/components/_project-filter.scss
@@ -159,6 +159,7 @@ a.clear-filter-tags {
   color: $color-red;
 }
 
+// Below tablet size, including mobile size
 @media #{$bp-below-tablet} {
   //resize dropdown on tablet and mobile view
   ul.filter-list li ul {
@@ -166,18 +167,16 @@ a.clear-filter-tags {
     padding: 15px;
     overflow: auto;
   }
-}
-// tablet down
-@media #{$bp-below-tablet} {
-  #technologies {
+
+  ul.dropdown#technologies {
     height: 370px;
     overflow: auto;
   }
 }
 
-// tablet up
+// Tablet size and up
 @media #{$bp-tablet-up} {
-  #technologies {
+  ul.dropdown#technologies {
     display: grid;
     grid-auto-flow: column; // flows the data from top to bottom rather than left to right
     grid-template-rows: repeat(16, 1fr); // ensures the list is 16 rows
@@ -189,9 +188,9 @@ a.clear-filter-tags {
   }
 }
 
-// iPad Air to Desktop
+// Desktop size and up
 @media #{$bp-desktop-up} {
-  #technologies {
+  ul.dropdown#technologies {
     left: -18em;
     width: 768px;
   }

--- a/_sass/variables/_layout.scss
+++ b/_sass/variables/_layout.scss
@@ -12,16 +12,24 @@ $screen-mobile: 480px;
  * Breakpoint Start and End Declaration
  *
  * These are generally used for declaring media queries.
- * As an example, if a developer wants to make a media query for   
- * anything above a tablet, use the variable $bp-tablet-up. For  
+ * As an example, if a developer wants to make a media query for
+ * anything above a tablet, use the variable $bp-tablet-up. For
  * anything below a tablet, use $bp-below-tablet.
  */
+
+// Desktop Large
 $bp-desktop-large-up: '(min-width: #{$screen-desktop-large})';
 $bp-below-desktop-large: '(max-width: #{$screen-desktop-large - 1})';
+
+// Desktop
 $bp-desktop-up: '(min-width: #{$screen-desktop})';
 $bp-below-desktop: '(max-width: #{$screen-desktop - 1})';
+
+// Tablets
 $bp-tablet-up: '(min-width: #{$screen-tablet})';
 $bp-below-tablet: '(max-width: #{$screen-tablet - 1})';
+
+// Mobile
 $bp-mobile-up: '(min-width: #{$screen-mobile})';
 $bp-below-mobile: '(max-width: #{$screen-mobile - 1})';
 

--- a/_sass/variables/_layout.scss
+++ b/_sass/variables/_layout.scss
@@ -12,24 +12,16 @@ $screen-mobile: 480px;
  * Breakpoint Start and End Declaration
  *
  * These are generally used for declaring media queries.
- * As an example, if a developer wants to make a media query for
- * anything above a tablet, use the variable $bp-tablet-up. For
+ * As an example, if a developer wants to make a media query for   
+ * anything above a tablet, use the variable $bp-tablet-up. For  
  * anything below a tablet, use $bp-below-tablet.
  */
-
-// Desktop Large
 $bp-desktop-large-up: '(min-width: #{$screen-desktop-large})';
 $bp-below-desktop-large: '(max-width: #{$screen-desktop-large - 1})';
-
-// Desktop
 $bp-desktop-up: '(min-width: #{$screen-desktop})';
 $bp-below-desktop: '(max-width: #{$screen-desktop - 1})';
-
-// Tablets
 $bp-tablet-up: '(min-width: #{$screen-tablet})';
 $bp-below-tablet: '(max-width: #{$screen-tablet - 1})';
-
-// Mobile
 $bp-mobile-up: '(min-width: #{$screen-mobile})';
 $bp-below-mobile: '(max-width: #{$screen-mobile - 1})';
 


### PR DESCRIPTION
Fixes #2754 and #2397

### What changes did you make and why did you make them?
- This is a follow up to pr #2757. PR #2757 was a temporary fix that removed the mobile languages/technology dropdown with scrollbar and the desktop languages/technology dropdown with scrollbar and 4 columns from the projects page in order to fix the problem with the detail information project pages having a large gap and technologies field not being wrapped. This pr is to fix the detail information project pages having a large gap and technologies field not being wrapped while still having on the projects page the mobile languages/technology dropdown with scrollbar and the desktop languages/technology dropdown with scrollbar and 4 columns.
- I changed `#technologies` to `ul.dropdown#technologies` because `ul.dropdown#technologies` has a higher specificity than `#technologies`. Also, SCSS `#technologies` caused problems with the technologies field on the detailed project page since it also has an `id="technologies"`; this caused a problem because all the SCSS files are compiled into a main.scss, which is shared sitewide by all webpages.
- I combined `ul.filter-list li ul` and `ul.dropdown#technologies` into one @media #{$bp-below-tablet} to make it so there wasn't multiple media queries with the same `$bp-below-tablet` parameter.
- I edited the comments related to the media queries to make them clearer.
- 2/15/2022 I changed the languages/technologies dropdown to be 3 columns instead of 4 columns to address the problem of gaps being created when a menu item had to wrap its text onto a second line and make other menu items that only needed 1 line to have gaps. (See bullet point 3 in this comment for a picture and more details: https://github.com/hackforla/website/issues/2397#issuecomment-1031962636)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

Mobile view of Languages/Technologies dropdown
![before-mobile-proj-tech-lang-filter](https://user-images.githubusercontent.com/31293603/153321818-3dee3b1f-b2fa-46a6-be3d-94877443daf4.png)

Desktop view of Languages/Technologies dropdown
![before-desktop-proj-tech-lang-filter](https://user-images.githubusercontent.com/31293603/153322047-9e41efec-5234-4cfb-87d3-937dc6b1f414.jpeg)

Desktop view of 311 Data project page
![before-311-data](https://user-images.githubusercontent.com/31293603/153322568-2a2bfbf9-7e67-42e3-82ac-559b0b1f9310.png)

Desktop view of Civic Tech Jobs project page
![before-civic-tech-jobs](https://user-images.githubusercontent.com/31293603/153322610-10cab945-bf48-4260-818f-4714a9869087.png)

Desktop view of Civic Tech Index project page
![before-civic-tech-index](https://user-images.githubusercontent.com/31293603/153322575-49c9906c-1e65-4f65-97d7-fa862d12657b.png)

Desktop view of Food Oasis project page
![before-food-oasis](https://user-images.githubusercontent.com/31293603/153322626-47769d52-4a8b-4052-98d7-6a0de26934f6.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
Mobile view of Languages/Technologies dropdown
![after-mobile-proj-tech-lang-filter](https://user-images.githubusercontent.com/31293603/153318827-a353be19-c064-4ae3-bd20-8593c781d421.png)

Desktop view of Languages/Technologies dropdown
![after-desktop-tech-dropdown](https://user-images.githubusercontent.com/31293603/154159942-c4df0ad8-fe69-47e8-8035-11d1cee8bbe8.jpg)

Desktop view of 311 Data project page (should look the same as the before image and putting it here to show it is the same)
![after-311-data](https://user-images.githubusercontent.com/31293603/153319029-85b625d3-896c-4574-8fe0-78f120be7aef.png)

Desktop view of Civic Tech Jobs project page (should look the same as the before image and putting it here to show it is the same)
![after-civic-tech-jobs](https://user-images.githubusercontent.com/31293603/153319047-3bcc3df0-b3be-45db-a11c-d720d1313991.png)

Desktop view of Civic Tech Index project page (should look the same as the before image and putting it here to show it is the same)
![after-civic-tech-index](https://user-images.githubusercontent.com/31293603/153319086-2401f2ef-0210-4a21-8c1a-e35f5cde65d3.png)

Desktop view of Food Oasis project page (should look the same as the before image and putting it here to show it is the same)
![after-food-oasis](https://user-images.githubusercontent.com/31293603/153319098-ea62aa36-4baf-4e75-909e-257fa9e5a003.png)

</details>
