### PR TITLE
added the correct link to Git gui wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -567,7 +567,7 @@ If you do not see the changes you applied when you run `docker-compose up`, **do
 
 Once you are done with the work on your issue you will push it to your repository.  Before you can push your work to your repository, you will stage and commit your changes.  These two commands are similar to the save command that you have used to in other programs. 
 
-**Note:** If you are using Visual studios code you can use the Git graphical user interface to stage your changes. For instructions check out the [Git Gui Wiki](https://github.com/hackforla/website/wiki/Using-Git-GUI-(Graphical-user-Interface)-in-Visual-Studios-Code)
+**Note:** If you are using Visual studios code you can use the Git graphical user interface to stage your changes. For instructions check out the [Git Gui Wiki](https://github.com/hackforla/website/wiki/How-to-Use-Git-GUI-(Graphical-user-Interface)-in-Visual-Studios-Code)
    
 ##### **i. Prepare repo changes (1): Use the `git add` command to stage your changes.** 
 


### PR DESCRIPTION
Fixes #2673

### What changes did you make and why did you make them ?
 
  - added a correct link to Git Gui Wiki from How to Contribute to Hack for LA

<details>
From
https://github.com/hackforla/website/wiki/Using-Git-GUI-(Graphical-user-Interface)-in-Visual-Studios-Code
changed to
https://github.com/hackforla/website/wiki/How-to-Use-Git-GUI-(Graphical-user-Interface)-in-Visual-Studios-Code
</details>

<details>
<summary>no visual changes</summary>
  
</details>
