### PR TITLE
Edit credit for data science image in feature-homepage-launch

### DIFF
--- a/_data/internal/credits/data-science.yml
+++ b/_data/internal/credits/data-science.yml
@@ -1,12 +1,11 @@
 ---
 title: Data Science
-title-link: https://thenounproject.com/mb.icons/collection/artificial-intelligence-solid/?i=1705416
-content: icon
-used-in: Home
+title-link: https://thenounproject.com/search/?q=data+science&i=1705416
+content-type: image
+used-in: Homepage
 artist: Med Marki
 provider: Noun Project 
 provider-link: https://thenounproject.com/
 image-url: /assets/images/hero/communities-icons/data-science.png
-alt: 'Data Science Icon'
-type: icon
+alt: ''
 ---


### PR DESCRIPTION
Fixes #3331

### What changes did you make and why did you make them ?
Per the issue requirements, I made the following changes to `_data/internal/credits/data-science.yml`:
  - Change
`title-link: https://thenounproject.com/mb.icons/collection/artificial-intelligence-solid/?i=1705416`
to
`title-link: https://thenounproject.com/search/?q=data+science&i=1705416`
  - Change `content: icon` to `content-type: image`
  - Change `used-in: Home` to `used-in: Homepage`
  - Change `alt: 'Data Science Icon'` to `alt: ''`
  - Remove `type: icon`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="319" alt="Screen Shot 2022-08-11 at 12 50 14 PM" src="https://user-images.githubusercontent.com/82679637/184227220-4407aa87-a1b4-4747-ba11-6230321ff93b.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="379" alt="Screen Shot 2022-08-11 at 12 42 33 PM" src="https://user-images.githubusercontent.com/82679637/184227354-35e8510b-14e5-4b8e-a252-bc1cdfe40fea.png">

</details>
