### PR TITLE
changed alt text for Sustainable Development Logo

### DIFF
--- a/_includes/about-page/about-card-sustainability.html
+++ b/_includes/about-page/about-card-sustainability.html
@@ -53,7 +53,7 @@
                     <img src="/assets/images/about/sdg-elements/climate-action.svg" alt="Climate Action goal logo" />
                     <img src="/assets/images/about/sdg-elements/peace-justice.svg" alt="16 Peace, Justice and Strong Institutions" />
                     <img src="/assets/images/about/sdg-elements/partnerships.svg" alt="Partnerships for the goals goal logo" />
-                    <div class="grid-center"><img src="/assets/images/about/sdg-elements/sdg-la.svg" alt="Los Angeles Sustainable Development wheel logo" /><br />
+                    <div class="grid-center"><img src="/assets/images/about/sdg-elements/sdg-la.svg" alt="" /><br />
                     </div>
                 </div>
                 <a href="https://sdg.lamayor.org"><span class="small-text">https://sdg.lamayor.org</span></a>


### PR DESCRIPTION
Fixes #3403

### What changes did you make and why did you make them ?
In the file _includes/about-page/about-card-sustainability.html, I changed the following alt text
From

alt="Los Angeles Sustainable Development wheel logo"
To

alt=""
  
This change was explicitly specified in the issue, for accessibility reasons.  It is a best practice to provide alt text only where useful.  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No visual changes to the website.
  
