### PR TITLE
removed unused alt-hero field from ems-triage-tracker.md project file

### DIFF
--- a/_projects/ems-triage-tracker.md
+++ b/_projects/ems-triage-tracker.md
@@ -5,7 +5,6 @@ description: 'The EMS Triage Tracker app provides the ability to track both prim
 image: /assets/images/projects/ems-triage-tracker.png
 alt: 'EMS Triage Tracker Logo'
 image-hero: /assets/images/projects/ems-triage-tracker-hero.png
-alt-hero: 'EMS Triage Tracker dashboard with breakdown of casualty numbers and a satellite view of the street grid with blue casualty location markers.'
 leadership:
   - name: Bonnie Wolfe
     role: Agile Coach


### PR DESCRIPTION
Fixes #3194 

### What changes did you make and why did you make them ?

  - deleted the alt-hero field on line 8 in the _projects/ems-triage-tracker.md file
  -
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

Removed text from a file. No visual changes made to website
