### PR TITLE
Removed unused alt-hero #3213

### DIFF
--- a/_projects/undebate.md
+++ b/_projects/undebate.md
@@ -5,7 +5,6 @@ description: For down ballot offices like school-board, voters often don’t kno
 image: /assets/images/projects/undebate.jpg
 alt: 'Undebate with moderator and 4 participants, displayed question as "Why are you running for office?".'
 image-hero: /assets/images/projects/undebate-hero.jpg
-alt-hero: "Silhouette of three people sitting in chairs. Two of them have empty speach bubbles over their heads."
 leadership:
   - name: David Fridley
     role: Stake Holder/Technical Lead


### PR DESCRIPTION
Fixes #3213 

### What changes did you make and why did you make them ?

- Removed unused alt-hero field from undebate.md project file
(alt-hero: "Silhouette of three people sitting in chairs. Two of them have empty speach bubbles over their heads.")
- alt-hero text is not used anywhere in the codebase since the image-hero is used as an SCSS background image.
- No visuals before changes are applied
