### PR TITLE
Removed lightyellow and papayawhip variables from requested files

### DIFF
--- a/_sass/elements/_color-styles.scss
+++ b/_sass/elements/_color-styles.scss
@@ -18,8 +18,6 @@
 
 // Yellows
 .color-mustard { color: $color-mustard; }
-.color-lightyellow { color: $color-lightyellow; }
-.color-papayawhip { color: $color-papayawhip; }
 
 // Greens
 .color-forestgreen { color: $color-forestgreen; }

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -18,8 +18,6 @@ $color-gold: #F2C94D;
 
 // Yellows
 $color-mustard: #d49f28;
-$color-lightyellow: #ffff97;
-$color-papayawhip: #ffefd5;
 
 // Greens
 $color-forestgreen: #58915b;


### PR DESCRIPTION
Fixes #2199

### What changes did you make and why did you make them?
- Per @JessicaLucindaCheng's [comment](https://github.com/hackforla/website/issues/2199#issuecomment-1304875746) on #2199, removed ```color-lightyellow``` and ```color-papayawhip``` from ```_sass/variables/_colors.scss``` and 
```_sass/elements/_color-styles.scss```.

### Screenshots of proposed changes of the website (if any, please do not screenshot code changes)
- No visual changes.
