### PR TITLE
Fixes #2852: Edit people.yml content field to content-type and remove type field

### DIFF
--- a/_data/internal/credits/people.yml
+++ b/_data/internal/credits/people.yml
@@ -1,12 +1,11 @@
 ---
 title: People
 title-link: https://www.freepik.com/free-vector/team-spirit-concept-illustration_7079890.htm
-content: icon
+content-type: image
 used-in: Getting Started
 artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/getting-started/step3.png
 alt: 'Team spirit concept illustration'
-type: icon
 ---


### PR DESCRIPTION
Fixes #2852

### What changes did you make and why did you make them?

  -Edit content field to content-type and changed value from icon to image
  -Removed redundant type field

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

Minor changes to people.yml for better code readability and redundant code removed. List is self-explanatory.