### PR TITLE
Replacing Alt Text on Citizen Engagement Page

### DIFF
--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -47,7 +47,7 @@ permalink: /citizen-engagement
                 </div>
                 <div class="organizations-images">
                     <img class="org-img org-img-large" src="/assets/images/sponsors/code-for-america.svg" alt="code for america logo"/>
-                    <img class="org-img" src="/assets/images/citizen-engagement/la_neighborhood_councils.svg" alt="neighborhood councils empower LA: department of neighborhood empowerment logo">
+                    <img class="org-img" src="/assets/images/citizen-engagement/la_neighborhood_councils.svg" alt="Lost Angeles Department of Neighborhood Empowerment">
                     <img class="org-img" src="/assets/images/citizen-engagement/palms_neighborhood_council.svg" alt="Palms Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/echo_park_neighborhood_council.svg" alt="Echo Park Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/la_county_open_data.svg" alt="County of Los Angeles Open Data">

--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -47,7 +47,7 @@ permalink: /citizen-engagement
                 </div>
                 <div class="organizations-images">
                     <img class="org-img org-img-large" src="/assets/images/sponsors/code-for-america.svg" alt="code for america logo"/>
-                    <img class="org-img" src="/assets/images/citizen-engagement/la_neighborhood_councils.svg" alt="Lost Angeles Department of Neighborhood Empowerment">
+                    <img class="org-img" src="/assets/images/citizen-engagement/la_neighborhood_councils.svg" alt="Los Angeles Department of Neighborhood Empowerment">
                     <img class="org-img" src="/assets/images/citizen-engagement/palms_neighborhood_council.svg" alt="Palms Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/echo_park_neighborhood_council.svg" alt="Echo Park Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/la_county_open_data.svg" alt="County of Los Angeles Open Data">


### PR DESCRIPTION
Fixes #3101

### What changes did you make and why did you make them ?

  - Changed line 50 of alt text to "Lost Angeles Department of Neighborhood Empowerment"
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
No visual changes to webstie.
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
