### PR TITLE
changed the alt tag description

### DIFF
--- a/_includes/events-page/our-locations-content.html
+++ b/_includes/events-page/our-locations-content.html
@@ -1,7 +1,7 @@
 <div class="getting-started-locations-only">
     <div class="events-card-container">
         <div class="event-card" >
-            <img class="location-image" src="../assets/images/hack-nights/westside1.png" alt="Westside L.A."  />
+            <img class="location-image" src="../assets/images/hack-nights/westside1.png" alt="Westside" />
         </div>
         <div class="event-card" >
             <img class="location-image" src="../assets/images/hack-nights/DTLA.png" alt="Downtown L.A." />


### PR DESCRIPTION
Fixes #3255

### What changes did you make and why did you make them ?

  - The alt tag for Westside was labeled as "Westside L.A. 
  - Changed the alt tag to show "Westside" per the standard of WCAG for issue 3255
 
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/38971729/216258327-07b94ba2-8d34-48e0-b49a-4de18ca40776.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/38971729/216258385-244ff593-cb48-4ffb-b77b-44f8b8f6287c.png)

</details>
