### PR TITLE
Hide suggest buttons on Toolkit Page

### DIFF
--- a/pages/toolkit.html
+++ b/pages/toolkit.html
@@ -34,9 +34,10 @@ permalink: /toolkit/
     <div class="toolkit-flex-container">
       <div class="suggest-guide-group">
         <h2 class="title3">Guides</h2>
-        <button class="btn btn-primary btn-md-narrow">Suggest a guide</button>
+        <!-- The Suggest a guide button has been temporarily hidden until we figure out how this button will function after it's clicked. See issue #3678 for more details. -->
+        <button hidden class="btn btn-primary btn-md-narrow">Suggest a guide</button>
       </div>
-    <div class="dropdown"> 
+    <div class="dropdown">
         {% assign category_list = "All, Development, Design, Project Management, Professional Development" | split: ", " %}
         <select id ="dropdown-select">
         {% for category in category_list %}
@@ -60,7 +61,8 @@ permalink: /toolkit/
         <div class="toolkit-flex-container">
             <div class="suggest-guide-group">
                 <h2 class="external-resources-text title3">External Resources</h2>
-                <button class="btn btn-primary btn-md-narrow">Suggest a resource</button>
+                <!-- The Suggest a resource button has been temporarily hidden until we figure out how this button will function after it's clicked. See issue #3678 for more details. -->
+                <button hidden class="btn btn-primary btn-md-narrow">Suggest a resource</button>
             </div>
             <!-- Searching through toolkitResources collection -->
                 {%- for item in site.data.internal.toolkitresources -%}


### PR DESCRIPTION
Fixes #3678 

### What changes did you make and why did you make them ?

  - Added the hidden attribute to buttons "Suggest a guide" and "Suggest a resource" because we currently do not have any functionality for those buttons yet
  - Added comment on each button to explain that the buttons would stay hidden until we figure out how we want the buttons to function later
  - Checked desktop, mobile, and tablet views to make sure both buttons no longer appear
  - Checked with a screen reader to make sure both buttons are not read
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screen Shot 2022-11-15 at 6 17 01 PM](https://user-images.githubusercontent.com/69279538/201999200-524eab89-6d32-431d-ac7a-fdefbf140649.png)
![Screen Shot 2022-11-15 at 6 17 13 PM](https://user-images.githubusercontent.com/69279538/201999218-20aed2f8-1287-4a5f-b927-bafee008a61f.png)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screen Shot 2022-11-15 at 6 19 00 PM](https://user-images.githubusercontent.com/69279538/201999287-2348da73-761a-4da9-bbaf-d533afbf5925.png)
![Screen Shot 2022-11-15 at 6 19 10 PM](https://user-images.githubusercontent.com/69279538/201999306-ae6691d4-5fc6-45d9-a14c-5b3cc8c99894.png)


</details>
