### PR TITLE
Add No Wrapping to Getting Started Page "Step" Headers

### DIFF
--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -43,6 +43,7 @@
   text-decoration: none;
   font-size: 18px;
   text-align: center;
+  white-space: nowrap;
 }
 
 .getting-started-step-title-overview {


### PR DESCRIPTION
Fixes #3976 

### What changes did you make and why did you make them ?

  - Added a "white-space" property to the "gs-link" class in _getting-started-page.scss to stop default wrapping behavior of text. This class was already assigned to every "Step" header, so adding the "white-space" property with a value of "nowrap" would prevent each header text positioning from wrapping into a second line if the width of the viewport was from 768px to 795px (inclusive). There were no side effects from testing inside and outside of the specified range. This fixes "Step 5", which previously displayed a visual inconsistency with the other steps in which "5" wrapped into a second line.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/61027932/220248687-2b9ce2b0-8aa3-4580-93e9-ab6d21802201.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/61027932/220248733-ea04a133-b010-4153-a885-b0fd0da272c5.png)

</details>
