### PR TITLE
Apply heading class to Program Areas Page

### DIFF
--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -24,7 +24,7 @@ permalink: /program-areas
             <img class="page-card-image" src="{{ program_areas[1].image }}" alt="{{ program_areas[1].image_alt }}" />
         </div>
         <div class="page-card-content">
-            <h3 class="title4">{{program_areas[1].name}}</h3>
+            <h2 class="title4">{{program_areas[1].name}}</h2>
             <p>{{program_areas[1].description}}</p>
             <p>
                 <strong>SDGs: </strong>

--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -24,7 +24,7 @@ permalink: /program-areas
             <img class="page-card-image" src="{{ program_areas[1].image }}" alt="{{ program_areas[1].image_alt }}" />
         </div>
         <div class="page-card-content">
-            <h3>{{program_areas[1].name}}</h3>
+            <h3 class="title4">{{program_areas[1].name}}</h3>
             <p>{{program_areas[1].description}}</p>
             <p>
                 <strong>SDGs: </strong>


### PR DESCRIPTION
Fixes #2088

### What changes did you make and why did you make them?

  - Added the ".title4" class to the h3 tags within the Program Areas Page to remove the styling reliance on h tags
  - The original issue asks for ".Title4" class to be added to headings, however, the Figma design system page has ".title4" instead.  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screenshot code changes)
  - No visual changes

