### PR TITLE
Add program-area text to Resources section

### DIFF
--- a/_projects/curbmap.md
+++ b/_projects/curbmap.md
@@ -18,6 +18,8 @@ looking:
 location: 
   # - Downtown LA
   - Remote
+program-area:  
+  - Citizen Engagement
 visible: false
 status: On Hold
 ---


### PR DESCRIPTION
Fixes #2277

### What changes did you make and why did you make them ?

The following changes were made to add program area information to the Curbmap project so that it will show up when we add the program areas filter:
- Reviewed the project.md file model in the Resources section
- Added the following text to the file indicated in the Resources section in the _projects/curbmap.md file:

```
program-area:  
    - Citizen Engagement
```

### Screenshots of Proposed Changes Of The Website
- Changes made in _projects/curbmap.md file, so no visual changes to the website.