### PR TITLE
Change line 160 from .js file - 3166

### DIFF
--- a/github-actions/trigger-schedule/github-data/get-project-data.js
+++ b/github-actions/trigger-schedule/github-data/get-project-data.js
@@ -157,7 +157,7 @@ async function getCommentContributors(repo, dateLastRan) {
 }
 
 /**
- * Fetches comment contributors for a given repo
+ * Requests owner login for a given repo.
  * @param {Object} repo     [Repository object from GitHub]
  * @return {Object}     [An object containing parameters for making a contributors data request]
  */


### PR DESCRIPTION
Fixes #3166 

### What changes did you make and why

  - Changed line 160 from the .js file because the comment does not fetch the comment contributors for a given repo.
  - Completed this task by using a text editor
  - Changed comment to "Requests owner login for a given repo."
