### PR TITLE
Fix project meeting time not displaying on VRMS project page

### DIFF
--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -122,13 +122,12 @@ let meetingsFound = [];
 {% assign localData = site.data.external.vrms_data %}
 // Escapes JSON for injections. See: #2134. If this is no longer the case, perform necessary edits, and remove this comment.
 let localData = JSON.parse(decodeURIComponent("{{ localData | jsonify | uri_escape }}"));
-const API_URL = 'https://www.vrms.io/api/recurringevents';
 
 // Function schedules data that is passed in
 function schedule(scheduleData) {
 
     // Loops through data and assigns information to variables in a readable format
-    for (let event of scheduleData) {
+    for (const event of scheduleData) {
         try {
             const startTime = timeFormat(new Date(event.startTime));
             const endTime = timeFormat(new Date(event.endTime));

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -137,7 +137,7 @@ function appendMeetingTimes(scheduleData) {
             const day = new Date(event.date).toString().substring(0,3);
     
             // only append the meeting times to the correct project page
-            if (projectTitle === projectName) {
+            if (projectTitle.toLowerCase() === projectName.toLowerCase()) {
                 meetingsList.insertAdjacentHTML("beforeend", `<li class="meetingTime">${day} ${startTime} - ${endTime} <br>${description}</li>`);
                 meetingsFound.push(day);
             }

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -118,48 +118,37 @@ let meetingsHeader = document.querySelector('.meetingsHeader');
 let projectTitle = scriptTag.getAttribute("projectTitle");
 let meetingsFound = [];
 
-// Assigns local JSON Data to localData variable
-{% assign localData = site.data.external.vrms_data %}
+// Grab the meeting time data from the vrms_data.json file
+{% assign vrmsData = site.data.external.vrms_data %}
 // Escapes JSON for injections. See: #2134. If this is no longer the case, perform necessary edits, and remove this comment.
-let localData = JSON.parse(decodeURIComponent("{{ localData | jsonify | uri_escape }}"));
+const vrmsData = JSON.parse(decodeURIComponent("{{ vrmsData | jsonify | uri_escape }}"));
 
-// Function schedules data that is passed in
-function schedule(scheduleData) {
+// Loops through the VRMS data and inserts each meeting time into the HTML of the correct project page
+function appendMeetingTimes(scheduleData) {
 
-    // Loops through data and assigns information to variables in a readable format
     for (const event of scheduleData) {
         try {
+            // Assigning information to variables in a readable format
             const startTime = timeFormat(new Date(event.startTime));
             const endTime = timeFormat(new Date(event.endTime));
             const webURL = event.project.hflaWebsiteUrl;
             const projectName = event.project.name;
             const description = event.description;
             const day = new Date(event.date).toString().substring(0,3);
-            let scheduleClass;
     
-            // Function that adds data to proper header
-            function scheduleDay() {
-                // Assigns different class to data depending if it utilized local JSON file or the VRMS fetch data
-                if (scheduleData == localData) {
-                    scheduleClass = "localData";
-                } else {
-                    scheduleClass = "updated";
-                }
-                if (projectTitle === projectName) {
-                    meetingsList.insertAdjacentHTML("beforeend", `<li class="${scheduleClass} meetingTime">${day} ${startTime} - ${endTime} <br>${description}</li>`);
-                    meetingsFound.push(day);
-                }
+            // only append the meeting times to the correct project page
+            if (projectTitle === projectName) {
+                meetingsList.insertAdjacentHTML("beforeend", `<li class="meetingTime">${day} ${startTime} - ${endTime} <br>${description}</li>`);
+                meetingsFound.push(day);
             }
-            scheduleDay(day);
+
         } catch (e) {
             console.error(e);
         }
     } 
 }
 
-
-// Executes schedule with localData
-schedule(localData);
+appendMeetingTimes(vrmsData);
 
 
 if (meetingsFound.length >= 1) {

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -128,81 +128,39 @@ const API_URL = 'https://www.vrms.io/api/recurringevents';
 function schedule(scheduleData) {
 
     // Loops through data and assigns information to variables in a readable format
-    for (let i = 0; i <= scheduleData.length - 1; i++) {
-        let startTime = timeFormat(new Date(scheduleData[i].startTime));
-        let endTime = timeFormat(new Date(scheduleData[i].endTime));
-        let webURL = scheduleData[i].project.hflaWebsiteUrl;
-        let projectName = scheduleData[i].project.name;
-        let description = scheduleData[i].description;
-        let day = new Date(scheduleData[i].date).toString().substring(0,3);
-        let scheduleClass;
-
-        // Function that adds data to proper header
-        function scheduleDay() {
-            // Assigns different class to data depending if it utilized local JSON file or the VRMS fetch data
-            if (scheduleData == localData) {
-                scheduleClass = "localData";
-            } else {
-                scheduleClass = "updated";
+    for (let event of scheduleData) {
+        try {
+            const startTime = timeFormat(new Date(event.startTime));
+            const endTime = timeFormat(new Date(event.endTime));
+            const webURL = event.project.hflaWebsiteUrl;
+            const projectName = event.project.name;
+            const description = event.description;
+            const day = new Date(event.date).toString().substring(0,3);
+            let scheduleClass;
+    
+            // Function that adds data to proper header
+            function scheduleDay() {
+                // Assigns different class to data depending if it utilized local JSON file or the VRMS fetch data
+                if (scheduleData == localData) {
+                    scheduleClass = "localData";
+                } else {
+                    scheduleClass = "updated";
+                }
+                if (projectTitle === projectName) {
+                    meetingsList.insertAdjacentHTML("beforeend", `<li class="${scheduleClass} meetingTime">${day} ${startTime} - ${endTime} <br>${description}</li>`);
+                    meetingsFound.push(day);
+                }
             }
-            if (projectTitle === projectName) {
-                meetingsList.insertAdjacentHTML("beforeend", `<li class="${scheduleClass} meetingTime">${day} ${startTime} - ${endTime} <br>${description}</li>`);
-                meetingsFound.push(day);
-            }
+            scheduleDay(day);
+        } catch (e) {
+            console.error(e);
         }
-        scheduleDay(day);
-    }
+    } 
 }
 
-// Function checks for differences between two arrays
-function arr_diff (a1, a2) {
-
-    let a = [], diff = [];
-
-    for (let i = 0; i < a1.length; i++) {
-        a[a1[i]] = true;
-    }
-
-    for (let i = 0; i < a2.length; i++) {
-        if (a[a2[i]]) {
-            delete a[a2[i]];
-        } else {
-            a[a2[i]] = true;
-        }
-    }
-
-    for (let k in a) {
-        diff.push(k);
-    }
-
-    return diff;
-}
-
-// Function clears the schedule
-function clearSchedule() {
-    let prevDayList = meetingsList.getElementsByClassName("localData");
-
-    while (prevDayList[0]) {
-        prevDayList[0].parentNode.removeChild(prevDayList[0]);
-    }
-}
 
 // Executes schedule with localData
 schedule(localData);
-
-// Fetchs JSON file from VRMS_API
-fetch(API_URL, {method: 'GET'})
-    .then(response => response.json())
-    .then((data) => {
-    // Checks for differences between localData and VRMS data
-    if (arr_diff(data, localData)) {
-        clearSchedule();
-        schedule(data);
-    }
-})
-.catch(err => {
-    console.log(err);
-})
 
 
 if (meetingsFound.length >= 1) {


### PR DESCRIPTION
Fixes #3890

### What changes did you make and why did you make them ?
  - Wrapped the logic of the for loop that appends meeting times to the project page with a `try...catch` block so that the loop doesn't prematurely exit if an error is thrown
  - Further refactored and simplified the for loop to make it more readable and less susceptible to future errors
  - Removed all of the legacy code associated with making a `fetch()` request to the VRMS API since we are now handling that with a cron job that runs in `vrms-data.yml`
  - Added `.toLowerCase()` to both the `projectTitle` and `projectName` variables because a letter casing discrepancy was causing the "Access The Data" meeting times to not be displayed

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/73561520/216849922-ba2a7dc5-430f-4f8f-9cb6-aca71bd72b81.png)
![image](https://user-images.githubusercontent.com/73561520/216853159-fcd89450-f277-4b99-8286-a18a88284251.png)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/73561520/216849896-42c04e2b-a557-490f-af22-d775ebe1e0a8.png)

![image](https://user-images.githubusercontent.com/73561520/216853143-ea4042de-04f1-4dd1-bceb-d575c526b93f.png)



</details>
