### PR TITLE
Remove Unused Alt-Text Field in Toolkit Guides HTML Files: github-issues, use-of-images, 1password (file names abbreviated)

### DIFF
--- a/_guide-pages/github-issues.html
+++ b/_guide-pages/github-issues.html
@@ -16,7 +16,6 @@ status: coming-soon
 display: true
 category: Development
 svg: svg/default.svg
-alt-text: default-toolkit-image
 provider-link: '/guide-pages/github-issues'
 ---
 

--- a/_guide-pages/responsible-use-of-images-on-opensource-projects.html
+++ b/_guide-pages/responsible-use-of-images-on-opensource-projects.html
@@ -7,6 +7,5 @@ status: coming-soon
 display: true
 category: Design
 svg: svg/default.svg
-alt-text: default-toolkit-image
 provider-link: ''
 ---

--- a/_guide-pages/setting-up-1password-on-opensource-project.html
+++ b/_guide-pages/setting-up-1password-on-opensource-project.html
@@ -7,6 +7,5 @@ status: coming-soon
 display: true
 category: Project Management
 svg: svg/default.svg
-alt-text: default-toolkit-image
 provider-link: ''
 ---


### PR DESCRIPTION
Fixes #2930

### What changes did you make and why did you make them ?

  - Removed unused alt-text field in toolkit guides: github-issues.html, responsible-use-of-images-on-opensource-projects.html, setting-up-1password-on-opensource-projects.html. Per the associated issue, this was done because the alt-text field in the relevant files is presently unused, and removing unused code can help to lower the website load time, enable the code to be easier to understand, and reduce the time to review the code.
  - Per the action items in the associated issue, the updated site was then checked against the current site to ensure no visible changes occurred in the removal of the alt-text fields.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

N/A—no visible changes to the website occurred.
