### PR TITLE
GHA: Update 'getCommentContributors' Function

### DIFF
--- a/github-actions/trigger-schedule/github-data/get-project-data.js
+++ b/github-actions/trigger-schedule/github-data/get-project-data.js
@@ -116,7 +116,7 @@ async function getAllRepos() {
 /**
  * Fetches commit contributors for a given repo
  * @param {Object} repo     [Repository object from GitHub]
- * @return {Array}     [An array of contributors based on how many commits they have made]
+ * @return {Array}     [An array of contributors, sorted by the number of issue commits per contributor, in descending order]
  */
 async function getCommitContributors(repo) {
   // Construct parameters for request
@@ -140,13 +140,14 @@ async function getCommitContributors(repo) {
  * Fetches comment contributors for a given repo
  * @param {Object} repo     [Repository object from GitHub]
  * @param {String} dateLastRan      [ISO 8601 Date to fetch contributors from]
- * @return {Array}     [An array of contributors based on how many commits they have made]
+ * @return {Array}     [An array of contributors, sorted by the number of issue comments per contributor, in descending order]
  */
 async function getCommentContributors(repo, dateLastRan) {
   // Construct parameters for request
   let requestParams = constructContributorParams(repo);
   if(dateLastRan) requestParams.since = dateLastRan;
 
+  // Get comment contributors. listCommentContributors and listCommentContributorsForOrg are methods from trueContributorsMixin
   let issueCommentContributors = (requestParams.hasOwnProperty("org")) ?
     await octokit.listCommentContributorsForOrg(requestParams) :
     await octokit.listCommentContributors(requestParams);


### PR DESCRIPTION
  Fixes #3165 

### What changes did you make and why did you make them ?

  -Updated @return comment for getCommentContributors with information based on [true-github-contributors ](https://github.com/100Automations/true-github-contributors) documentation.
  -Updated @return comment for getCommitContributors with similar information.
  -Added comment clarifying that listCommentContributorsForOrg and listCommentContributors methods are from true-github-contributors and not Octokit.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to the website.
