### PR TITLE
Change alt text for CFA logo image in citizen engagement html file Issue#3100

### DIFF
--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -46,7 +46,7 @@ permalink: /citizen-engagement
                         A big thank you to:</p>
                 </div>
                 <div class="organizations-images">
-                    <img class="org-img org-img-large" src="/assets/images/sponsors/code-for-america.svg" alt="code for america logo"/>
+                    <img class="org-img org-img-large" src="/assets/images/sponsors/code-for-america.svg" alt="Code for America"/>
                     <img class="org-img" src="/assets/images/citizen-engagement/la_neighborhood_councils.svg" alt="Los Angeles Department of Neighborhood Empowerment">
                     <img class="org-img" src="/assets/images/citizen-engagement/palms_neighborhood_council.svg" alt="Palms Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/echo_park_neighborhood_council.svg" alt="Echo Park Neighborhood Council">


### PR DESCRIPTION
Fixes #3100


### What changes did you make and why did you make them ?

  - in pages/citizen-engagement.html, line 49's alt text img was change from 'code for america logo' to 'Code for America'
  -Alt text was updated in order to be more accurate and web accessible
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
no changes to visuals
