### PR TITLE
Update docker-compose.yml to clean Jekyll data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ services:
   hfla_site:
     image: hackforlaops/ghpages:latest
     container_name: hfla_site
-    command: jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I
+    command: >
+      sh -c "jekyll clean &&
+             jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I"
     environment:
       - JEKYLL_ENV=docker
     ports:


### PR DESCRIPTION
Fixes #3587 

### What changes did you make and why did you make them ?

Updated `docker-compose.yml` file to add a Jekyll command (`jekyll clean`) to the command key. The `jekyll clean` command removes all of the generated site and Jekyll metadata before docker builds the site. Without the `jekyll clean` command, Jekyll may not rebuild every file and serve old files instead. 
  
In addition to the `jekyll clean` command, `sh -c` was added in order to run multiple Jekyll commands. `sh` indicates which language interpreter to use and the `-c` argument indicates to read the jekyll commands in the following string. The `&&` part of the string separates the jekyll commands. `sh` was chosen over `bash` since `sh` is more widely supported. 

`>` was also added to indicate that the value for the command key is a multi-line string and that newlines should be treated as spaces when read. 

### Screenshots of Proposed Changes Of The Website 
No visual changes to the website.
