### PR TITLE
Updated credit for Dicussion Teamwork image

### DIFF
--- a/_data/internal/credits/discussion-teamwork.yml
+++ b/_data/internal/credits/discussion-teamwork.yml
@@ -1,12 +1,11 @@
 ---
-title: Product Management
+title: Discussion Teamwork
 title-link: https://thenounproject.com/kerismaker/collection/product-management-line/?i=3656728
-content: icon
-used-in: Home
+content-type: image
+used-in: Homepage
 artist: Tezar Tantular
-provider: Noun Project 
+provider: Noun Project
 provider-link: https://thenounproject.com/
 image-url: /assets/images/hero/communities-icons/product-management.png
-alt: 'Product Management Icon'
-type: icon
+alt: ''
 ---


### PR DESCRIPTION
Fixes #3131 

### What changes did you make and why did you make them ?

For `_data/internal/credits/product-management.yml`,
  - Changed the file name from `product-management.yml` to `discussion-teamwork.yml`
  - Changed `title: Product Management` to `title: Discussion Teamwork`
  - Changed `content: icon` to `content-type: image`
  - Changed `used-in: Home` to `used-in: Homepage`
  - Changed `alt: 'Product Management Icon'` to `alt: ''`
  - Removed `type: icon`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/44044350/177834938-5b2602dc-f0bc-441a-97cb-8a293ddddeb2.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/44044350/177834715-051934d9-4b66-47e1-b0de-436fc80608cb.png)

</details>
