### PR TITLE
Update alt text for Volunteer card on Join Us page

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -51,7 +51,7 @@ permalink: /join
     <a class="anchor" id="volunteer"></a>
     <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
       <h2 class="title4 page-card--large-icon-header">Volunteer with Us</h2>
-      <img class="join-us-card-img" src="/assets/images/join-us/volunteer-with-us-icon.svg" alt="join us card image" />
+      <img class="join-us-card-img" src="/assets/images/join-us/volunteer-with-us-icon.svg" alt="" />
       <div class="join-us-card-body page-card--large-icon-body">
         <p class="join-us-remove-p-padding">
           Hack for LA projects are currently recruiting for activists, coders, designers, researchers, testers, business


### PR DESCRIPTION
Fixes #3853  
**Join Us Page: Update alt text for Volunteer with Us card image to adhere to WCAG**


### What changes did you make and why did you make them ?

_According to the issue's Action Items the following changes were made:_
-  Change the image alt property value within `pages/join-us.html`:
From:
`alt="join us card image"`
To:
`alt=""`
**_This change was for line 54 for the "Volunteer with Us" image._**
- Ensure that the corresponding `Join Us` webpage stays the same after the change
-  Using developer tools to inspect the image, ensure that the new alt text gets incorporated after the change.
    - Note: `alt=""` in code while show up as `alt` when using developer tools to inspect the image's alt text property.


### Screenshots of Proposed Changes Of The Website 

**The visual appearance of the webpage remains the same after the change, as according to instructions. Below are screenshots of the changes in html elements and html properties before and after the change, according to Chrome devtools. On the lower left the img alt attribute changes from `alt="join us card image"` to `alt`. On the lower right the alt property changes from `alt: "join us card image"` to `alt: ""`.**

<details>
<summary>Element and properties before changes are applied</summary>

<img src="https://user-images.githubusercontent.com/17149108/216792857-da3ffc9a-601b-4b67-8eba-6753ef436472.png" width="800" height="411" />

</details>

<details>
<summary>Element and properties after changes are applied</summary>
  
<img src="https://user-images.githubusercontent.com/17149108/216793016-442b1e7d-7cc0-47f4-b1d0-563bab7db3fe.png" width="800" height="411" />

</details>
