### PR TITLE
Remove alt-hero field from civic-opportunity-project.md #2923

### DIFF
--- a/_projects/civic-opportunity-project.md
+++ b/_projects/civic-opportunity-project.md
@@ -5,7 +5,6 @@ description: The mission of the Civic Opportunity project is to develop and cura
 image: /assets/images/projects/civic-opportunity-project.jpg
 alt: 'Wireframing and designing process for Civic Opportunity Project, there are hands pointing to a tablet and papers of the low fidelity prototyping.'
 image-hero: /assets/images/projects/civic-opportunity-project-hero.png
-alt-hero: 'Wireframing and designing process for Civic Opportunity Project, there are hands pointing to a tablet and papers of the low fidelity prototyping.'
 leadership:
   - name: Ray Fambro
     role: Product Manager


### PR DESCRIPTION
Fixes #2923

### What changes did you make and why did you make them ?

  - Removed line 8 which was "alt-hero: 'Wireframing and designing process for Civic Opportunity Project, there are hands pointing to a tablet and papers of the low fidelity prototyping.'"
  - alt-hero is the alt text associated with image-hero, but alt-hero is not used anywhere and is therefore being deleted.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes were made, no pictures are needed.

