### PR TITLE
Add credit for Social Safety Net image for redesigned homepage #3416

### DIFF
--- a/_data/internal/credits/social-safety-net.yml
+++ b/_data/internal/credits/social-safety-net.yml
@@ -1,0 +1,22 @@
+---
+# The title from the source provider
+title: Social Safety Net
+# The url where you can get direct access to the image on the provider site
+title-link: https://unsplash.com/photos/lyiKExA4zQA
+# The type of content - image, audio, or video 
+content-type: image
+# The page it's used on
+used-in: Homepage
+# Name of the artist
+artist: Austin Kehmeier
+# Name of the image database you found it on
+provider: Unsplash
+# Please give the general site URL, not the link to the image
+provider-link: https://unsplash.com/
+# Location in our GitHub repo
+image-url: /assets/images/program-areas/social-safety-net.png
+# Alt text for the image on the Credits page
+alt: ''
+# If an image was altered, please give the name of the HfLA designer that altered the image
+altered-by: Kristine Eudey
+---


### PR DESCRIPTION
Fixes #3416 

### What changes did you make and why did you make them ?

  - Added a credit for a new image used in the redesigned version of the homepage so that the Credits webpage is up to date.
  - Added file social-safety-net.yml in _data/internal/credits
  - No screenshot taken.

