### PR TITLE
Replace hex value for redpurple to its color value

### DIFF
--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -348,7 +348,7 @@ a.anchor {
 }
 
 .color-brown {
-  color: #8e1737;
+  color: $color-redpurple;
   font-weight: 700;
 }
 

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -38,7 +38,9 @@ $color-dodgerblue: #1587FF;
 $color-skyblue: #89cff0;
 
 // Violets
+$color-blueviolet: #571DD1;
 $color-redpurple: #8e1737;
+$color-darkorchid: #981DD1;
 
 // Browns
 

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -38,9 +38,7 @@ $color-dodgerblue: #1587FF;
 $color-skyblue: #89cff0;
 
 // Violets
-$color-blueviolet: #571DD1;
 $color-redpurple: #8e1737;
-$color-darkorchid: #981DD1;
 
 // Browns
 


### PR DESCRIPTION
Fixes #2205

### What changes did you make and why did you make them ?

  - Changed all hex values associated to purple with their respective color value
  - In this case, only "redpurple" had a matching case to replace.
  - Deleted the other two purple colors from _colors.scss, since they were not found. Please make sure this part was done correctly!!!

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

None
