### PR TITLE
TESTING, again, changes for gha 2592 

### DIFF
--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -1,13 +1,39 @@
 name: Pull Request Trigger
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - 'gh-pages'
-      - 'feature-homepage-launch'
 
 jobs:
+  # Run an echo to confirm that the action was triggered
   Hello-World:
     runs-on: ubuntu-latest
     steps:
-     - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+     - run: echo "🍺 This job was automatically triggered by a ${{ github.event_name }} event."
+
+  # Gathers merged PRs from every location and moves to column 'test-approved-by-reviewer...'
+  Gather-Merged-PRs:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true }} 
+    steps:
+      - name: Gather Merged PRs
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Project Board
+          column: 'test-approved-by-reviewer (Automated Column, do not place items here manually)'
+          repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
+
+  # Deletes merged PRs from column 'test-approved-by-reviewer...' after 'needs: Gather-Merged-PRs'
+  Delete-Merged-PRs:
+    needs: Gather-Merged-PRs
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true }} 
+    steps: 
+      - name: Delete Merged PRs
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Project Board
+          column: 'test-approved-by-reviewer (Automated Column, do not place items here manually)'            
+          repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
+          action: delete


### PR DESCRIPTION
Fixes #2592

### What changes did you make and why did you make them ?

  - Continuation of first PR #3846 , and PR #3867
  - Changed workflow run from previous `on: pull_request` to `on: pull_request_target` on line 3, also fixed minor grammatical error on line 9.
  - Justin D and I discussed last Thursday, Jan 26 after the last PR was merged and then reverted due to an error message: `Parameter token or opts.auth is required` at the 'Gather-Merged-PRs' action. The token & automation here is the same as for 'Move-Closed-Issues.' The latter automation is triggered by an 'issue' event and the automation runs successfully with read/write privileges, and the former is triggered by a 'pull-request' event and fails to run due to read only privileges. The GitHub Docs discuss differences in permissions between the different events esp. with forked, public repositories.
  - See below: the GitHub Docs suggest that the problem may be solved by renaming the event as noted above.
 
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
![GitHub Docs 1](https://user-images.githubusercontent.com/40799239/215395798-23402b73-ceec-4f01-aa1d-0b1fe6a3c8fd.png)
![GitHub Docs 2](https://user-images.githubusercontent.com/40799239/215395823-a6f16f22-e1c2-49ee-a44b-a6d2de6b9554.png)


<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
