### PR TITLE
Updated site url link from food-oasis.md

### DIFF
--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -65,7 +65,7 @@ links:
   - name: GitHub
     url: "https://github.com/hackforla/food-oasis"
   - name: Site
-    url: "https://foodoasis.la/"
+    url: "https://foodoasis.net"
   - name: Readme
     url: "https://github.com/hackforla/food-oasis/blob/master/README.md"
   - name: Slack


### PR DESCRIPTION
Fixes #3955

### What changes did you make and why did you make them ?

  - Changed url under links from `https://foodoasis.la/` to `https://foodoasis.net`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
