### PR TITLE
Add alt tag to infinity image

### DIFF
--- a/_includes/home-page/home-technologies.html
+++ b/_includes/home-page/home-technologies.html
@@ -17,7 +17,7 @@
             <hr>
             <li class="metric">
                 <div class="metric-number">
-                    <img src="assets/images/hero/infinite.svg">
+                    <img src="assets/images/hero/infinite.svg" alt="infinite">
                 </div>
                 <p>Potential<span class="desktop-up-only"> to hone your skills</span></p>
             </li>


### PR DESCRIPTION
Fixes #3793 

### What changes did you make and why did you make them ?
  - Added alt tag to infinity image to comply with web content accessibility guidelines
 - No visual changes to website; including a screenshot of the image I added the alt tag to

 
<img width="1242" alt="image" src="https://user-images.githubusercontent.com/93944737/214364400-5e7f41f1-2e5d-42b0-85cd-b7aadc394eef.png"></details>
