### PR TITLE
Update sdg img size and .sustainable-dev-goal padding

### DIFF
--- a/_sass/components/_citizen_engagement.scss
+++ b/_sass/components/_citizen_engagement.scss
@@ -217,7 +217,7 @@
     .program-area {
         display: grid;
         grid-template-columns: 1fr 1fr;
-        grid-gap:2em;
+        grid-gap: 2em;
         padding: 44px;
 
         img {
@@ -258,6 +258,7 @@
             display: block !important;
             background: $color-pink;
             border-radius: 10px;
+            padding: 20px;
             grid-row: 2/3;
 
             h4 {
@@ -274,7 +275,7 @@
             }
 
             .sdg-image {
-                height: 100%;
+                height: 145px;
                 margin-right: 20px;
                 border-radius: 10px;
             }

--- a/_sass/components/_citizen_engagement.scss
+++ b/_sass/components/_citizen_engagement.scss
@@ -212,13 +212,15 @@
 
 @media #{$bp-tablet-up} {
     .program-area-container {
-        max-width: 1080px !important;
+        max-width: 1080px !important; 
     }
+
     .program-area {
         display: grid;
         grid-template-columns: 1fr 1fr;
         grid-gap: 2em;
         padding: 44px;
+        margin: 30px 0;
 
         img {
             border-radius: 10px;

--- a/_sass/components/_citizen_engagement.scss
+++ b/_sass/components/_citizen_engagement.scss
@@ -261,6 +261,10 @@
             padding: 20px;
             grid-row: 2/3;
 
+            p {
+                margin-bottom: 0;
+            }
+
             h4 {
                 margin-bottom: 10px;
                 font-style: bold;


### PR DESCRIPTION
Fixes #3738

### What changes did you make and why did you make them ?

  -All changes within $bp-media-up media query.
  -  .sdg-image height: 145 px
  -  .sustainable-dev-goal padding: 20px
  - p element within .sustainable-dev-goal margin-bottom: 0

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->

<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](
[screencapture-localhost-4000-citizen-engagement-2023-01-19-13_59_39 (1).pdf](https://github.com/hackforla/website/files/10461529/screencapture-localhost-4000-citizen-engagement-2023-01-19-13_59_39.1.pdf)
 )


</details>
