### PR TITLE
updated alt text for Mid-city neighborhood council image on line 55

### DIFF
--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -52,7 +52,7 @@ permalink: /citizen-engagement
                     <img class="org-img" src="/assets/images/citizen-engagement/echo_park_neighborhood_council.svg" alt="Echo Park Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/la_county_open_data.svg" alt="County of Los Angeles Open Data">
                     <img class="org-img" src="/assets/images/citizen-engagement/voices_neighborhood_council.svg" alt="Voices Neighborhood Council">
-                    <img class="org-img" src="/assets/images/citizen-engagement/mid_city_neighborhood_council.svg" alt="MINC mid-city neighborhood council logo">
+                    <img class="org-img" src="/assets/images/citizen-engagement/mid_city_neighborhood_council.svg" alt="Mid-City Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/mar_vista_community_council.svg" alt="Marvista Community Council">
                 </div>
         </div>


### PR DESCRIPTION
Fixes #3106

### What changes did you make and why did you make them ?

  - changed line 55 alt text to "Mid-City Neighborhood Council"
  - changes made in citizen engagement html file

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes to website; only changed alt text for image.
