### PR TITLE
edit content field, removed type field from yml credits

### DIFF
--- a/_data/internal/credits/process.yml
+++ b/_data/internal/credits/process.yml
@@ -1,12 +1,11 @@
 ---
 title: Process
 title-link: https://www.freepik.com/free-vector/organizing-projects-concept-illustration_5911566.htm
-content: icon
+content-type: image
 used-in: Events, Projects
 artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/hack-nights/org-projects.png
 alt: 'Organizing projects concept illustration'
-type: icon
 ---


### PR DESCRIPTION
Fixes #2856

### What changes did you make and why did you make them
for the file: `_data/internal/credits/process.yml`
  - replaced the `content` field with `content-type`
  - removed the `type` field