### PR TITLE
Added tools section to current project cards

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -466,7 +466,7 @@ return `
             ${project.tools ?
             `
             <div class="project-tools">
-            <strong>tools: </strong>
+            <strong>Tools: </strong>
             ${ project.tools }
             </div>
             `:""

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -97,6 +97,9 @@ function retrieveProjectDataFromCollection(){
                             {%- if project.partner -%},
                             "partner": `{{ project.partner }}`
                             {%- endif -%}
+                            {%- if project.tools -%},
+                            "tools": `{{ project.tools }}`
+                            {%- endif -%}
                             {%- if project.looking -%},
                             "looking": {{ project.looking | jsonify }}
                             {%- endif -%}
@@ -456,6 +459,15 @@ return `
             <div class="project-partner">
             <strong>Partner: </strong>
             ${ project.partner }
+            </div>
+            `:""
+            }
+
+            ${project.tools ?
+            `
+            <div class="project-tools">
+            <strong>tools: </strong>
+            ${ project.tools }
             </div>
             `:""
             }


### PR DESCRIPTION
Fixes #2764

### What changes did you make and why did you make them ?

  -Added tools section to current-projects.js file in order to show the tools used on the project page itself. 
  -Now the individual project information pages and their respective cards will match. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![project_page_tools_BEFORE](https://user-images.githubusercontent.com/93153059/160446957-974b16cb-a349-424c-86a9-ffa243f00bc7.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![project_page_tools_AFTER](https://user-images.githubusercontent.com/93153059/160447008-8f874415-3db6-4260-9706-6d73a3dcaf68.png)

</details>
