### PR TITLE
Update CONTRIBUTING.md sections 2.7.a & 2.7.d

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ The following is a set of guidelines for contributing to the website repository,
       - [**2.3.b Available issues for returning members (front end)**](#23b-available-issues-for-returning-members-front-end)
       - [**2.3.c Available issues for returning members (back end)**](#23c-available-issues-for-returning-members-back-end)
       - [**2.3.d Issues for Hacktoberfest contributors (Front-End/Back-End)**](#23d-issues-for-hacktoberfest-contributors-front-endback-end)
-       - [**2.3.e What if you see bugs/errors that are not connected to an issue?**](#23e-what-if-you-see-bugserrors-that-are-not-connected-to-an-issue)
+      - [**2.3.e What if you see bugs/errors that are not connected to an issue?**](#23e-what-if-you-see-bugserrors-that-are-not-connected-to-an-issue)
     - [**2.4 Claiming an Issue**](#24-claiming-an-issue)
       - [**2.4.a Assign & Unassign yourself to this issue**](#24a-assign--unassign-yourself-to-this-issue)
         - [**i. If you want to to self assign an issue:**](#i-if-you-want-to-to-self-assign-an-issue)
@@ -510,6 +510,21 @@ If you are not currently in the `gh-pages` branch, run the following command to 
 ```bash
 git checkout gh-pages
 ```
+
+**IMPORTANT:** Before you push your local commits to your repository, sync your fork to the main Hack For LA website repository. git pull upstream will ensure that your local repository is up-to-date with the main site:
+
+```bash
+git pull upstream
+```
+
+You can also sync your fork directly on GitHub by clicking "Sync Fork" at the right of the screen and then clicking "Update Branch"
+
+<details>
+  <summary><strong>Click here</strong> to see how sync the fork on GitHub</summary>
+  <p><strong>Assign/Unassign demo</strong></p>
+  <img src="https://docs.github.com/assets/cb-49937/images/help/repository/update-branch-button.png" />
+</details>
+
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 
 #### **2.7.b Working on an issue (2): Create a new branch where you will work on your issue**
@@ -600,11 +615,19 @@ git commit -m “insert message here”
   
 #### **2.7.d Working on an issue (4): Check upstream before you push**
 
-Before you push your local commits to your repository, check to see if there have been updates made in the main Hack For LA website repository. `git fetch` will check remote repositories for changes without altering your local repository.
+IMPORTANT: Before you push your local commits to your repository, sync your fork to the main Hack For LA website repository. `git pull upstream` will ensure that your local repository is up-to-date with the main site:
 
 ```bash
-git fetch upstream
+git pull upstream
 ```
+You can also sync your fork directly on GitHub by clicking "Sync Fork" at the right of the screen and then clicking "Update Branch"
+
+<details>
+  <summary><strong>Click here</strong> to see how sync the fork on GitHub</summary>
+  <p><strong>Assign/Unassign demo</strong></p>
+  <img src="https://docs.github.com/assets/cb-49937/images/help/repository/update-branch-button.png" />
+</details>
+
 
 ##### **i. If there are no changes in the upstream repository**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -521,7 +521,6 @@ You can also sync your fork directly on GitHub by clicking "Sync Fork" at the ri
 
 <details>
   <summary><strong>Click here</strong> to see how sync the fork on GitHub</summary>
-  <p><strong>Assign/Unassign demo</strong></p>
   <img src="https://docs.github.com/assets/cb-49937/images/help/repository/update-branch-button.png" />
 </details>
 
@@ -624,7 +623,6 @@ You can also sync your fork directly on GitHub by clicking "Sync Fork" at the ri
 
 <details>
   <summary><strong>Click here</strong> to see how sync the fork on GitHub</summary>
-  <p><strong>Assign/Unassign demo</strong></p>
   <img src="https://docs.github.com/assets/cb-49937/images/help/repository/update-branch-button.png" />
 </details>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -614,7 +614,7 @@ git commit -m “insert message here”
   
 #### **2.7.d Working on an issue (4): Check upstream before you push**
 
-IMPORTANT: Before you push your local commits to your repository, sync your fork to the main Hack For LA website repository. `git pull upstream` will ensure that your local repository is up-to-date with the main site:
+**IMPORTANT:** Before you push your local commits to your repository, sync your fork to the main Hack For LA website repository. `git pull upstream` will ensure that your local repository is up-to-date with the main site:
 
 ```bash
 git pull upstream

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ The following is a set of guidelines for contributing to the website repository,
         - [**ii. Prepare repos changes (2): Use the `git status` command to see what files are staged.**](#ii-prepare-repos-changes-2-use-the-git-status-command-to-see-what-files-are-staged)
         - [**iii. Prepare repos changes (3): Use the `git reset HEAD` command to remove a staged file.**](#iii-prepare-repos-changes-3-use-the-git-reset-head-command-to-remove-a-staged-file)
         - [**iv. Prepare repos changes (4): Use the `git commit` command**](#iv-prepare-repos-changes-4-use-the-git-commit-command)
-      - [**2.7.d Working on an issue (4): Check upstream before you push**](#27d-working-on-an-issue-4-check-upstream-before-you-push)
+      - [**2.7.d Working on an issue (4): Pulling from upstream before you push**](#27d-working-on-an-issue-4-pulling-from-upstream-before-you-push)
         - [**i. If there are no changes in the upstream repository**](#i-if-there-are-no-changes-in-the-upstream-repository)
         - [**ii. If there are conflicting changes in the upstream repository**](#ii-if-there-are-conflicting-changes-in-the-upstream-repository)
       - [**2.7.e Working on an issue (5): Incorporating changes from upstream**](#27e-working-on-an-issue-5-incorporating-changes-from-upstream)
@@ -511,7 +511,7 @@ If you are not currently in the `gh-pages` branch, run the following command to 
 git checkout gh-pages
 ```
 
-**IMPORTANT:** Before you push your local commits to your repository, sync your fork to the main Hack For LA website repository. git pull upstream will ensure that your local repository is up-to-date with the main site:
+**IMPORTANT:** Before you push your local commits to your repository, sync your fork to the main Hack For LA website repository. `git pull upstream` will ensure that your local repository is up-to-date with the main site:
 
 ```bash
 git pull upstream
@@ -612,7 +612,7 @@ git commit -m “insert message here”
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
   
-#### **2.7.d Working on an issue (4): Check upstream before you push**
+#### **2.7.d Working on an issue (4): Pulling from upstream before you push**
 
 **IMPORTANT:** Before you push your local commits to your repository, sync your fork to the main Hack For LA website repository. `git pull upstream` will ensure that your local repository is up-to-date with the main site:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -520,7 +520,7 @@ git pull upstream
 You can also sync your fork directly on GitHub by clicking "Sync Fork" at the right of the screen and then clicking "Update Branch"
 
 <details>
-  <summary><strong>Click here</strong> to see how sync the fork on GitHub</summary>
+  <summary><strong>Click here</strong> to see how to sync the fork on GitHub</summary>
   <img src="https://docs.github.com/assets/cb-49937/images/help/repository/update-branch-button.png" />
 </details>
 
@@ -622,7 +622,7 @@ git pull upstream
 You can also sync your fork directly on GitHub by clicking "Sync Fork" at the right of the screen and then clicking "Update Branch"
 
 <details>
-  <summary><strong>Click here</strong> to see how sync the fork on GitHub</summary>
+  <summary><strong>Click here</strong> to see how to sync the fork on GitHub</summary>
   <img src="https://docs.github.com/assets/cb-49937/images/help/repository/update-branch-button.png" />
 </details>
 


### PR DESCRIPTION
Fixes #3493 

### What changes did you make and why did you make them ?
- added `git pull upstream` instructions to the end of section **2.7.a**
- changed title of section **2.7.d**
- replaced `git fetch upstream` instructions with `git pull upstream` instructions in section **2.7.d**

These changes update `CONTRIBUTING.md` to incorporate the new best practices related to syncing a fork to the main Hack For LA website repository.

### Screenshots of Proposed Changes Of CONTRIBUTING.md
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Old Section 2.7.a](https://user-images.githubusercontent.com/73561520/196296807-0ba26368-ee55-4f68-a3b3-e2eb440c559b.png)
![Old Section 2.7.d](https://user-images.githubusercontent.com/73561520/196296914-56e102f2-e800-416b-be09-e1a04946d855.png)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![New Section 2.7.a](https://user-images.githubusercontent.com/73561520/196298055-362ffe2a-0818-4eac-825c-7f8cfb6e9a17.png)

![New Section 2.7.d](https://user-images.githubusercontent.com/73561520/196298467-8c55ac25-eedf-4c21-a08a-b37ec805fba7.png)

</details>

### Question

* The **line 40** change is a result of my code formatter functioning on auto-save. To me, it looks like it corrected a spacing mistake. Is this okay? Or should I find a way to disable the auto-formatting?