### PR TITLE
Update blank issue form with dependency

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form.yml
@@ -1,7 +1,20 @@
-name: 'Blank Issue '
-description: 'Standard HackforLA issue template '
+name: 'Blank Issue Form with Dependency'
+description: 'Standard HackforLA issue form with dependency'
 
 body:
+  - type: dropdown
+    id: dependency
+    attributes:
+      label: Is there a dependency?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+  - type: textarea
+    id: dependency-explanation
+    attributes:
+      label: If Yes, please explain
   - type: input
     id: overview
     attributes:
@@ -23,16 +36,4 @@ body:
       description: "Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc."
     validations:
       required: true
-  - type: dropdown
-    id: dependency
-    attributes:
-      label: Is there a dependency?
-      options:
-        - "Yes"
-        - "No"
-    validations:
-      required: true
-  - type: textarea
-    id: dependency-explanation
-    attributes:
-      label: If Yes, please explain
+  


### PR DESCRIPTION
Fixes #2904 

### What changes did you make and why did you make them ?

The blank issue form with dependency (blank-issue-form.yml) was updated to move the dependency form fields from the bottom of the form to the top of the form. In addition, the name and description of the form in the yml file were updated to clarify what the form is for. This was performed to make it clear that the form is for issues with dependencies. This will make it easier and quicker to pick an issue template and write an issue.

### Screenshots of Proposed Changes Of The Issue Form 
<details>
<summary>Visuals before changes are applied</summary>

![Blank Form with Dependency Issue Selection View - Before Update](https://user-images.githubusercontent.com/48114590/201577296-6f88025b-f02d-406b-8f51-60771e13b604.png)

![Blank Form with Dependency - Form View - Before Update](https://user-images.githubusercontent.com/48114590/201577549-e9b88a40-397d-48b5-bb9e-29888dd2caab.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Blank Form with Dependency Issue Selection View - After Update](https://user-images.githubusercontent.com/48114590/201576461-ff054fc3-e7b9-4965-8b47-e587e30f8193.png)

![Blank Form with Dependency - Form View - After Update](https://user-images.githubusercontent.com/48114590/201577267-86e7d1d5-86fd-41a9-a9f3-154b3655a5a8.png)

</details>
