### PR TITLE
Updated donate page image's alt text to adhere to WCAG

### DIFF
--- a/_includes/donate-card.html
+++ b/_includes/donate-card.html
@@ -1,7 +1,7 @@
 <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
   <h2 class="title4 page-card--large-icon-header">Help Us Keep The Lights On</h2>
   <img id="join-us-donation-icon" class='join-us-card-img' src="/assets/images/join-us/help-us-icon.svg"
-      alt="join us card image" />
+      alt="" />
   <div class="join-us-card-body page-card--large-icon-body">
     <h3 class="title6 page-card--large-icon-header-secondary">Running Hack for LA costs money</h3>
     <p>
@@ -11,7 +11,7 @@
       world-class training to our members and valuable, scalable, impactful
       products to the community.
     </p>
-    <img class="join-us-donation-img" src="/assets/images/join-us/donation-graphic.svg" alt="donation chart" />
+    <img class="join-us-donation-img" src="/assets/images/join-us/donation-graphic.svg" alt="Hosting, mailing list services, Zoom accounts, domain names, stickers, t-shirts" />
     <h3 class="title6 page-card--large-icon-header-secondary">How to help us continue to do impactful work</h3>
     <ul>
       <li>
@@ -25,7 +25,7 @@
       <img
         class="join-us-donation-img"
         src="/assets/images/about/hfla-donate.gif"
-        alt="donation form image"
+        alt=""
       />
       <div class="join-us-donation-body">
         <h3 class="title6 page-card--large-icon-header-secondary">Make a donation to Hack for LA</h3>


### PR DESCRIPTION
Fixes #3630 

### What changes did you make and why did you make them ?

  -updated alt="join us card image" to alt=""
  -updated alt="donation chart" to alt="Hosting, mailing list services, Zoom accounts, domain names, stickers, t-shirts"
  -updated line 28 from alt="donation form image" to alt=""

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

Alt text was changed. No visual changes to website
