### PR TITLE
Updated calendar-time.yml in Credits Page - #2800

### DIFF
--- a/_data/internal/credits/calendar-time.yml
+++ b/_data/internal/credits/calendar-time.yml
@@ -1,12 +1,11 @@
 ---
 title: Calendar Time
 title-link: https://thenounproject.com/kmgdesignid/collection/calendar-time-line/?i=3256421
-content: icon
+content-type: image
 used-in: Getting Started
 artist: Kmg Design
 provider: Noun Project
 provider-link: 'https://thenounproject.com/'
 image-url: /assets/images/getting-started/proj-2.png
 alt: 'Image of Calendar Time'
-type: icon
 ---


### PR DESCRIPTION
Fixes #2800

### What changes did you make and why did you make them ?

  - changed line 4 of calendar-time.yml from content field to content: icon
  - removed line 11 for type field
  - the information was redundant, and using content-type makes it clearer for developers what the content is used for in the future

No visible changes were made to the website.