### PR TITLE
Update the Communities of Practice meeting times and one leadership role

### DIFF
--- a/_data/internal/communities/ops.yml
+++ b/_data/internal/communities/ops.yml
@@ -9,7 +9,7 @@ location:
 image: /assets/images/communities-of-practice/ops.jpg
 alt: 'A dramatic closeup of a screen filled with code'
 
-meeting-times: Tuesdays 8:00-9:00 pm PT
+meeting-times: Wednesdays 6:00-7:00 pm PT
 
 leadership-type: Community Led
 leadership:

--- a/_data/internal/communities/project-management.yml
+++ b/_data/internal/communities/project-management.yml
@@ -9,16 +9,16 @@ location:
 image: /assets/images/communities-of-practice/product.jpg
 alt: 'Several people around a small table listen intently as one person speaks.'
 
-meeting-times: Tuesdays 6:00-7:00 pm PT
+meeting-times: Fridays 12:00-1:00 pm PT
 
-leadership-type: Peer Led
+leadership-type: Mentor Led
 leadership:
-  - name: Priyanka Talwar
-    role: Co-lead
+  - name: Bonnie Wolfe
+    role: Lead
     links:
-      slack: https://hackforla.slack.com/team/U029P91EY15
-      github: https://github.com/priyatalwar
-    picture: https://avatars.githubusercontent.com/u/7972395
+      slack: https://hackforla.slack.com/team/UE1UG1YFP
+      github: https://github.com/experimentsinhonesty
+    picture: https://avatars.githubusercontent.com/u/37763229
     
 links:
   - name: Slack

--- a/_data/internal/communities/ui-ux.yml
+++ b/_data/internal/communities/ui-ux.yml
@@ -9,7 +9,7 @@ location:
 image: /assets/images/communities-of-practice/uiux.jpg
 alt: 'A board full of Post-it notes is used as a communication tool'
 
-meeting-times: Mondays 6:00-7:00 PM PT
+meeting-times: Wednesdays 6:00-7:00 PM PT
 
 leadership-type: Peer Led
 leadership:


### PR DESCRIPTION
No issue opened.  This is a hot fix

### What changes did you make and why did you make them ?
- added my name and info as a leader of the Product Management CoP
- removed Priyanka as the CoP lead of the Product Management CoP
- changed the time of ops, project management and ui/ux meetings to match their actual meeting times
  - ops and ui/ux on wed at 6pm PT
  - product on frid at 12pm PT


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

### Related page
URL of the page I am changing https://www.hackforla.org/communities-of-practice
