### PR TITLE
Update styling 404 page 2097

### DIFF
--- a/_sass/components/_404.scss
+++ b/_sass/components/_404.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-flow: row;
   justify-content: center;
-  align-items: center; 
+  align-items: center;
   padding: 120px;
 
   @media #{$bp-below-desktop} {
@@ -17,7 +17,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    margin: 0px 20px;
+    margin: 0px 62px;
     padding-top: 80px;
     padding-bottom: 20px;
   }
@@ -30,9 +30,9 @@
     line-height: 2.5;
     color: #FA114F;
   }
-  
-  a { 
-    text-decoration: none; 
+
+  a {
+    text-decoration: none;
   }
 }
 
@@ -91,7 +91,7 @@
   font-size: 24px;
   color: #000000;
   opacity: 0.5;
-  margin-bottom: 80px;  
+  margin-bottom: 80px;
 
   @media #{$bp-below-desktop} {
     margin-bottom: 0px;

--- a/_sass/components/_404.scss
+++ b/_sass/components/_404.scss
@@ -17,7 +17,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    margin: 0px 62px;
+    margin: 0px 60px;
     padding-top: 100px;
     padding-bottom: 20px;
   }
@@ -100,7 +100,8 @@
   @media #{$bp-below-tablet} {
     margin-top: 10px;
     margin-bottom: 5px;
-    font-size: 18px;
+    margin-right: 5px;
+    font-size: 16px;
   }
 }
 

--- a/_sass/components/_404.scss
+++ b/_sass/components/_404.scss
@@ -18,7 +18,7 @@
     justify-content: center;
     align-items: center;
     margin: 0px 62px;
-    padding-top: 80px;
+    padding-top: 100px;
     padding-bottom: 20px;
   }
 

--- a/_sass/components/_404.scss
+++ b/_sass/components/_404.scss
@@ -96,6 +96,12 @@
   @media #{$bp-below-desktop} {
     margin-bottom: 0px;
   }
+
+  @media #{$bp-below-tablet} {
+    margin-top: 10px;
+    margin-bottom: 5px;
+    font-size: 18px;
+  }
 }
 
 .link-message-404 {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   hfla_site:
-    image: jekyll/jekyll:4.2.0
+    image: jekyll/jekyll:pages
     container_name: hfla_site
     command: jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   hfla_site:
-    image: jekyll/jekyll:pages
+    image: jekyll/jekyll:4.2.0
     container_name: hfla_site
     command: jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I
     environment:


### PR DESCRIPTION
Fixes #2097 

### What changes did you make and why did you make them ?

  - Added left/right margin to 404 page to match figma design
  - Added top/bottom margin to main-message-404 element
  - Lowered font size for main-message-404 element

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/63172733/172243958-be858278-9e03-4d8e-a97d-bab8a5cbba75.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/63172733/172244436-52ad0f47-ed67-4f28-bf10-14da4b7fe113.png)


</details>
