### PR TITLE
Renamed content field and removed type field in credits's redo.yml

### DIFF
--- a/_data/internal/credits/redo.yml
+++ b/_data/internal/credits/redo.yml
@@ -1,12 +1,11 @@
 ---
 title: Redo
 title-link: https://thenounproject.com/search/?q=next%20arrow&i=1781061
-content: icon
+content-type: image
 used-in: Getting Started
 artist: Numero Uno
 provider: Noun Project
 provider-link: 'https://thenounproject.com/'
 image-url: /assets/images/getting-started/onboard-4.png
 alt: 'Redo Icon'
-type: icon
 ---


### PR DESCRIPTION
Fixes #2876 

### What changes did you make and why did you make them ?

  - Renamed the `content` field to `content-type` on `_data/internal/credits/redo.yml` to merge it with the redundant `type` field
  - Deleted the `type` field on `_data/internal/credits/redo.yml`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Edited a field on a data file. No visual changes to the website.