### PR TITLE
Update card format 2339

### DIFF
--- a/_includes/wins-page/wins-card-template.html
+++ b/_includes/wins-page/wins-card-template.html
@@ -25,7 +25,7 @@
               expandable
               tabindex="0"
               class="see-more-div"
-            >...see more</span>
+            >See more</span>
           </div>
           <!-- <div class="wins-icon-container" id="icons-0"></div> -->
         </div>

--- a/_includes/wins-page/wins-card-template.html
+++ b/_includes/wins-page/wins-card-template.html
@@ -20,7 +20,7 @@
         <div class="project-inner wins-card-text">
           <p class="wins-card-overview"></p>
           <div class="wins-see-more-div">
-            <span id="0" expandable tabindex="0" class="see-more-div">See More</span>
+            <span id="0" expandable tabindex="0" class="see-more-div" aria-label="see more">See More</span>
           </div>
           <!-- <div class="wins-icon-container" id="icons-0"></div> -->
         </div>

--- a/_includes/wins-page/wins-card-template.html
+++ b/_includes/wins-page/wins-card-template.html
@@ -18,14 +18,12 @@
       <img class="wins-card-big-quote" />
       <div class="wins-card-info-container">
         <div class="project-inner wins-card-text">
-          <p class="wins-card-overview"></p>
           <div class="wins-see-more-div">
-            <span 
-              id="0"
-              expandable
-              tabindex="0"
-              class="see-more-div"
-            >See more</span>
+            <span id="0" expandable tabindex="0" class="see-more-div">See More</span>
+          </div>
+          <div>
+            <p class="wins-card-overview"></p>
+
           </div>
           <!-- <div class="wins-icon-container" id="icons-0"></div> -->
         </div>

--- a/_includes/wins-page/wins-card-template.html
+++ b/_includes/wins-page/wins-card-template.html
@@ -18,12 +18,9 @@
       <img class="wins-card-big-quote" />
       <div class="wins-card-info-container">
         <div class="project-inner wins-card-text">
+          <p class="wins-card-overview"></p>
           <div class="wins-see-more-div">
             <span id="0" expandable tabindex="0" class="see-more-div">See More</span>
