### PR TITLE
Applied "title3" Classes to Headings.

### DIFF
--- a/pages/project-meetings.html
+++ b/pages/project-meetings.html
@@ -24,31 +24,31 @@ permalink: /project-meetings
     <div class='page-card card-primary page-card-lg page-card--project-meetings'>
         <div id="userTimeZone" class='userTimeZone'></div>
         <div id="Monday">
-            <h3 class='day-header'>Monday</h3>
+            <h2 class='title3'>Monday</h2>
             <ul id="Monday-List" class="schedule-list"></ul>
         </div>
         <div id="Tuesday">
-            <h3 class='day-header'>Tuesday</h3>
+            <h2 class='title3'>Tuesday</h2>
             <ul id="Tuesday-List" class="schedule-list"></ul>
         </div>
         <div id="Wednesday">
-            <h3 class='day-header'>Wednesday</h3>
+            <h2 class='title3'>Wednesday</h2>
             <ul id="Wednesday-List" class="schedule-list"></ul>
         </div>
         <div id="Thursday">
-            <h3 class='day-header'>Thursday</h3>
+            <h2 class='title3'>Thursday</h2>
             <ul id="Thursday-List" class="schedule-list"></ul>
         </div>
         <div id="Friday">
-            <h3 class='day-header'>Friday</h3>
+            <h2 class='title3'>Friday</h2>
             <ul id="Friday-List" class="schedule-list"></ul>
         </div>
         <div id="Saturday">
-            <h3 class='day-header'>Saturday</h3>
+            <h2 class='title3'>Saturday</h2>
             <ul id="Saturday-List" class="schedule-list"></ul>
         </div>
         <div id="Sunday">
-            <h3 class='day-header'>Sunday</h3>
+            <h2 class='title3'>Sunday</h2>
             <ul id="Sunday-List" class="schedule-list"></ul>
         </div>
     </div>

--- a/pages/project-meetings.html
+++ b/pages/project-meetings.html
@@ -14,7 +14,7 @@ permalink: /project-meetings
             Details about a team's meeting can be obtained in each team's slack channel.
         </p>
     </div>
-    <img class="header-hero-image" src="./assets/images/project-meetings-page/project-meetings-banner-image.png" alt="project meetings banner image">
+    <img class="header-hero-image" src="../assets/images/project-meetings-page/project-meetings-banner-image.png" alt="project meetings banner image">
 </div>
 
 <div class='covid-notification-banner'>

--- a/pages/project-meetings.html
+++ b/pages/project-meetings.html
@@ -24,31 +24,31 @@ permalink: /project-meetings
     <div class='page-card card-primary page-card-lg page-card--project-meetings'>
         <div id="userTimeZone" class='userTimeZone'></div>
         <div id="Monday">
-            <h2 class='title3'>Monday</h2>
+            <h2 class='day-header title3'>Monday</h2>
             <ul id="Monday-List" class="schedule-list"></ul>
         </div>
         <div id="Tuesday">
-            <h2 class='title3'>Tuesday</h2>
+            <h2 class='day-header title3'>Tuesday</h2>
             <ul id="Tuesday-List" class="schedule-list"></ul>
         </div>
         <div id="Wednesday">
-            <h2 class='title3'>Wednesday</h2>
+            <h2 class='day-header title3'>Wednesday</h2>
             <ul id="Wednesday-List" class="schedule-list"></ul>
         </div>
         <div id="Thursday">
-            <h2 class='title3'>Thursday</h2>
+            <h2 class='day-header title3'>Thursday</h2>
             <ul id="Thursday-List" class="schedule-list"></ul>
         </div>
         <div id="Friday">
-            <h2 class='title3'>Friday</h2>
+            <h2 class='day-header title3'>Friday</h2>
             <ul id="Friday-List" class="schedule-list"></ul>
         </div>
         <div id="Saturday">
-            <h2 class='title3'>Saturday</h2>
+            <h2 class='day-header title3'>Saturday</h2>
             <ul id="Saturday-List" class="schedule-list"></ul>
         </div>
         <div id="Sunday">
-            <h2 class='title3'>Sunday</h2>
+            <h2 class='day-header title3'>Sunday</h2>
             <ul id="Sunday-List" class="schedule-list"></ul>
         </div>
     </div>


### PR DESCRIPTION
Fixes #2089

### What changes did you make and why did you make them?

  - added the 'title3' utility class to decouple the font size from HTML heading tag.
  - changed 'h3' tags to 'h2' because there were no h2 elements on the page and these headings mark the second most important pieces of information in the document.
  - changed hero image src path to begin with "../" instead of "./" because it wasn't loading with "./" prefix. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->


<details>
<summary>Visuals before changes are applied</summary>

![Before-Full-iPad](https://user-images.githubusercontent.com/6194542/159995625-e3c7eb86-e1af-4c19-8dc3-c349323e6010.png)
![Before-Full-iPhone-X](https://user-images.githubusercontent.com/6194542/159995626-14a2c15b-802a-41b6-9108-aaa4f712c3f9.png)
![Before-Full-Generic-Laptop](https://user-images.githubusercontent.com/6194542/159995618-b2267e92-7a27-4703-8d78-6d2dded374d1.png)
</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after-desktop](https://user-images.githubusercontent.com/6194542/160941002-47870363-e955-4309-a93b-544928e9141f.png)
![after-tablet](https://user-images.githubusercontent.com/6194542/160941011-dad2c57f-655d-4775-b588-e975651fbf16.png)
![after-mobile](https://user-images.githubusercontent.com/6194542/160941012-440efa6c-8b29-47bd-b585-2bc3c845eb7e.png)


</details>
