### PR TITLE
Removed the alt text for the 311 project card image

### DIFF
--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -68,7 +68,7 @@ solution: We partnered with the Los Angeles Department of Neighborhood Empowerme
 impact: Neighborhood Councils are able to use visualizations to demonstrate and discuss the city service levels with constituents and determine where to send mailings to target information to those parts of their community not availing themselves of specific city services.
 sdg: '<strong>16.8:</strong> Broaden and strengthen the awareness and participation of City and local communities, especially those traditionally underserved and marginalized, in the institutions of local and global governance.'
 card-image-src: /assets/images/projects/311.jpg
-card-image-alt: 311 project card
+card-image-alt:
 sdg-image-src: /assets/images/about/sdg-elements/peace-justice.svg
 sdg-image-alt: peace justice bottom sustainable dev goal
 ---


### PR DESCRIPTION
Fixes #3090

### What changes did you make and why did you make them ?

  - Removed alt text

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
Alt text highlighted

![Sustainable Development Goal](https://user-images.githubusercontent.com/11727808/173479031-924ba4e2-2569-4b15-974c-120fa7b4c8bd.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="566" alt="O localhost4000citizen-engagement" src="https://user-images.githubusercontent.com/11727808/173462266-31618206-2dc8-4437-a152-43293eaf1b36.png">

</details>
