### PR TITLE
Change Alt Text for SDG Image

### DIFF
--- a/_data/internal/credits/team.yml
+++ b/_data/internal/credits/team.yml
@@ -1,12 +1,11 @@
 ---
 title: Team
 title-link: https://thenounproject.com/search/?creator=638256&q=team&i=1092053
-content: icon
+content-type: image
 used-in: Wins Page
 artist: Creative Stall
 provider: Noun Project 
 provider-link: https://thenounproject.com/
 image-url: /assets/images/wins-page/wins-badges/team.svg
 alt: 'Team Icon'
-type: icon
 ---

--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -70,5 +70,5 @@ sdg: '<strong>16.8:</strong> Broaden and strengthen the awareness and participat
 card-image-src: /assets/images/projects/311.jpg
 card-image-alt:
 sdg-image-src: /assets/images/about/sdg-elements/peace-justice.svg
-sdg-image-alt: peace justice bottom sustainable dev goal
+sdg-image-alt: '16: peace, justice and strong institutions'
 ---


### PR DESCRIPTION
Fixes #3091

### What changes did you make and why did you make them?

- I changed sdg-image-alt to '16: peace, justice and strong institutions' to ensure that alt texts adhere to Web Content Accessibility Guidelines (WCAG).