### PR TITLE
added  "Altered by" field to be displayed for yml information files t…

### DIFF
--- a/_data/internal/credits/civil-tech-infrastructure.yml
+++ b/_data/internal/credits/civil-tech-infrastructure.yml
@@ -19,4 +19,6 @@ image-url: /assets/images/program-areas/civic-tech-infrastructure.png
 alt: ''
 # If an image was altered, please give the name of the HfLA designer that altered the image
 altered-by: Kristine Eudey
+# If an image was altered, please give the LinkedIn URL of the HfLA designer that altered the image
+altered-by-link: https://www.linkedin.com/in/kristine-eudey/
 ---

--- a/_data/internal/credits/diversity-equity-inclusion.yml
+++ b/_data/internal/credits/diversity-equity-inclusion.yml
@@ -19,4 +19,6 @@ image-url: /assets/images/program-areas/diversity-equity-inclusion.png
 alt: ''
 # If an image was altered, please give the name of the HfLA designer that altered the image
 altered-by: Kristine Eudey
+# If an image was altered, please give the LinkedIn URL of the HfLA designer that altered the image
+altered-by-link: https://www.linkedin.com/in/kristine-eudey/
 ---

--- a/_data/internal/credits/social-safety-net.yml
+++ b/_data/internal/credits/social-safety-net.yml
@@ -19,4 +19,6 @@ image-url: /assets/images/program-areas/social-safety-net.png
 alt: ''
 # If an image was altered, please give the name of the HfLA designer that altered the image
 altered-by: Kristine Eudey
+# If an image was altered, please give the LinkedIn URL of the HfLA designer that altered the image
+altered-by-link: https://www.linkedin.com/in/kristine-eudey/
 ---

--- a/pages/credits.html
+++ b/pages/credits.html
@@ -61,6 +61,18 @@ permalink: /credits/
                           {%- endif -%}
                         </p>
                       {%- endif -%}
+
+                      {%- if item[1].altered-by -%}
+                        <p>
+                          <strong>Altered by: </strong>
+                          {%- if item[1].altered-by-link -%}
+                            <a href="{{item[1].altered-by-link}}">{{ item[1].altered-by }}</a>
+                          {%- else -%}
+                            {{ item[1].altered-by }}
+                          {%- endif -%}
+                        </p>
+                      {%- endif -%}
+
                     </div>
                   </div>
                 </li>


### PR DESCRIPTION
Fixes #3775 

### What changes did you make and why did you make them ?

  - Added Altered by: field to credits page for any yml information file has an altered-by entry, to show up after the Provider field for that credit on the Credits page. 
  - Per Bonnie's request,  link edthe Altered by name to their LinkedIn.
  - To files credits/diversity-equity-inclusion.yml, civil-tech-infrastructure.yml, social-safety-net.yml that had altered-by field, added altered-by-link with the HackForLa's designers LinkedIn URL (provided by Bonnie). This was not outlined in the above issue but refer to the comments below. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>
<img width="415" alt="Screen Shot 2023-01-23 at 12 22 30 PM" src="https://user-images.githubusercontent.com/79809138/221735880-65d32d9e-0080-434c-a470-f0845b554e69.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="344" alt="Screen Shot 2023-02-27 at 6 21 41 PM" src="https://user-images.githubusercontent.com/79809138/221736745-dda3a033-e68f-4c4b-9a3e-3db7c778c27f.png">

</details>
