### PR TITLE
Fixed the Windows docker-users link under 1.5a Docker intallation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,7 +220,7 @@ More on using Docker and the concepts of containerization:
 #### **1.5.a Docker installation troubleshooting**
 
 If you are on Windows and get 'You are not allowed to use Docker, you must be in the "docker-users" group' as an error message, the following wiki page is a guide for solving te issue:
-- [Windows docker-users group error guide](https://github.com/hackforla/website/wiki/Adding-local-user-accounts-to-the-docker-users-group-on-Windows-10)
+- [Windows docker-users group error guide](https://github.com/hackforla/website/wiki/Add-local-user-accounts-to-the-docker-users-group-on-Windows-10)
 
 Installing WSL2 on windows
 - https://docs.microsoft.com/en-us/windows/wsl/install-win10


### PR DESCRIPTION
Fixes #3822 

### What changes did you make and why did you make them ?

  - Changed the current link:
  ```
  - [Windows docker-users group error guide](https://github.com/hackforla/website/wiki/Adding-local-user-accounts-to-the-docker-users-group-on-Windows-10)
  ```
  to
  ```
  - [Windows docker-users group error guide](https://github.com/hackforla/website/wiki/Add-local-user-accounts-to-the-docker-users-group-on-Windows-10)
  ```
  - The fixed link will be useful to future and current developers who need the exact link to troubleshoot for Windows docker-users group errors.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied (note link below when mouse hovers over the link)</summary>

![image](https://user-images.githubusercontent.com/94583613/219550728-9f20569e-f55d-42d9-978a-5866feec1b7b.png)

</details>

<details>
<summary>Visuals after changes are applied (note link below when mouse hovers over the link)</summary>
  
![image](https://user-images.githubusercontent.com/94583613/219550766-e6f30d18-d4ab-4e9b-ab07-a81643c9eb28.png)

The page that it goes to after clicking:

![link](https://user-images.githubusercontent.com/94583613/219550840-83441444-3ef0-48d3-b783-508ff9a48ad2.png)

</details>
