### PR TITLE
added a new note in section 2.2 before the existing one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,6 +353,8 @@ And the following **size** labels:
 * `size: Medium`
 * `size: Large`
 
+**Note:** The Prioritized Backlog column is filtered so the first (top) issue has the highest priority and should be worked on next. <br />
+
 **Note:** if you would like to learn more about our label system you can read this [wiki on how to read and interpret our repo labels](https://github.com/hackforla/website/wiki/How-to-read-and-interpret-labels)
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>


### PR DESCRIPTION
Fixes #3018 

### What changes did you make and why did you make them ?

  - I added a new note "Note: The Prioritized Backlog column is filtered so the first (top) issue has the highest priority and should be worked on next." to section 2.2 of the Contributing.md file.
   This was done to clarify the process for choosing new issues to work on for the new members, so that higher priority issues can be worked upon first.
  - 
  -
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
![1-before](https://user-images.githubusercontent.com/103976465/172702234-bee4dab7-3387-4d7d-bedb-c48ed97adf63.jpg)


![image](https://user-images.githubusercontent.com/103976465/172702234-bee4dab7-3387-4d7d-bedb-c48ed97adf63.jpg)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![2-After](https://user-images.githubusercontent.com/103976465/172702439-807c401d-55a1-462c-8d5d-bb0c0d1bfe28.jpg)

![image](https://user-images.githubusercontent.com/103976465/172702439-807c401d-55a1-462c-8d5d-bb0c0d1bfe28.jpg)

</details>
