### PR TITLE
Removed unused 'alt-hero' field, line 8, from lucky-parking.md

### DIFF
--- a/_projects/lucky-parking.md
+++ b/_projects/lucky-parking.md
@@ -5,7 +5,6 @@ description: Visualization of parking data to assist in understanding of the eff
 image: /assets/images/projects/lucky-parking.png
 alt: 'Lucky Parking Logo'
 image-hero: /assets/images/projects/lucky-parking-hero.png
-alt-hero: 'Lucky Parking Logo overlaid on a parking lot with a yellow Volkswagen.'
 leadership:
   - name: Greg Pawin
     role: Product Owner / Data Science Lead


### PR DESCRIPTION
Fixes #3204

### What changes did you make and why did you make them ?

  - Deleted unused `alt-hero` text, originally on line 8 of the lucky-parking.md file.
  - This was done to reduce website loading time, and to make the code easier to understand and review.


### Screenshots of Proposed Changes Of The Website  
n/a- The alt text was never used.


