### PR TITLE
Changed alt text for LA Open Data image

### DIFF
--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -50,7 +50,7 @@ permalink: /citizen-engagement
                     <img class="org-img" src="/assets/images/citizen-engagement/la_neighborhood_councils.svg" alt="neighborhood councils empower LA: department of neighborhood empowerment logo">
                     <img class="org-img" src="/assets/images/citizen-engagement/palms_neighborhood_council.svg" alt="palms neighborhood council logo">
                     <img class="org-img" src="/assets/images/citizen-engagement/echo_park_neighborhood_council.svg" alt="Echo Park Neighborhood Council">
-                    <img class="org-img" src="/assets/images/citizen-engagement/la_county_open_data.svg" alt="county of los angeles open data logo">
+                    <img class="org-img" src="/assets/images/citizen-engagement/la_county_open_data.svg" alt="County of Los Angeles Open Data">
                     <img class="org-img" src="/assets/images/citizen-engagement/voices_neighborhood_council.svg" alt="Voices Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/mid_city_neighborhood_council.svg" alt="MINC mid-city neighborhood council logo">
                     <img class="org-img" src="/assets/images/citizen-engagement/mar_vista_community_council.svg" alt="Join Us! marvista.org | mar vista community college logo">


### PR DESCRIPTION
Fixes #3104

### What changes did you make and why did you make them ?

  -On line 53, changed alt text from "los angeles open data logo" to "County of Los Angeles Open Data"
  -
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes to website, other than alt text being updated