### PR TITLE
Change alt tag for Public Tree Map Project image on events page to adhere to WCAG issue #3284

### DIFF
--- a/_includes/events-page/our-locations-content.html
+++ b/_includes/events-page/our-locations-content.html
@@ -43,7 +43,7 @@
           </div>
 
           <div class="img-dis">
-            <img id="mini-img" src="../assets/images/projects/public-tree-map.png" alt="Public Tree Map Project" />
+            <img id="mini-img" src="../assets/images/projects/public-tree-map.png" alt="" />
             <div class="proj-desc">
               <a href="https://www.hackforla.org/projects/public-tree-map">Public Tree Map</a>
             </div>


### PR DESCRIPTION
Fixes #3284 

### What changes did you make and why did you make them ?

  -Removed alt text from Public Tree Map div in our-locations-content.html

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
This PR causes no visual changes to the website.
