### PR TITLE
Implemented New Design For Toolkit Mobile Menu

### DIFF
--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -235,8 +235,6 @@
         max-width: 250px;
     }
     .suggest-guide-group {
-        // flex-direction: column;
-        // padding: 0;
         margin: 1.2rem 1rem;
 
         h2 {

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -208,17 +208,7 @@
     }
 
     .external-resources-text {
-      text-align: left;
-    }
-}
-
-@media #{$bp-below-mobile} {
-    .toolkit-header {
-
-        &__banner-item {
-            font-size: .5rem;
-            max-width: 3.6rem;
-        }
+    text-align: left;
     }
 }
 
@@ -245,9 +235,9 @@
         max-width: 250px;
     }
     .suggest-guide-group {
-        flex-direction: column;
-        padding: 0;
-        margin: 0;
+        // flex-direction: column;
+        // padding: 0;
+        margin: 1.2rem 1rem;
 
         h2 {
             margin-bottom: 1rem;
@@ -260,6 +250,54 @@
         flex-direction: column;
     }
     .external-resources-text {
-      text-align: center;
+    text-align: center;
     }
+    
+}
+
+@media #{$bp-below-mobile} {
+
+    .toolkit-header {
+
+        &__text-group {
+            display: none;
+        }
+
+        &__banner-item {
+            display: none;
+        }
+    }
+}
+
+.dropdown {
+    margin: 0 auto;
+}
+#dropdown-select {
+    width: 310px;
+    height: 44px;
+    background: #FFFFFF;
+    border: 1px solid rgba(0, 0, 0, 0.24);
+    box-sizing: border-box;
+    border-radius: 5px;
+}
+
+@media #{$bp-mobile-up} {
+    .dropdown {
+        display: none;
+    }
+    #dropdown-select {
+        display: none;
+        }
+    }
+
+// For display on very narrow screens such as Galaxy Fold. There are currently
+// no sitewide settings for this size screen:
+@media (max-width: 281px) {
+    .suggest-guide-group {
+        display: block;    
+    }
+    #dropdown-select {
+        width: 216px;
+    }
+
 }

--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -249,8 +249,7 @@
     }
     .external-resources-text {
     text-align: center;
-    }
-    
+    }   
 }
 
 @media #{$bp-below-mobile} {
@@ -297,5 +296,4 @@
     #dropdown-select {
         width: 216px;
     }
-
 }

--- a/pages/toolkit.html
+++ b/pages/toolkit.html
@@ -32,6 +32,14 @@ permalink: /toolkit/
         <h2 class="title3">Guides</h2>
         <button class="btn btn-primary btn-md-narrow">Suggest a guide</button>
       </div>
+    <div class="dropdown"> 
+        {% assign category_list = "All, Development, Design, Project Management, Professional Development" | split: ", " %}
+        <select id ="dropdown-select">
+        {% for category in category_list %}
+        <option value="#{{category | replace: ' ', '+'}}">{{category}}</option>
+        {% endfor %}
+        </select>
+    </div>
         <!-- Iterating through toolkitPages collection -->
             {%- assign guides = site.guide-pages | sort: "title" -%}
             {%- for item in guides -%}
@@ -62,6 +70,11 @@ permalink: /toolkit/
               }
           });
       });
+      //add handler for dropdown navigation selection
+        document.getElementById("dropdown-select").onchange = function() {
+            window.location.href = this.value;
+        }
+
           //add listener for url change and toggle visible cards.
           window.addEventListener("hashchange", hashFilter);
           function hashFilter(e) {


### PR DESCRIPTION
Implemented New Design For Toolkit Mobile Menu

Fixes #2391

### What changes did you make and why did you make them ?

  - Added dropdown navigation menu for project guide navigation on mobile devices. Dropdown appears on mobile only. (toolkit.scss, lines 272-299, toolkit.html, lines 35-42)
  - Added media query to hide current project guide nav bar on mobile screens (toolkit.scss lines 258-267).
  - Added onchange function (Javascript) to redirect on selection from mobile menu (toolkit.html lines 273-276).
  - Removed lines 238 and 239 from suggest-guide-group class so that elements display side by side on mobile, as per Figma design.
  - Removed lines 215-221 from toolkit.scss, as they were redundant and interfered with with new mobile implementation
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![mobile_before](https://user-images.githubusercontent.com/81049661/166132982-7755e21b-aa3a-473f-ba9d-95aaca452ec1.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![mobile_after](https://user-images.githubusercontent.com/81049661/166132994-67b70fd6-f673-4d1b-ac74-d9494bc12e5e.png)

</details>



