### PR TITLE
Remove type field 2793

### DIFF
--- a/_data/internal/credits/avatar.yml
+++ b/_data/internal/credits/avatar.yml
@@ -1,12 +1,11 @@
 ---
 title: Avatar
 title-link: https://thenounproject.com/search/?q=avatar&i=2309777
-content: icon
+content-type: image
 used-in: Wins Page
 artist: Nawicon
 provider: Noun Project 
 provider-link: https://thenounproject.com/
 image-url: /assets/images/wins-page/avatar-default.svg
 alt: 'Avatar Icon'
-type: icon
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   hfla_site:
-    image: jekyll/jekyll:4.2.0
+    image: jekyll/jekyll:pages
     container_name: hfla_site
     command: jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   hfla_site:
-    image: jekyll/jekyll:pages
+    image: jekyll/jekyll:4.2.0
     container_name: hfla_site
     command: jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I
     environment:


### PR DESCRIPTION
Fixes #2793 

### What changes did you make and why did you make them ?

  - Deleted 'type' field from credits yml file in `_data/internal/credits/avatar.yml` because it is now redundant
  - Changed 'content' field to 'content-type' in `_data/internal/credits/avatar.yml` to make its purpose clearer for devs

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Edited a credits yml file to add clarity to its fields. No visual changes to the website.
