### PR TITLE
Removed alt-hero field from _projects/spare.md file

### DIFF
--- a/_projects/spare.md
+++ b/_projects/spare.md
@@ -5,7 +5,6 @@ description: A fun new project project that connects people in need of clothing 
 image: /assets/images/projects/spare.png
 alt: 'Spare logo. Different article of clothing icons surrounds "What can you spare?"'
 image-hero: /assets/images/projects/spare-hero.png
-alt-hero: ''
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/spare'


### PR DESCRIPTION
Fixes #3211

### What changes did you make and why did you make them?
- Per the action items, for the file ```_projects/spare.md```, removed line 8 for the alt-hero
<strike>

```
alt-hero: ''
```
</strike>

### Screenshots of proposed changes of the website (if any; please do not screenshot code changes)
- No visual changes to the website.
