### PR TITLE
Add Anchors to Join Us page sections

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -25,6 +25,7 @@ permalink: /join
   </div>
 
   <div class="content-section join-us-card-container">
+    <a class="anchor" id="advise"></a>
     <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
       <h2 class="title4 page-card--large-icon-header">Advise Us</h2>
       <img class="join-us-card-img" src="/assets/images/join-us/advice-us-icon.svg" alt="join us card image" />
@@ -47,6 +48,7 @@ permalink: /join
       </div>
     </div>
 
+    <a class="anchor" id="volunteer"></a>
     <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
       <h2 class="title4 page-card--large-icon-header">Volunteer with Us</h2>
       <img class="join-us-card-img" src="/assets/images/join-us/volunteer-with-us-icon.svg" alt="join us card image" />
@@ -65,6 +67,7 @@ permalink: /join
       </div>
     </div>
 
+    <a class="anchor" id="partner"></a>
     <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
       <h2 class="title4 page-card--large-icon-header">Partner with Us</h2>
       <img class="join-us-card-img" src="/assets/images/join-us/partner-with-us-icon.svg" alt="join us card image" />


### PR DESCRIPTION
Added anchors to Advise Us, Volunteer with Us, and Partner with Us

Fixes #3026

### What changes did you make and why did you make them ?

  - Added anchor to Advise Us section
  - Added anchor to Volunteer with Us section
  - Added anchor to Partner with Us section

### Screenshots of Proposed Changes Of The Website

<details><summary>Visuals after changes are applied</summary>
 
![anchors](https://user-images.githubusercontent.com/88953806/180066365-81f30a2c-9b4e-47bc-a8fc-30a9087f1caf.gif)

Navigating to /join/#advise will jump to Advise Us.
Navigating to /join/#volunteer will jump to Volunteer with Us.
Navigating to /join/#partner will jump to Partner with Us.

</details>
