### PR TITLE
Alt Text Change for Palms Image

### DIFF
--- a/_data/internal/credits/delegate.yml
+++ b/_data/internal/credits/delegate.yml
@@ -1,12 +1,11 @@
 ---
 title: People Network
 title-link: https://thenounproject.com/search/?q=people+network&i=2228897
-content: icon
+content-type: image
 used-in: Join Us
 artist: Sérgio Filipe Cardoso Pires, PT
 provider: Noun Project
 provider-link: https://thenounproject.com/
 image-url: /assets/images/join-us/advice-us-icon.svg
 alt: 'Delegate Icon'
-type: icon
 --- 

--- a/_data/internal/credits/delegate.yml
+++ b/_data/internal/credits/delegate.yml
@@ -1,11 +1,12 @@
 ---
 title: People Network
 title-link: https://thenounproject.com/search/?q=people+network&i=2228897
-content-type: image
+content: icon
 used-in: Join Us
 artist: Sérgio Filipe Cardoso Pires, PT
 provider: Noun Project
 provider-link: https://thenounproject.com/
 image-url: /assets/images/join-us/advice-us-icon.svg
 alt: 'Delegate Icon'
+type: icon
 --- 

--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -48,7 +48,7 @@ permalink: /citizen-engagement
                 <div class="organizations-images">
                     <img class="org-img org-img-large" src="/assets/images/sponsors/code-for-america.svg" alt="code for america logo"/>
                     <img class="org-img" src="/assets/images/citizen-engagement/la_neighborhood_councils.svg" alt="neighborhood councils empower LA: department of neighborhood empowerment logo">
-                    <img class="org-img" src="/assets/images/citizen-engagement/palms_neighborhood_council.svg" alt="palms neighborhood council logo">
+                    <img class="org-img" src="/assets/images/citizen-engagement/palms_neighborhood_council.svg" alt="Palms Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/echo_park_neighborhood_council.svg" alt="Echo Park Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/la_county_open_data.svg" alt="county of los angeles open data logo">
                     <img class="org-img" src="/assets/images/citizen-engagement/voices_neighborhood_council.svg" alt="Voices Neighborhood Council">


### PR DESCRIPTION
Fixes #3102

### What changes did you make and why did you make them ?

  - Changed line 51 from `alt="palms neighborhood council logo"` to `alt="Palms Neighborhood Council"`
  - Change were made to adhere to WCAG to make the alt text shorter

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Changing the alt text. No visual changes to the website.
