### PR TITLE
replace content field remove type field in process.yml

### DIFF
--- a/_data/internal/credits/process.yml
+++ b/_data/internal/credits/process.yml
@@ -1,12 +1,11 @@
 ---
 title: Process
 title-link: https://www.freepik.com/free-vector/organizing-projects-concept-illustration_5911566.htm
-content: icon
+content-type: image
 used-in: Events, Projects
 artist: stories
 provider: Freepik
 provider-link: 'https://www.freepik.com/'
 image-url: /assets/images/hack-nights/org-projects.png
 alt: 'Organizing projects concept illustration'
-type: icon
 ---


### PR DESCRIPTION
Fixes #2856

### What changes did you make and why did you make them
For the file: `_data/internal/credits/process.yml`
- replaced the content field with content-type
- removed the type field

Oops about the bad link. Unsure if it was caused by the initial "Fixes ####", or the commit message. Opted to not include an issue code within the commit to be safe.