### PR TITLE
Updating food oasis profile #3232

### DIFF
--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -7,42 +7,49 @@ alt: 'Stacks of freshly harvested beets'
 image-hero: /assets/images/projects/food-oasis-hero.jpg
 alt-hero: 'Stacks of freshly harvested carrots, beets and vegetables'
 leadership:
-  - name: John Darragh
+  - name: John
     role: Architect & Technology Lead
     links:
       slack: "https://hackforla.slack.com/team/UFLDX9V19"
       github: "https://github.com/entrotech"
     picture: https://avatars.githubusercontent.com/entrotech
-  - name: Erika Gill
-    role: Product Manager
-    links:
-      slack: "https://hackforla.slack.com/team/U01NB9SEKUJ"
-      github: "https://github.com/erigilg"
-    picture: https://avatars.githubusercontent.com/erigilg
-  - name: Katie Jensen
-    role: Product Manager
-    links:
-      slack: "https://hackforla.slack.com/team/U01JKTLQGBF"
-      github: "https://github.com/ktjnyc"
-    picture: https://avatars.githubusercontent.com/ktjnyc
-  - name: Andrew Strauss
-    role: Product Manager
-    links:
-      slack: "https://hackforla.slack.com/team/U018LSRS37Y"
-      github: "https://github.com/pageignited"
-    picture: https://avatars.githubusercontent.com/pageignited
-  - name: Thy Tran
-    role: Subject Matter Expert & User Researcher
-    links:
-      slack: "https://hackforla.slack.com/team/U01R74KS81Y"
-      github: "https://github.com/wanderingspoon"
-    picture: https://avatars.githubusercontent.com/wanderingspoon
   - name: Bryan Wu
-    role: UX Designer
+    role: Design Lead
     links:
       slack: "https://hackforla.slack.com/team/U01PG6RD0T1"
       github: "https://github.com/fancyham"
     picture: https://avatars.githubusercontent.com/fancyham
+  - name: Jieun Ryu
+    role: UX Researcher
+    links:
+      slack: "https://hackforla.slack.com/team/U02LL2DF4HL"
+      github: "https://github.com/ryu-jieun"
+    picture: https://avatars.githubusercontent.com/ryu-jieun
+  - name: Gigi Patel
+    role: UX Researcher
+    links:
+      slack: "https://hackforla.slack.com/team/U02KZ8WSHHV"
+      github: "https://github.com/LIlinit"
+    picture: https://avatars.githubusercontent.com/LIlinit
+  - name: Virginia Wu
+    role: Full Stack Engineer
+    links:
+      slack: "https://hackforla.slack.com/team/U02G7SBKSV7"
+      github: "https://github.com/VirginiaWu11"
+    picture: https://avatars.githubusercontent.com/VirginiaWu11
+  - name: Seiko Igi
+    role: Product Designer
+    links:
+      slack: "https://hackforla.slack.com/team/U02U55MQEQ7"
+      github: "https://github.com/sei1122"
+    picture: https://avatars.githubusercontent.com/sei1122
+  - name: Hannah Zulueta
+    role: Full Stack Engineer
+    links:
+      slack: "https://hackforla.slack.com/team/U01G7AH18J3"
+      github: "https://github.com/hanapotski"
+    picture: https://avatars.githubusercontent.com/hanapotski 
+
 links:
   - name: GitHub
     url: "https://github.com/hackforla/food-oasis"

--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -7,7 +7,7 @@ alt: 'Stacks of freshly harvested beets'
 image-hero: /assets/images/projects/food-oasis-hero.jpg
 alt-hero: 'Stacks of freshly harvested carrots, beets and vegetables'
 leadership:
-  - name: John
+  - name: John Darragh
     role: Architect & Technology Lead
     links:
       slack: "https://hackforla.slack.com/team/UFLDX9V19"
@@ -29,8 +29,8 @@ leadership:
     role: UX Researcher
     links:
       slack: "https://hackforla.slack.com/team/U02KZ8WSHHV"
-      github: "https://github.com/LIlinit"
-    picture: https://avatars.githubusercontent.com/LIlinit
+      github: "https://github.com/GigiUxR"
+    picture: https://avatars.githubusercontent.com/GigiUxR
   - name: Virginia Wu
     role: Full Stack Engineer
     links:


### PR DESCRIPTION
Fixes #3232

### What changes did you make and why did you make them ?

  - I updated the food oasis profile
  - deleted the leadership people and changed it to :
 Name: John
GitHub handle: @entrotech
Role: Architect and Technology Lead
Slack ID: UFLDX9V19

Name: Bryan Wu
GitHub handle: @fancyham
Role: Design Lead
Slack ID: U01PG6RD0T1

Name: Jieun Ryu
GitHub handle: @ryu-jieun
Role: UX Researcher
Slack ID: U02LL2DF4HL

Name: Gigi Patel
GitHub handle: @LIlinit
Role: UX Researcher
Slack ID: U02KZ8WSHHV

Name: Virginia Wu
GitHub handle: VirginiaWu11
Role: Full Stack Engineer
Slack ID: U02G7SBKSV7

Name: Seiko Igi
GitHub handle: @sei1122
Role: Product Designer
Slack ID: U02U55MQEQ7

Name: Hannah Zulueta
GitHub handle: hanapotski
Role: Full Stack Engineer
Slack ID: U9SCMTNK0 ( I actually used a different slack id, one that I got off slack for Hannah Zulueta because this one did not connect to an account) - This was the one I used (U01G7AH18J3)
- I made these changes so the Food Oasis could have an updated profile with the people who are currently on the leadership team and all of their roles were described accurately.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="840" alt="Screen Shot 2022-06-26 at 10 51 39 AM" src="https://user-images.githubusercontent.com/103547011/175999709-5a6bf6bd-122d-4ff2-8d1a-232411d0a383.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="840" alt="Screen Shot 2022-06-26 at 10 50 44 AM" src="https://user-images.githubusercontent.com/103547011/175999784-b042cc0a-2802-430f-ab22-7e6e1aa0af41.png">

</details>
