### PR TITLE
Update docker-compose.yml file to use hackforla image instead of jekyll/jekyll:pages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   hfla_site:
-    image: jekyll/jekyll:pages
+    image: hackforlaops/ghpages:latest
     container_name: hfla_site
     command: jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I
     environment:


### PR DESCRIPTION
Fixes #3068

### What changes did you make and why did you make them ?

  - In `docker-compose.yml` file, changed value of `image:` key from `jekyll/jekyll:pages` to `hackforlaops/ghpages:latest`
  - This fixes the various Jekyll/Ruby errors new volunteers have been experiencing when setting up Docker for the first time, and eliminates the need for the current temp fix (changing `image:` to `jekyll/jekyll:4.2.0`)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Updated a Docker config file in the root of website directory. No visual changes to the website.