### PR TITLE
Re-added lightyellow color variable and class

### DIFF
--- a/_sass/components/_home.scss
+++ b/_sass/components/_home.scss
@@ -309,7 +309,7 @@ button {
   float: right;
   text-align: center;
   margin-left: 10px;
-  background-color: rgb(255, 255, 151);
+  background-color: $color-lightyellow;
   width: 92px;
   padding: 2px 7px;
   border-radius: 6px;

--- a/_sass/components/_projects-page.scss
+++ b/_sass/components/_projects-page.scss
@@ -86,7 +86,7 @@
     float: right;
     text-align: center;
     margin-left: 10px;
-    background-color: rgb(255, 255, 151);
+    background-color: $color-lightyellow;
     width: 92px;
     padding: 2px 7px;
     border-radius: 6px;

--- a/_sass/components/_projects.scss
+++ b/_sass/components/_projects.scss
@@ -86,7 +86,7 @@
   float: right;
   text-align: center;
   margin-left: 10px;
-  background-color: rgb(255, 255, 151);
+  background-color: $color-lightyellow;
   width: 92px;
   padding: 2px 7px;
   border-radius: 6px;

--- a/_sass/elements/_color-styles.scss
+++ b/_sass/elements/_color-styles.scss
@@ -18,6 +18,7 @@
 
 // Yellows
 .color-mustard { color: $color-mustard; }
+.color-lightyellow { color: $color-lightyellow; }
 
 // Greens
 .color-forestgreen { color: $color-forestgreen; }

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -18,6 +18,7 @@ $color-gold: #F2C94D;
 
 // Yellows
 $color-mustard: #d49f28;
+$color-lightyellow: #ffff97;
 
 // Greens
 $color-forestgreen: #58915b;


### PR DESCRIPTION
Fixes #2199

### What changes did you make and why did you make them?

My previous PR #3749 had removed a color variable for a color that is actively being used on the website, so this PR is to correct those changes.

Per @JessicaLucindaCheng's [comment](https://github.com/hackforla/website/issues/2199#issuecomment-1334702332) on #2199:
- Put the ```$lightyellow``` variable back in ```_sass/variables/_colors.scss```
- Put the ```.lightyellow``` class back in ```_sass/elements/_color-styles.scss```
- Replaced the RGB equivalents (```rgb(255, 255, 151)```) of ```lightyellow``` with the variable, which occurred in
  - ```_sass/components/_home.scss```
  - ```_sass/components/_projects-page.scss```
  - ```_sass/components/_projects.scss```

### Screenshots of proposed changes of the website (if any, please do not screenshot code changes)
- No visual changes.