### PR TITLE
Removed unused alt-hero field

### DIFF
--- a/_projects/public-tree-map.md
+++ b/_projects/public-tree-map.md
@@ -5,7 +5,6 @@ description: Public Tree Map helps connect people to Santa Monica's urban forest
 image: /assets/images/projects/public-tree-map.png
 alt: 'Zoomed-in map showing ten streets of the neighborhood. Each dot on the map displaying a tree from the urban forest'
 image-hero: /assets/images/projects/public-tree-map-hero.jpeg
-alt-hero: 'Coral tree from City of Santa Monica. Photo by Dave Baiocchi www.studiobaiocchi.net'
 leadership: 
   - name: Emily F.
     role: Product Owner


### PR DESCRIPTION
Fixes #3209 

### What changes did you make and why did you make them ?

  - Removed the unused alt-hero field because it was not being used anywhere in the code page since the image-hero was being used as a background image. 
  - As a result it'll reduce unnecessary code as well as reduce time to review code and load the website. 