### PR TITLE
Removed alt-hero from guides-team.md

### DIFF
--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -7,7 +7,6 @@ image: /assets/images/projects/guides-team.jpg
 alt: 'Globe Map made of dots and hackforla logo and text reading Guides Team'
 # hero image should be 1500px wide x 700px high
 image-hero: /assets/images/projects/guides-team-hero.jpg
-alt-hero: 'Globe Map made of dots'
 leadership:
   - name: Bonnie Wolfe
     role: Product Manager


### PR DESCRIPTION
Fixes #3199

### Changes:

  - Removed line 10 alt-hero from `_projects/guides-team.md`

### Why:
 Removing unused code:
 - Reduces website loading time
 - Makes it easier to understand the code
 - Shortens time required to review the code

### Screenshots of Proposed Changes Of The Website:

Removing alt text. No visual changes to the website.

