### PR TITLE
Enhance wins alt text 3960

### DIFF
--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -402,7 +402,7 @@ function seeMore(id){
 		parent.setAttribute('class','project-inner wins-card-text expanded');
 		span.setAttribute('class', 'see-more-div show-less-btn');
 		winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
-  	span.parentElement.removeAttribute('hidden');
+		span.parentElement.removeAttribute('hidden');
 		for (const child of winsIconContainer.children) {
 			child.firstElementChild.setAttribute('alt', '')
 		};

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -388,6 +388,7 @@ function seeMore(id){
 	let screenWidth = window.innerWidth;
 	let parent = span.parentElement.parentElement;
 	let winsIconContainer = document.getElementById(`icons-${id}`)
+	console.log(winsIconContainer)
 	if (parent.classList.contains('expanded') && screenWidth > 960) {
 		parent.setAttribute('class', 'project-inner wins-card-text');
 		winsIconContainer.setAttribute('class', 'wins-icon-container');
@@ -395,11 +396,17 @@ function seeMore(id){
 		parent.setAttribute('class', 'project-inner wins-card-text');
 		span.setAttribute('class', 'see-more-div');
 		winsIconContainer.setAttribute('class', 'wins-icon-container');
+		for (const child of winsIconContainer.children) {
+			child.firstElementChild.alt = child.lastElementChild.textContent
+		};
 	} else {
 		parent.setAttribute('class','project-inner wins-card-text expanded');
 		span.setAttribute('class', 'see-more-div show-less-btn');
 		winsIconContainer.setAttribute('class', 'wins-tablet wins-icon-container');
-  		span.parentElement.removeAttribute('hidden');
+  	span.parentElement.removeAttribute('hidden');
+		for (const child of winsIconContainer.children) {
+			child.firstElementChild.setAttribute('alt', '')
+		};
 	}
 }
 

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -263,7 +263,7 @@
 			if (badgeIcons.hasOwnProperty(item)) {
 				iconContainer.insertAdjacentHTML('beforeend',
 					`<div class='${view}-item-container'>
-						<img class="${view}-badge-icon" alt="${badgeIcons[item]}" src="${SVG_FILE_PATH}${badgeIcons[item]}">
+						<img class="${view}-badge-icon" alt="${item}" src="${SVG_FILE_PATH}${badgeIcons[item]}">
 						<div class="${view}-text-bubble" data-wins="font-styling">${item}</div>
 					</div>`
 				)

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -388,7 +388,6 @@ function seeMore(id){
 	let screenWidth = window.innerWidth;
 	let parent = span.parentElement.parentElement;
 	let winsIconContainer = document.getElementById(`icons-${id}`)
-	console.log(winsIconContainer)
 	if (parent.classList.contains('expanded') && screenWidth > 960) {
 		parent.setAttribute('class', 'project-inner wins-card-text');
 		winsIconContainer.setAttribute('class', 'wins-icon-container');

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -263,14 +263,14 @@
 			if (badgeIcons.hasOwnProperty(item)) {
 				iconContainer.insertAdjacentHTML('beforeend',
 					`<div class='${view}-item-container'>
-						<img class="${view}-badge-icon" alt="${item}" src="${SVG_FILE_PATH}${badgeIcons[item]}">
+						<img class="${view}-badge-icon" alt="${view === 'wins' ? item: ''}" src="${SVG_FILE_PATH}${badgeIcons[item]}">
 						<div class="${view}-text-bubble" data-wins="font-styling">${item}</div>
 					</div>`
 				)
 			} else if (item !== '') {
 				iconContainer.insertAdjacentHTML('beforeend',
 					`<div class='${view}-item-container'>
-						<img class="${view}-badge-icon" alt="" src="${SVG_FILE_PATH}${otherIcon}">
+						<img class="${view}-badge-icon" alt="${view === 'wins' ? item: ''}" src="${SVG_FILE_PATH}${otherIcon}">
 						<div class="${view}-text-bubble" data-wins="font-styling">${item}</div>
 					</div>`
 				)

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -54,7 +54,7 @@
   document.addEventListener('click', event => {
 	// if the .see-more-div element is clicked
 	if (event.target.closest('.see-more-div')) {
-	  // open the seeMore with the id of the selected target 
+	  // open the seeMore with the id of the selected target
 	  seeMore(event.target.id)
 	}
 	if (event.target.matches('.overlay') || event.target.closest('.overlay-close-icon') || event.target.closest('.top-buffer') || event.target.closest('.bottom-buffer')) {
@@ -63,7 +63,7 @@
 	// else, do nothing
 	return false;
   }, false);
-  
+
   document.addEventListener('keydown', function(event) {
 	// if its the enter key and the .see-more-div element is currently tabbed on
 	if (event.key === "Enter" && document.activeElement.classList.contains('see-more-div')) {
@@ -73,7 +73,7 @@
 	// else, do nothing
 	return false;
   }, false);
-  
+
   function createFilter(){
 
   	const roleArr = [];
@@ -86,7 +86,7 @@
   		Array.isArray(team) ? teamArr.push(...team)  :  teamArr.push(team);
 
   	})
-	//Assign Role for each Wins-Card  
+	//Assign Role for each Wins-Card
   	responses.querySelectorAll('.wins-card-role:not([style*="display:none"]):not([style*="display: none"]').forEach(item =>{
   		let value = item.textContent.replace("Role(s):","").trim();
   		let role = value.split(",").map(x=>x.trim());
@@ -239,7 +239,7 @@
   	}
   }
 
- 
+
 	function insertIcons(cardSelector, cardString, viewType, cloneCardTemplate = document) {
 		let initialCardList = cardString.split(',').map(item => item.trim())
 		let otherWinsText = [];
@@ -270,7 +270,7 @@
 			} else if (item !== '') {
 				iconContainer.insertAdjacentHTML('beforeend',
 					`<div class='${view}-item-container'>
-						<img class="${view}-badge-icon" alt="${badgeIcons[otherIcon]}" src="${SVG_FILE_PATH}${otherIcon}">
+						<img class="${view}-badge-icon" alt="" src="${SVG_FILE_PATH}${otherIcon}">
 						<div class="${view}-text-bubble" data-wins="font-styling">${item}</div>
 					</div>`
 				)
@@ -305,17 +305,17 @@
 				})
 
 			})
-		} 
+		}
 		let profileImgSrc = ghId ?
 			`https://avatars1.githubusercontent.com/u/${ghId}?v=4` :
 			AVATAR_DEFAULT_PATH;
-		
+
 		cloneCardTemplate.querySelector('.wins-card-profile-img').src = profileImgSrc;
 		cloneCardTemplate.querySelector('.wins-card-profile-img').id = `ghImg-${index}`;
 
 		cloneCardTemplate.querySelector('.wins-card-big-quote').src = QUOTE_ICON_PATH;
 		cloneCardTemplate.querySelector('.wins-card-name').textContent = card[name];
-	
+
 		if (card[linkedin_url].length > 0) {
 			cloneCardTemplate.querySelector('.wins-card-linkedin-icon').href = card[linkedin_url];
 			cloneCardTemplate.querySelector('.linkedin-icon').src = LINKEDIN_ICON ;
@@ -405,19 +405,19 @@ function seeMore(id){
 
 function changeSeeMoreBtn(x) {
 	const span = document.querySelectorAll(".see-more-div");
-	if (x.matches) { 
+	if (x.matches) {
 		for(let i = 0; i < span.length; i++) {
 			span[i].innerHTML = ''
 		}
 	} else {
 		for(let i = 0; i < span.length; i++) {
 			// removes show-less-btn class
-			span[i].setAttribute('class', 'see-more-div');	
+			span[i].setAttribute('class', 'see-more-div');
 			span[i].innerHTML = "See More";
 		}
 	}
   }
-  
+
   const x = window.matchMedia("(max-width: 960px)");
   x.addListener(changeSeeMoreBtn);
 


### PR DESCRIPTION
Fixes #3960

### What changes did you make and why did you make them ?

  - Added a ternary operator on line 266 and 273 to change the alt text for each badge icon to the toolkit text when the view is 'win' or to change the alt text to '' when the view is 'overlay'
  - In phone/tablet view, when the icon container is expanded, I added a for loop on lines 407-409 to remove the alt text from the badge icons
  - In phone/tablet view, when the icon container is expanded, I added a for loop on lines 399-401 to add the correct alt text for each badge icon based on its siblings textContent

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Before and After of wins page view</summary>

## Before

![Screenshot 2023-02-28 at 9 37 59 PM](https://user-images.githubusercontent.com/105510284/222055985-3e622fc8-7bbe-4ceb-82c5-00ce8fe173c4.png)

## After

![Screenshot 2023-02-28 at 9 38 16 PM](https://user-images.githubusercontent.com/105510284/222056020-a3a911da-6156-44e4-9709-0064224019f5.png)

</details>

<details>
<summary>Before and after of overlay view</summary>
  
## Before

![Screenshot 2023-02-28 at 9 38 46 PM](https://user-images.githubusercontent.com/105510284/222056146-187a6778-80b2-4cb6-9a4e-3e15c23250c4.png)

## After

![Screenshot 2023-02-28 at 9 39 00 PM](https://user-images.githubusercontent.com/105510284/222056176-16925e67-6b12-44bf-856e-8fd741ac9a8f.png)

</details>

<details>
<summary>Before and after of wins page view NOT expanded (Phone/tablet)</summary>
  
## Before

![Screenshot 2023-02-28 at 9 39 30 PM](https://user-images.githubusercontent.com/105510284/222056445-26575a9f-9da0-4d09-9221-31b0ebbc9734.png)

## After

![Screenshot 2023-02-28 at 9 40 17 PM](https://user-images.githubusercontent.com/105510284/222056500-b092bd76-6ea1-43a8-8129-de64931dc400.png)

</details>

<details>
<summary>Before and after of wins page view  expanded (Phone/tablet)</summary>
  
## Before

![Screenshot 2023-02-28 at 9 39 55 PM](https://user-images.githubusercontent.com/105510284/222056540-5f2b591d-2dab-49b0-a082-5bad61649723.png)

## After

![Screenshot 2023-02-28 at 9 40 36 PM](https://user-images.githubusercontent.com/105510284/222056584-697016f8-a136-4fc1-8e7c-6973f21a9a6f.png)

</details>