### PR TITLE
Change-linter-to-@v4-2479

### DIFF
--- a/.github/workflows/lint-scss.yml
+++ b/.github/workflows/lint-scss.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint SCSS
-        uses: github/super-linter@v4.8.1
+        uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: gh-pages


### PR DESCRIPTION
to @v4 after bug fix confirmed

Fixes #2479 

### What changes did you make and why did you make them ?

  - changed line 22 from "@v4.8.1 to @v4"
  - this was done after confirming image bug fix from @v4.8.3

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
