### PR TITLE
Updated Program Areas page so projects are dynamically rendered

### DIFF
--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -36,7 +36,7 @@ location:
   - Remote
 partner:
 tools: 
-program area:
+program-area:
   - Civic Tech Infrastructure
 status: Active
 # If the card should not be included on the site, change visible to "false"

--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -18,7 +18,7 @@ permalink: /program-areas
 <section class="content-section content--program-areas">
     {% assign sorted_program_areas = site.data.internal.program-areas | sort %}
     {% for program_areas in sorted_program_areas %}
-    {% if program_areas[1].size > 0 %}
+    {% if program_areas[1].size > 0 %}  <!--program_areas[0] is a reference to yaml file name, program_areas[1] references contents of that yaml file-->
     <div class="page-card card-primary page-card-lg page-card-container">
         <div class="page-card-image-container">
             <img class="page-card-image" src="{{ program_areas[1].image }}" alt="{{ program_areas[1].image_alt }}" />
@@ -39,11 +39,14 @@ permalink: /program-areas
                 {% endif %}<br>
             </p>
             <ul class="project-card-mini-list-alignment">
-                {% for project in program_areas[1].projects%}
-                <li class="project-card-mini inline-list" id="{{project.id}}">
-                    <img class="project-card-mini-image" src="{{project.image}}" alt="{{project.image_alt}}" />
-                    <a class="project-card-mini-title" href="{{project.link}}">{{project.name}}</a>
-                </li>
+                {% for project in site.projects %}
+                {% if program_areas[1].program-area != project.program-area %}
+                <li class="project-card-mini inline-list" id="{{project.identification}}">
+                  <h6>{{project.title}}</h6>
+                    <!-- <img class="project-card-mini-image" src="{{project.image}}" alt="{{project.image_alt}}" />
+                    <a class="project-card-mini-title" href="{{project.links[0].url}}">{{project.title}}</a>
+                </li> -->
+                {% endif %}
                 {% endfor %}
                 <!--Spacer li are used to center the project card mini on mobile-->
                 <li class="project-card-mini-spacer"></li> 

--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -40,13 +40,14 @@ permalink: /program-areas
             </p>
             <ul class="project-card-mini-list-alignment">
                 {% for project in site.projects %}
-                {% if program_areas[1].program-area != project.program-area %}
+                {% for project_program in project.program-area %}
+                {% if program_areas[1].program-area == project_program %}
                 <li class="project-card-mini inline-list" id="{{project.identification}}">
-                  <h6>{{project.title}}</h6>
-                    <!-- <img class="project-card-mini-image" src="{{project.image}}" alt="{{project.image_alt}}" />
+                    <img class="project-card-mini-image" src="{{project.image}}" alt="{{project.image_alt}}" />
                     <a class="project-card-mini-title" href="{{project.links[0].url}}">{{project.title}}</a>
-                </li> -->
+                </li>
                 {% endif %}
+                {% endfor %}
                 {% endfor %}
                 <!--Spacer li are used to center the project card mini on mobile-->
                 <li class="project-card-mini-spacer"></li> 

--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -18,7 +18,7 @@ permalink: /program-areas
 <section class="content-section content--program-areas">
     {% assign sorted_program_areas = site.data.internal.program-areas | sort %}
     {% for program_areas in sorted_program_areas %}
-    {% if program_areas[1].size > 0 %}  <!--program_areas[0] is a reference to yaml file name, program_areas[1] references contents of that yaml file-->
+    {% if program_areas[1].size > 0 %} 
     <div class="page-card card-primary page-card-lg page-card-container">
         <div class="page-card-image-container">
             <img class="page-card-image" src="{{ program_areas[1].image }}" alt="{{ program_areas[1].image_alt }}" />


### PR DESCRIPTION
Fixes #2485

### What changes did you make and why did you make them ?

  - Removed loop that uses [data/_internal/program-areas](https://github.com/hackforla/website/tree/gh-pages/_data/internal/program-areas) to render cards
  - Added two loops to loop through [_projects collection](https://github.com/hackforla/website/tree/gh-pages/_projects)
  - Outer loop loops through projects, inner loop loops through each project's program area(s) and renders those whose program area matches that of the larger card
  - Edited fields in Liquid to pull from the project md files rather than the program area yml files

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/88953806/193187209-92dd60d8-ac7c-4d79-b153-5cb8daf341f3.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/88953806/193187539-0990248f-842a-44cc-b0a0-a1532f1185f8.png)

</details>

** Note that this now adds projects that were not previously rendered. 
** Also corrected minor typo in guides-team.md that prevented card from being rendered. 