-          </div>
-          <div>
-            <p class="wins-card-overview"></p>
-
           </div>
           <!-- <div class="wins-icon-container" id="icons-0"></div> -->
         </div>

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -54,20 +54,11 @@
 .wins-card-text {
 	margin-top: 40px;
 	max-height: 88px;
-	// overflow: hidden;
 	position: inherit;
-	// &.relative {
-	//     position: relative;
-	//     .wins-see-more-div {
-	//         bottom: 0;
-	//         right: 0;
-	//     }
-	// }
 }
 
 .wins-card-overview{
     margin: 1em 0 0;
-    margin-top: 1em;
     text-overflow: ellipsis;
     overflow: hidden;
     display: -webkit-box;
@@ -87,7 +78,6 @@
         background-size: 12px;
         background-image: url(../../assets/images/wins-page/caret.svg);
         transform: rotate(180deg);
-        
         &.show-less-btn{
             transform: rotate(0deg);
         }
@@ -456,7 +446,7 @@
     .expanded{
         max-height: none;
         height: auto;
-        .wins-card-overview{
+        .wins-card-overview {
             display: block;
         }
         .wins-see-more-div {
@@ -469,8 +459,6 @@
 .wins-card-content > * {
     flex: 0 0 auto;
 }
-
-
 
 //wins page filter override section begin
 .wins-page-contain > ul.filter-list{

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -54,18 +54,44 @@
 .wins-card-text {
 	margin-top: 40px;
 	max-height: 88px;
-	overflow: hidden;
-	position: relative;
-    &.relative {
-        position: relative;
-        .wins-see-more-div {
-            bottom: 0;
-            right: 0;
-        }
-    }
-    p {
-        margin: 0;
-    }
+	// overflow: hidden;
+	position: inherit;
+	// &.relative {
+	//     position: relative;
+	//     .wins-see-more-div {
+	//         bottom: 0;
+	//         right: 0;
+	//     }
+	// }
+	// p {
+	// 	margin: 0;
+	// 	text-overflow: ellipsis;
+	// 	overflow: hidden;
+	// 	display: -webkit-box !important;
+	// 	-webkit-line-clamp: 3;
+	// 	-webkit-box-orient: vertical;
+	// 	white-space: normal;
+	// }
+}
+
+.wins-card-overview{
+    margin: 0;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: -webkit-box !important;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    white-space: normal;
+}
+
+.see-more-div {
+	.caret {
+		width: 12px;
+	}
+
+	@media #{$bp-below-desktop} {
+		padding: 5px 16px;
+	}
 }
 
 .wins-icon-container {

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -76,12 +76,20 @@
 }
 
 .see-more-div {
-	.caret {
-		width: 12px;
-	}
 
 	@media #{$bp-below-desktop} {
-		padding: 5px 16px;
+        display: inline-block;
+        width: 44px;
+        height: 28px;
+        background-repeat: no-repeat;
+        background-position: center center;
+        background-size: 12px;
+        background-image: url(../../assets/images/wins-page/caret.svg);
+        transform: rotate(180deg);
+        
+        &.show-less-btn{
+            transform: rotate(0deg);
+        }
 	}
 }
 

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -44,8 +44,8 @@
 .wins-see-more-div {
     position: absolute;
     background-color: white;
-    right: 0px;
-    bottom: 0px;
+    right: 32px;
+    bottom: 26px;
     color: $color-red;
     padding: 0px 3px;
     cursor: pointer;
@@ -63,23 +63,14 @@
 	//         right: 0;
 	//     }
 	// }
-	// p {
-	// 	margin: 0;
-	// 	text-overflow: ellipsis;
-	// 	overflow: hidden;
-	// 	display: -webkit-box !important;
-	// 	-webkit-line-clamp: 3;
-	// 	-webkit-box-orient: vertical;
-	// 	white-space: normal;
-	// }
 }
 
 .wins-card-overview{
     margin: 0;
     text-overflow: ellipsis;
     overflow: hidden;
-    display: -webkit-box !important;
-    -webkit-line-clamp: 3;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     white-space: normal;
 }
@@ -459,6 +450,9 @@
     .expanded{
         max-height: none;
         height: auto;
+        .wins-card-overview{
+            display: block;
+        }
         .wins-see-more-div {
             z-index: 10;
         }

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -66,7 +66,8 @@
 }
 
 .wins-card-overview{
-    margin: 0;
+    margin: 1em 0 0;
+    margin-top: 1em;
     text-overflow: ellipsis;
     overflow: hidden;
     display: -webkit-box;
@@ -287,9 +288,6 @@
 }
 .wins-card-icons{
     display: flex;
-}
-.wins-card-overview{
-    margin-top: 1em;
 }
 
 @media #{$bp-below-desktop} {

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -78,7 +78,7 @@
         background-size: 12px;
         background-image: url(../../assets/images/wins-page/caret.svg);
         transform: rotate(180deg);
-        &.show-less-btn{
+        &.show-less-btn {
             transform: rotate(0deg);
         }
 	}

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -70,7 +70,7 @@
     text-overflow: ellipsis;
     overflow: hidden;
     display: -webkit-box;
-    -webkit-line-clamp: 4;
+    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     white-space: normal;
 }

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -382,18 +382,6 @@ function seeMore(id){
 		}))
 	}
 
