### PR TITLE
Linked and stored visual demo pdf for pull request review in contributing wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -891,7 +891,7 @@ Now you are all set to work on a new PR. Start over at [**2.3 Where can I find G
 If you find an error in your code or your reviewer asks you to make a change, please avoid editing your code directly from the pull request. Instead update it in your local branch first and then push it to your origin remote. This will update the original pull request.
 
 
-For new volunteers, check this [wiki on completing pull request reviews](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests) and our [wiki on creating issues](https://github.com/hackforla/website/wiki/How-to-create-issues) for more ways to contribute to the project.
+For new volunteers, check this [wiki on completing pull request reviews](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests), [visual demo on pull request reviews](https://github.com/hackforla/website/assets/How.to.Review.a.PR.2.pdf), and our [wiki on creating issues](https://github.com/hackforla/website/wiki/How-to-create-issues) for more ways to contribute to the project.
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 ***

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -891,7 +891,7 @@ Now you are all set to work on a new PR. Start over at [**2.3 Where can I find G
 If you find an error in your code or your reviewer asks you to make a change, please avoid editing your code directly from the pull request. Instead update it in your local branch first and then push it to your origin remote. This will update the original pull request.
 
 
-For new volunteers, check this [wiki on completing pull request reviews](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests), [visual demo on pull request reviews](assets/pdfs/How.to.Review.a.PR.2.pdf), and our [wiki on creating issues](https://github.com/hackforla/website/wiki/How-to-create-issues) for more ways to contribute to the project.
+For new volunteers, check this [wiki on completing pull request reviews](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests), [visual demo on pull request reviews](https://drive.google.com/file/d/1b6uW_Od8ftACsEr5u-nxe8qNb8UjkISN), and our [wiki on creating issues](https://github.com/hackforla/website/wiki/How-to-create-issues) for more ways to contribute to the project.
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 ***

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -891,7 +891,7 @@ Now you are all set to work on a new PR. Start over at [**2.3 Where can I find G
 If you find an error in your code or your reviewer asks you to make a change, please avoid editing your code directly from the pull request. Instead update it in your local branch first and then push it to your origin remote. This will update the original pull request.
 
 
-For new volunteers, check this [wiki on completing pull request reviews](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests), [visual demo on pull request reviews](assets/pdfs/How.to.Review.a.PR.2.pdf), and our [wiki on creating issues](https://github.com/hackforla/website/wiki/How-to-create-issues) for more ways to contribute to the project.
+For new volunteers, check this [wiki on completing pull request reviews](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests), <a href="assets/pdfs/How.to.Review.a.PR.2.pdf" download="How.to.Review.a.PR.2.pdf">visual demo on pull request reviews</a>, and our [wiki on creating issues](https://github.com/hackforla/website/wiki/How-to-create-issues) for more ways to contribute to the project.
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 ***

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -891,7 +891,7 @@ Now you are all set to work on a new PR. Start over at [**2.3 Where can I find G
 If you find an error in your code or your reviewer asks you to make a change, please avoid editing your code directly from the pull request. Instead update it in your local branch first and then push it to your origin remote. This will update the original pull request.
 
 
-For new volunteers, check this [wiki on completing pull request reviews](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests), <a href="assets/pdfs/How.to.Review.a.PR.2.pdf" download="How.to.Review.a.PR.2.pdf">visual demo on pull request reviews</a>, and our [wiki on creating issues](https://github.com/hackforla/website/wiki/How-to-create-issues) for more ways to contribute to the project.
+For new volunteers, check this [wiki on completing pull request reviews](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests), [visual demo on pull request reviews](assets/pdfs/How.to.Review.a.PR.2.pdf), and our [wiki on creating issues](https://github.com/hackforla/website/wiki/How-to-create-issues) for more ways to contribute to the project.
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 ***

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -891,7 +891,7 @@ Now you are all set to work on a new PR. Start over at [**2.3 Where can I find G
 If you find an error in your code or your reviewer asks you to make a change, please avoid editing your code directly from the pull request. Instead update it in your local branch first and then push it to your origin remote. This will update the original pull request.
 
 
-For new volunteers, check this [wiki on completing pull request reviews](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests), [visual demo on pull request reviews](https://github.com/hackforla/website/assets/How.to.Review.a.PR.2.pdf), and our [wiki on creating issues](https://github.com/hackforla/website/wiki/How-to-create-issues) for more ways to contribute to the project.
+For new volunteers, check this [wiki on completing pull request reviews](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests), [visual demo on pull request reviews](assets/pdfs/How.to.Review.a.PR.2.pdf), and our [wiki on creating issues](https://github.com/hackforla/website/wiki/How-to-create-issues) for more ways to contribute to the project.
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 ***


### PR DESCRIPTION
Fixes #3651 

### What changes did you make and why did you make them ?

  - Stored demo pdf in google drive in developers folder 
  - Linked demo to phrase "visual demo on pull request reviews" under section 3.1.c in contributing wiki 
  - Changed file name to "How-to-Review-a-PR.pdf" to be more in line with naming convention.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](<img width="700" alt="before pull 115" src="https://user-images.githubusercontent.com/50275188/200107244-42e74991-95fa-4e8e-b0cc-45aa9ac9d840.PNG">)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](<img width="700" alt="after 115" src="https://user-images.githubusercontent.com/50275188/200107281-783daa96-c49d-4dc8-9c2a-19981399cc73.PNG">)

</details>
