### PR TITLE
Updated content and type fields in people2.yml credits file #2853

### DIFF
--- a/_data/internal/credits/people2.yml
+++ b/_data/internal/credits/people2.yml
@@ -1,12 +1,11 @@
 ---
 title: People
 title-link: https://www.freepik.com/free-vector/hang-out-concept-illustration_6982628.htm
-content: icon
+content-type: image
 used-in: Events
 artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/hack-nights/happy-hour.png
 alt: 'Fireside discussion concept illustration'
-type: icon
 ---


### PR DESCRIPTION
Fixes #2853

### What changes did you make and why did you make them ?

  - replaced the line containing "content: icon" with "content-type: image"
  - removed line containing "type: icon" 
  - these were done to remove redundancy
  - made sure that this was done in a topic branch

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Changing fields in yml file. No visual changes to website.
