### PR TITLE
Remove alt-hero field from vrms.md project file

### DIFF
--- a/_projects/vrms.md
+++ b/_projects/vrms.md
@@ -5,7 +5,6 @@ description: VRMS is a browser-based software tool created by Hack for LA (HfLA)
 image: /assets/images/projects/vrms.png
 alt: 'VRMS logo. VRMS homepage.'
 image-hero: /assets/images/projects/vrms-hero.png
-alt-hero: 'City of LA skyline at dusk.'
 leadership:
   - name: Alex Anakin
     role: Software Architect / Tech Lead


### PR DESCRIPTION
Fixes #3214

### What changes did you make and why did you make them ?

  - Removed the `alt-hero` field from `_projects/vrms.md`
    - This field isn't used anywhere in the codebase, since the hero image is a CSS background image.  
    - If the hero image were used in an HTML tag, the `alt=""` properties could be set using information from other fields in this file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Editing this file did not create any visual changes.
