### PR TITLE
fixed spelling of non-profit to nonprofit, line 77, join-us.html

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   hfla_site:
-    image: jekyll/jekyll:4.2.0
+    image: jekyll/jekyll:pages
     container_name: hfla_site
     command: jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   hfla_site:
-    image: jekyll/jekyll:pages
+    image: jekyll/jekyll:4.2.0
     container_name: hfla_site
     command: jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I
     environment:

--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -74,7 +74,7 @@ permalink: /join
           the right resources.
         </p>
         <a href="./survey4" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Government Contact Form">Government</a>
-        <a href="./survey3" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Non-profit Contact Form">NonProfit</a>
+        <a href="./survey3" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Non-profit Contact Form">Nonprofit</a>
         <a href="./survey6" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="General Contact Form">Other</a>
       </div>
     </div>

--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -74,7 +74,7 @@ permalink: /join
           the right resources.
         </p>
         <a href="./survey4" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Government Contact Form">Government</a>
-        <a href="./survey3" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Non-profit Contact Form">Non-Profit</a>
+        <a href="./survey3" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Non-profit Contact Form">NonProfit</a>
         <a href="./survey6" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="General Contact Form">Other</a>
       </div>
     </div>

--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -74,7 +74,7 @@ permalink: /join
           the right resources.
         </p>
         <a href="./survey4" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Government Contact Form">Government</a>
-        <a href="./survey3" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Non-profit Contact Form">Nonprofit</a>
+        <a href="./survey3" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="Nonprofit Contact Form">Nonprofit</a>
         <a href="./survey6" target="_blank" class="btn btn-primary btn-md btn-partner-with-us btn--default" title="General Contact Form">Other</a>
       </div>
     </div>


### PR DESCRIPTION
Fixes #2914

### What changes did you make and why did you make them ?

  - Changed text on line 77 in the join-us.html page from non-profit to nonprofit. 
  -
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](
![Screen Shot 2022-04-21 at 7 53 42 PM](https://user-images.githubusercontent.com/89555843/164587813-a3351a98-01d2-42b4-9b87-4ac628fec41e.png)
)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](
![Screen Shot 2022-04-21 at 8 00 30 PM](https://user-images.githubusercontent.com/89555843/164587845-a87014dd-cda1-4511-81b4-927d690fb43e.png)
)

</details>
