### PR TITLE
Display VRMS data on Events and Project Meetings pages

### DIFF
--- a/assets/js/utility/api-events.js
+++ b/assets/js/utility/api-events.js
@@ -32,16 +32,15 @@ function insertEventSchedule(eventData, page) {
       );
     } else {
       value.forEach((event) => {
-        let eventHtml;
-        // insert the correct html for the current page
-        if ( page === "events" ) {
-          eventHtml = `<li>${event.start} - ${event.end} </li><li><a href="${event.hflaWebsiteUrl}">${event.name}</a> ${event.dsc}</li>`;
-        } else {
-          eventHtml = `<li>${event.start} - ${event.end} <a href="${event.hflaWebsiteUrl}">${event.name}</a> ${event.dsc}</li>`;
-        }
-        placeToInsert.insertAdjacentHTML(
-          "beforeend", eventHtml
-        );
+        if (event) {
+          let eventHtml;
+				  // insert the correct html for the current page
+				  if (page === "events") {
+					  eventHtml = `<li>${event.start} - ${event.end} </li><li><a href="${event.hflaWebsiteUrl}">${event.name}</a> ${event.dsc}</li>`;
+				  } else {
+					  eventHtml = `<li>${event.start} - ${event.end} <a href="${event.hflaWebsiteUrl}">${event.name}</a> ${event.dsc}</li>`;
+				  }
+				  placeToInsert.insertAdjacentHTML("beforeend", eventHtml);}
       });
     }
   }
@@ -143,14 +142,16 @@ function convertTime12to24(time12h) {
  * Function that represent the individual object extracted from the api
  */
 function display_object(item) {
-  const rv_object = {
-    name: item.project.name,
-    dsc: item.description,
-    start: localeTimeIn12Format(item.startTime),
-    end: localeTimeIn12Format(item.endTime),
-    hflaWebsiteUrl: item.project.hflaWebsiteUrl,
-  };
-  return rv_object;
+  if (item && item.project) { 
+    const rv_object = {
+      name: item.project.name,
+      dsc: item.description,
+      start: localeTimeIn12Format(item.startTime),
+      end: localeTimeIn12Format(item.endTime),
+      hflaWebsiteUrl: item.project.hflaWebsiteUrl,
+	  };
+	  return rv_object;
+  }
 }
 
 export { getEventData, insertEventSchedule };


### PR DESCRIPTION
Fixes #3701

### What changes did you make and why did you make them?

  - I added 'if' statements in the `insertEventSchedule` and `display_object` functions in `assets/js/utility/api-events.js`, which fixed TypeErrors caused by incompatible or missing values in the data. Rather than combing through the VRMS data to find what caused these errors, I thought this was a more efficient solution that safeguards against similar issues in the future.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1032" alt="Screen Shot 2023-01-16 at 10 20 21 PM" src="https://user-images.githubusercontent.com/104411072/212829490-ee663d2d-f357-4d7d-b8ce-7d067c085ecd.png">

<img width="936" alt="Screen Shot 2023-01-16 at 10 21 56 PM" src="https://user-images.githubusercontent.com/104411072/212829705-4c06356c-c89d-44cb-a231-817db7a7f838.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1039" alt="Screen Shot 2023-01-16 at 10 21 00 PM" src="https://user-images.githubusercontent.com/104411072/212829737-d632c00f-5d54-45aa-851e-bab13692b46e.png">

<img width="943" alt="Screen Shot 2023-01-16 at 10 21 30 PM" src="https://user-images.githubusercontent.com/104411072/212829516-c6898a4f-4a3d-4354-9d42-964e40eb3493.png">

</details>
