### PR TITLE
Change alt text for Marvista community council image

### DIFF
--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -53,7 +53,7 @@ permalink: /citizen-engagement
                     <img class="org-img" src="/assets/images/citizen-engagement/la_county_open_data.svg" alt="county of los angeles open data logo">
                     <img class="org-img" src="/assets/images/citizen-engagement/voices_neighborhood_council.svg" alt="Voices Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/mid_city_neighborhood_council.svg" alt="MINC mid-city neighborhood council logo">
-                    <img class="org-img" src="/assets/images/citizen-engagement/mar_vista_community_council.svg" alt="Join Us! marvista.org | mar vista community college logo">
+                    <img class="org-img" src="/assets/images/citizen-engagement/mar_vista_community_council.svg" alt="Marvista Community Council">
                 </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes #3107

### What changes did you make and why did you make them ?

  - Changed alt text for Marvista community council image on [citizen engagement page](https://www.hackforla.org/citizen-engagement) from "Join Us! marvista.org | mar vista community college logo" to "Marvista Community Council"
  - This change was made to better conform to Web Content Accessibility Guidelines

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visible changes to website.