### PR TITLE
Update Zero Hunger image alt text for About Us page

### DIFF
--- a/_includes/about-page/about-card-sustainability.html
+++ b/_includes/about-page/about-card-sustainability.html
@@ -46,7 +46,7 @@
             <!-- This is the bottom and then left cell-->
             <div class="sdg-left-column sdg-left-flex-container">
                 <div class="grid-2-column">
-                    <img src="/assets/images/about/sdg-elements/zero-hunger.svg" alt="Zero Hunger goal logo" />
+                    <img src="/assets/images/about/sdg-elements/zero-hunger.svg" alt="2 Zero Hunger" />
                     <img src="/assets/images/about/sdg-elements/gender-equality.svg" alt="Gender Equality goal logo" />
                     <img src="/assets/images/about/sdg-elements/decent-work.svg" alt="8 Decent Work and Economic Growth" />
                     <img src="/assets/images/about/sdg-elements/sustainable-cities.svg" alt="Sustainable Cities and Communities goal logo" />


### PR DESCRIPTION
Fixes #3382

### What changes did you make and why did you make them ?
  - Changed Zero Hunger logo image alt text from `Zero Hunger goal logo` to `2 Zero Hunger`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to site.