### PR TITLE
Changed the status of 100-automation

### DIFF
--- a/_projects/100-automations.md
+++ b/_projects/100-automations.md
@@ -73,5 +73,5 @@ location:
 visible: true
 program-area:
   - Civic Tech Infrastructure
-status: Active
+status: On Hold
 ---


### PR DESCRIPTION
Fixes #3892

### What changes did you make and why did you make them ?

  - On the project 100-automations, the status was set to active.
  - Changed the project from hactive to on hold.
  - The displayed item now shows as on hold on the status in the project itself and the project card.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>


![image](https://user-images.githubusercontent.com/38971729/215893801-97c28421-d5ab-4c0e-9791-295e3831cdab.png)



![image](https://user-images.githubusercontent.com/38971729/215657692-c0ccfb41-7b7f-4e87-b9b6-75e6a95f0d59.png)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/38971729/215893507-47c983a5-b462-474e-82ea-c0d65843896f.png)
![image](https://user-images.githubusercontent.com/38971729/215657745-7fd4728e-ec72-41fd-894f-488379e40586.png)

</details>