-	let query = window.matchMedia('max-width: 500px')
-	function render(e){
-			// if the viewport is 960px or less
-		if(e.matches){
-			console.log('change');
-		} else{
-			console.log('nope', e.matches, e)
-		}
-	};
-	render(query);
-	query.addEventListener('change', render);
-
   // Toggles between see more and see less in tablet and mobile view
   function toggleSeeMoreLess(id){
 	let span = document.getElementById(id);
@@ -402,19 +390,36 @@ function seeMore(id){
 	let winsIconContainer = document.getElementById(`icons-${id}`)
 	  if (parent.classList.contains('expanded') && screenWidth > 960) {
 		parent.setAttribute('class', 'project-inner wins-card-text');
-		span.innerHTML = "See More";
 		winsIconContainer.setAttribute('class', 'wins-icon-container');
 	} else if(parent.classList.contains('expanded') && screenWidth < 960) {
 		parent.setAttribute('class', 'project-inner wins-card-text');
-		span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" alt="caret" style="width: 12px;transform: rotate(180deg);">'
+		span.setAttribute('class', 'see-more-div');
 		winsIconContainer.setAttribute('class', 'wins-icon-container');
 	}else {
 		parent.setAttribute('class','project-inner wins-card-text expanded');
-		span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" alt="caret" style="width: 12px;">';
+		span.setAttribute('class', 'see-more-div show-less-btn');
 		winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
   		span.parentElement.removeAttribute('hidden');
 	}
 }
+
+function changeSeeMoreBtn(x) {
+	const span = document.querySelectorAll(".see-more-div");
+	if (x.matches) { 
+		for(let i = 0; i < span.length; i++ ){
+			span[i].innerHTML = ''
+		}
+	} else {
+		for(let i = 0; i < span.length; i++ ){
+			// removes show-less-btn class
+			span[i].setAttribute('class', 'see-more-div');	
+			span[i].innerHTML = "See More";
+		}
+	}
+  }
+  
+  const x = window.matchMedia("(max-width: 960px)")
+  x.addListener(changeSeeMoreBtn) // Attach listener function on state changes
 
   // need to delete makeElement and makeIcon
   function makeElement(elementType, parent, className) {
@@ -505,4 +510,5 @@ function seeMore(id){
 
 
   main();
+  changeSeeMoreBtn(x)
 

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -345,22 +345,6 @@
 		function addSeeMore() {
 			const winText = winTextContainer.querySelector('.wins-card-overview')
 			const seeMoreDiv = winTextContainer.querySelector('.wins-see-more-div')
-			//makes the see more span on the bottom of the card
-			if (
-				!winTextContainer.classList.contains('expanded') && 
-				winText.offsetHeight <= winTextContainer.offsetHeight 
-			) {
-        // Adds see more
-				seeMoreDiv.setAttribute('hidden', 'true')
-			} else {
-        // Removes see more if not needed
-				seeMoreDiv.removeAttribute('hidden')
-			}
-			
-			// remove added relative class on click
-			// if (!winTextContainer.classList.contains('expanded'))
-			// 	winTextContainer.classList.add('relative')
-
 			if (window.innerWidth > 960){
 				const winsCardTextContainer = seeMoreDiv.parentElement
 				if (winsCardTextContainer.classList.contains("expanded")){
@@ -397,6 +381,18 @@ function seeMore(id){
 				toggleSeeMoreLess(id);
 		}))
 	}
+
+	let query = window.matchMedia('max-width: 500px')
+	function render(e){
+			// if the viewport is 960px or less
+		if(e.matches){
+			console.log('change');
+		} else{
+			console.log('nope', e.matches, e)
+		}
+	};
+	render(query);
+	query.addEventListener('change', render);
 
   // Toggles between see more and see less in tablet and mobile view
   function toggleSeeMoreLess(id){

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -383,19 +383,19 @@ function seeMore(id){
 	}
 
   // Toggles between see more and see less in tablet and mobile view
-  function toggleSeeMoreLess(id){
+  function toggleSeeMoreLess(id) {
 	let span = document.getElementById(id);
 	let screenWidth = window.innerWidth;
 	let parent = span.parentElement.parentElement;
 	let winsIconContainer = document.getElementById(`icons-${id}`)
-	  if (parent.classList.contains('expanded') && screenWidth > 960) {
+	if (parent.classList.contains('expanded') && screenWidth > 960) {
 		parent.setAttribute('class', 'project-inner wins-card-text');
 		winsIconContainer.setAttribute('class', 'wins-icon-container');
 	} else if(parent.classList.contains('expanded') && screenWidth < 960) {
 		parent.setAttribute('class', 'project-inner wins-card-text');
 		span.setAttribute('class', 'see-more-div');
 		winsIconContainer.setAttribute('class', 'wins-icon-container');
-	}else {
+	} else {
 		parent.setAttribute('class','project-inner wins-card-text expanded');
 		span.setAttribute('class', 'see-more-div show-less-btn');
 		winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
@@ -406,11 +406,11 @@ function seeMore(id){
 function changeSeeMoreBtn(x) {
 	const span = document.querySelectorAll(".see-more-div");
 	if (x.matches) { 
-		for(let i = 0; i < span.length; i++ ){
+		for(let i = 0; i < span.length; i++) {
 			span[i].innerHTML = ''
 		}
 	} else {
-		for(let i = 0; i < span.length; i++ ){
+		for(let i = 0; i < span.length; i++) {
 			// removes show-less-btn class
 			span[i].setAttribute('class', 'see-more-div');	
 			span[i].innerHTML = "See More";
@@ -418,8 +418,8 @@ function changeSeeMoreBtn(x) {
 	}
   }
   
-  const x = window.matchMedia("(max-width: 960px)")
-  x.addListener(changeSeeMoreBtn) // Attach listener function on state changes
+  const x = window.matchMedia("(max-width: 960px)");
+  x.addListener(changeSeeMoreBtn);
 
   // need to delete makeElement and makeIcon
   function makeElement(elementType, parent, className) {
@@ -510,5 +510,5 @@ function changeSeeMoreBtn(x) {
 
 
   main();
-  changeSeeMoreBtn(x)
+  changeSeeMoreBtn(x);
 

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -400,21 +400,25 @@ function seeMore(id){
 
   // Toggles between see more and see less in tablet and mobile view
   function toggleSeeMoreLess(id){
-		let span = document.getElementById(id);
-		let screenWidth = window.innerWidth;
-		let parent = span.parentElement.parentElement;
-		let winsIconContainer = document.getElementById(`icons-${id}`)
-		if (parent.classList.contains('expanded') || screenWidth > 960) {
-			parent.setAttribute('class', 'project-inner wins-card-text relative');
-			span.innerHTML = `<img src="/assets/images/wins-page/caret.svg" class="caret" alt="caret" style="transform: rotate(180deg);">`;
-			winsIconContainer.setAttribute('class', 'wins-icon-container');
-		} else {
-			parent.setAttribute('class','project-inner wins-card-text expanded');
-			span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" class="caret" alt="caret">&nbsp';
-			winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
-      span.parentElement.removeAttribute('hidden')
-		}
-  }
+	let span = document.getElementById(id);
+	let screenWidth = window.innerWidth;
+	let parent = span.parentElement.parentElement;
+	let winsIconContainer = document.getElementById(`icons-${id}`)
+	  if (parent.classList.contains('expanded') && screenWidth > 960) {
+		parent.setAttribute('class', 'project-inner wins-card-text');
+		span.innerHTML = "See More";
+		winsIconContainer.setAttribute('class', 'wins-icon-container');
+	} else if(parent.classList.contains('expanded') && screenWidth < 960) {
+		parent.setAttribute('class', 'project-inner wins-card-text');
+		span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" alt="caret" style="width: 12px;transform: rotate(180deg);">'
+		winsIconContainer.setAttribute('class', 'wins-icon-container');
+	}else {
+		parent.setAttribute('class','project-inner wins-card-text expanded');
+		span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" alt="caret" style="width: 12px;">';
+		winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
+  		span.parentElement.removeAttribute('hidden');
+	}
+}
 
   // need to delete makeElement and makeIcon
   function makeElement(elementType, parent, className) {

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -356,8 +356,11 @@
         // Removes see more if not needed
 				seeMoreDiv.removeAttribute('hidden')
 			}
-			if (!winTextContainer.classList.contains('expanded'))
-				winTextContainer.classList.add('relative')
+			
+			// remove added relative class on click
+			// if (!winTextContainer.classList.contains('expanded'))
+			// 	winTextContainer.classList.add('relative')
+
 			if (window.innerWidth > 960){
 				const winsCardTextContainer = seeMoreDiv.parentElement
 				if (winsCardTextContainer.classList.contains("expanded")){
@@ -401,13 +404,15 @@ function seeMore(id){
 		let screenWidth = window.innerWidth;
 		let parent = span.parentElement.parentElement;
 		let winsIconContainer = document.getElementById(`icons-${id}`)
-	  	if (parent.classList.contains('expanded') || screenWidth > 960) {
-			parent.setAttribute('class', 'project-inner wins-card-text relative');
-			span.innerHTML = "...see more";
+	  	if (parent.classList.contains('expanded') && screenWidth > 960) {
+			// parent.setAttribute('class', 'project-inner wins-card-text relative');
+			span.innerHTML = "See more";
 			winsIconContainer.setAttribute('class', 'wins-icon-container');
-		} else {
+		} else if(parent.classList.contains('expanded') && screenWidth < 960) {
+			span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" alt="caret" style="width: 12px;transform: rotate(180deg);">'
+		}else {
 			parent.setAttribute('class','project-inner wins-card-text expanded');
-			span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" alt="caret">&nbsp; see less';
+			span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" alt="caret" style="width: 12px;">';
 			winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
       span.parentElement.removeAttribute('hidden')
 		}

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -404,15 +404,13 @@ function seeMore(id){
 		let screenWidth = window.innerWidth;
 		let parent = span.parentElement.parentElement;
 		let winsIconContainer = document.getElementById(`icons-${id}`)
-	  	if (parent.classList.contains('expanded') && screenWidth > 960) {
-			// parent.setAttribute('class', 'project-inner wins-card-text relative');
-			span.innerHTML = "See more";
+		if (parent.classList.contains('expanded') || screenWidth > 960) {
+			parent.setAttribute('class', 'project-inner wins-card-text relative');
+			span.innerHTML = `<img src="/assets/images/wins-page/caret.svg" class="caret" alt="caret" style="transform: rotate(180deg);">`;
 			winsIconContainer.setAttribute('class', 'wins-icon-container');
-		} else if(parent.classList.contains('expanded') && screenWidth < 960) {
-			span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" alt="caret" style="width: 12px;transform: rotate(180deg);">'
-		}else {
+		} else {
 			parent.setAttribute('class','project-inner wins-card-text expanded');
-			span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" alt="caret" style="width: 12px;">';
+			span.innerHTML = '<img src="/assets/images/wins-page/caret.svg" class="caret" alt="caret">&nbsp';
 			winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
       span.parentElement.removeAttribute('hidden')
 		}


### PR DESCRIPTION
Fixes #2339

### What changes did you make and why did you make them?

  - Cards within desktop view of the Wins page match Option A within the [The Wins Page Figma design (within the dark blue border)](https://www.figma.com/file/0RRPy1Ph7HafI3qOITg0Mr/Hack-for-LA-Website?node-id=16207%3A101187)
  - Cards within mobile view of the Wins page match Option B within the [The Wins Page Figma design (within the dark blue border)](https://www.figma.com/file/0RRPy1Ph7HafI3qOITg0Mr/Hack-for-LA-Website?node-id=16207%3A101187)
  - Positioned the "See More" button relative to the card itself rather than the card text

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
 Desktop View

![desktop-card](https://user-images.githubusercontent.com/85038929/158076574-98baf84b-9fe9-451d-a19b-e8e447a3ed9c.jpg)

Mobile View
![desktop-mobile](https://user-images.githubusercontent.com/85038929/158076577-65624780-2f03-43ec-9e53-54336740d0e0.jpg)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
Desktop View
![updated-desktop-1](https://user-images.githubusercontent.com/85038929/158076611-54148daa-8ff5-48bf-90ca-1d58bb2beb0b.PNG)

Mobile View
![updated-desktop-mobile-1](https://user-images.githubusercontent.com/85038929/158076617-2e117fd9-6e81-4800-9323-1fa76191c1aa.PNG)
![updated-desktop-mobile-2](https://user-images.githubusercontent.com/85038929/158076619-f12d61a1-f2f6-45c0-b141-f98c4acc0e67.PNG)
</details>
