### PR TITLE
Remove unused alt-hero field from not-today.md

### DIFF
--- a/_projects/not-today.md
+++ b/_projects/not-today.md
@@ -5,7 +5,6 @@ description:  Not Today is an app intended to help people wait out periods of su
 image: /assets/images/projects/not-today.png
 alt: 'Not Today logo. A person embrace another person with full support. Art by C.W. Moss'
 image-hero: /assets/images/projects/not-today-hero.png
-alt-hero: ''
 leadership:
   - name: Mya Stark
     role: Product Owner & SME


### PR DESCRIPTION
Fixes #3207 

### What changes did you make and why did you make them ?

Removed unused alt-hero text from not-today.md file. alt-hero is the alt text for image-hero (a decorative background image). alt-hero isn't used in the codebase since image-hero a SCSS background image. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Removing an unused field from a file. No visual changes to the website.
