### PR TITLE
Sort events by project name after by time

### DIFF
--- a/assets/js/utility/api-events.js
+++ b/assets/js/utility/api-events.js
@@ -84,7 +84,7 @@ function filterDataFromApi(responseData) {
 function sortData(filteredData) {
   for (const [key, value] of Object.entries(filteredData)) {
     value.sort(function (a, b) {
-      return convertTime12to24(a.start) - convertTime12to24(b.start);
+      return convertTime12to24(a.start) - convertTime12to24(b.start) || a.name.localeCompare(b.name);
     });
   }
   return filteredData;


### PR DESCRIPTION
Fixes #2751

### What changes did you make and why did you make them ?

  - Changed events to be sorted by project name after the time so that meetings with the same name will appear next to each other.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

![2751_before](https://user-images.githubusercontent.com/69996875/157811700-14c39582-3e95-4be4-a510-bda12060b9b4.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![2751_after](https://user-images.githubusercontent.com/69996875/157811708-477518fa-8de1-44fc-bbda-fd9fe52ad085.png)

</details>
