### PR TITLE
Updated image alt text in "Join Us" page

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -28,7 +28,7 @@ permalink: /join
     <a class="anchor" id="advise"></a>
     <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
       <h2 class="title4 page-card--large-icon-header">Advise Us</h2>
-      <img class="join-us-card-img" src="/assets/images/join-us/advice-us-icon.svg" alt="join us card image" />
+      <img class="join-us-card-img" src="/assets/images/join-us/advice-us-icon.svg" alt="" />
       <div class="join-us-card-body ">
         <p>
           Hack for LA needs Advisors in a variety of areas. These roles are
@@ -51,7 +51,7 @@ permalink: /join
     <a class="anchor" id="volunteer"></a>
     <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
       <h2 class="title4 page-card--large-icon-header">Volunteer with Us</h2>
-      <img class="join-us-card-img" src="/assets/images/join-us/volunteer-with-us-icon.svg" alt="join us card image" />
+      <img class="join-us-card-img" src="/assets/images/join-us/volunteer-with-us-icon.svg" alt="" />
       <div class="join-us-card-body page-card--large-icon-body">
         <p class="join-us-remove-p-padding">
           Hack for LA projects are currently recruiting for activists, coders, designers, researchers, testers, business
@@ -70,7 +70,7 @@ permalink: /join
     <a class="anchor" id="partner"></a>
     <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
       <h2 class="title4 page-card--large-icon-header">Partner with Us</h2>
-      <img class="join-us-card-img" src="/assets/images/join-us/partner-with-us-icon.svg" alt="join us card image" />
+      <img class="join-us-card-img" src="/assets/images/join-us/partner-with-us-icon.svg" alt="" />
       <div class="join-us-card-body page-card--large-icon-body">
         <p>
           The more you tell us about yourself, the better we can match you with


### PR DESCRIPTION
Fixes #3854 

### What changes did you make and why did you make them ?

  - Updated "join-us-card-img" class images' alt text to ""
  -
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Changing alt text for images. No visual changes to the website.
