### PR TITLE
removed unused alt-hero line in shared-housing-project.md

### DIFF
--- a/_projects/shared-housing-project.md
+++ b/_projects/shared-housing-project.md
@@ -5,7 +5,6 @@ description: The shared housing team works on creating an efficient & effective 
 image: /assets/images/projects/shared-housing-project.jpg
 alt: 'Linked arms'
 image-hero: /assets/images/projects/shared-housing-project-hero.png
-alt-hero: 'Light-gray background'
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/shared-housing'


### PR DESCRIPTION
Fixes #3210

### What changes did you make and why did you make them ?

  - removed line 8: "alt-hero: 'Light-gray background'" from the file _projects/shared-housing-project.md due to it being unused

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No screenshots, since the alt text wasn't used.