### PR TITLE
GitHub Actions: 2 weeks inactive label bug

### DIFF
--- a/github-actions/add-update-label-weekly/add-label.js
+++ b/github-actions/add-update-label-weekly/add-label.js
@@ -136,14 +136,19 @@ async function getTimeline(issueNum) {
  */
 
 async function isTimelineOutdated(timeline, issueNum, assignees) {
+  assignedWithinFourteenDays = false;
 	for await (let [index, moment] of timeline.entries()) {
 		if (isMomentRecent(moment.created_at, threeDayCutoffTime)) { // all the events of an issue within last three days will return true
-			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum)) { // checks if cross referenced within last three days 
+			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.assignee) { // checks if cross referenced within last three days 
 				return {result: false, labels: statusUpdatedLabel}
 			}
 			else if (moment.event == 'commented' && isCommentByAssignees(moment, assignees)) { // checks if commented within last three days 
 				return {result: false, labels: statusUpdatedLabel}
 			}
+      else if (moment.event == 'assigned' && assignees == moment.assignee)
+      {
+        assignedWithinFourteenDays = true;
+      }
 			else if (index === timeline.length-1 && (Date.parse(timeline[0].created_at) < fourteenDayCutoffTime.valueOf())) { // returns true if issue was created before 14 days after comparing the two dates in millisecond format  
 				return {result: true, labels: inactiveLabel}
 			}
@@ -155,7 +160,7 @@ async function isTimelineOutdated(timeline, issueNum, assignees) {
 			}
 		}
 		else if (isMomentRecent(moment.created_at, sevenDayCutoffTime)) { // all the events of an issue between three and seven days will return true
-			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum)) { // checks if cross referenced between 3 and 7 days
+			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.assignee) { // checks if cross referenced between 3 and 7 days
 				console.log('between 3 and 7 cross referenced');
 				return {result: false, labels: statusUpdatedLabel}
 			}
@@ -163,6 +168,10 @@ async function isTimelineOutdated(timeline, issueNum, assignees) {
 				console.log('between 3 and 7 commented');
 				return {result: false, labels: statusUpdatedLabel}
 			}
+      else if (moment.event == 'assigned' && assignees == moment.assignee)
+      {
+        assignedWithinFourteenDays = true;
+      }
 			else if (index === timeline.length-1 && (Date.parse(timeline[0].created_at) < fourteenDayCutoffTime.valueOf())) { // returns true if issue was created before 14 days after comparing the two dates in millisecond format  
 				return {result: true, labels: inactiveLabel}
 			}
@@ -171,19 +180,27 @@ async function isTimelineOutdated(timeline, issueNum, assignees) {
 			}
 		}
 		else if (isMomentRecent(moment.created_at, fourteenDayCutoffTime)) { // all the events of an issue between seven and fourteen days will return true
-			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum)) { // checks if cross referenced between 7 and 14 days
+			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.assignee) { // checks if cross referenced between 7 and 14 days
 				console.log('between 7 and 14 cross referenced');
 				return {result: false, labels: statusUpdatedLabel}
 			}
+      else if (moment.event == 'commented' && isCommentByAssignees(moment, assignees)) { // checks if commented between 3 and 7 days
+				console.log('between 7 and 14 commented');
+				return {result: false, labels: statusUpdatedLabel}
+			}
+      else if (moment.event == 'assigned' && assignees == moment.assignee)
+      {
+        assignedWithinFourteenDays = true;
+      }
 			else if (index === timeline.length-1 && (Date.parse(timeline[0].created_at) < fourteenDayCutoffTime.valueOf())) { // returns true if issue was created before 14 days after comparing the two dates in millisecond format  
-				return {result: true, labels: inactiveLabel}
+				return {result: true, labels: inactiveLabel}  
 			}
 			else if (index === timeline.length-1) { // returns true if the latest event created is between 7 and 14 days  
 				return {result: true, labels: toUpdateLabel}
 			}
 		}
 		else    { // all the events of an issue older than fourteen days will be processed here
-			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum)) { // checks if cross referenced older than fourteen days
+			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.assignee) { // checks if cross referenced older than fourteen days
 				console.log('14 day event cross referenced');
 				return {result: false, labels: statusUpdatedLabel}
 			}
@@ -192,6 +209,8 @@ async function isTimelineOutdated(timeline, issueNum, assignees) {
 			}
 		}
 	}
+  if (assignedWithinFourteenDays)
+    return {result: true, labels: toUpdateLabel}
 }	
 
 /**

--- a/github-actions/add-update-label-weekly/add-label.js
+++ b/github-actions/add-update-label-weekly/add-label.js
@@ -139,7 +139,7 @@ async function isTimelineOutdated(timeline, issueNum, assignees) {
   assignedWithinFourteenDays = false;
 	for await (let [index, moment] of timeline.entries()) {
 		if (isMomentRecent(moment.created_at, threeDayCutoffTime)) { // all the events of an issue within last three days will return true
-			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.assignee) { // checks if cross referenced within last three days 
+			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.actor.login) { // checks if cross referenced within last three days 
 				return {result: false, labels: statusUpdatedLabel}
 			}
 			else if (moment.event == 'commented' && isCommentByAssignees(moment, assignees)) { // checks if commented within last three days 
@@ -160,7 +160,7 @@ async function isTimelineOutdated(timeline, issueNum, assignees) {
 			}
 		}
 		else if (isMomentRecent(moment.created_at, sevenDayCutoffTime)) { // all the events of an issue between three and seven days will return true
-			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.assignee) { // checks if cross referenced between 3 and 7 days
+			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.actor.login) { // checks if cross referenced between 3 and 7 days
 				console.log('between 3 and 7 cross referenced');
 				return {result: false, labels: statusUpdatedLabel}
 			}
@@ -180,7 +180,7 @@ async function isTimelineOutdated(timeline, issueNum, assignees) {
 			}
 		}
 		else if (isMomentRecent(moment.created_at, fourteenDayCutoffTime)) { // all the events of an issue between seven and fourteen days will return true
-			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.assignee) { // checks if cross referenced between 7 and 14 days
+			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.actor.login) { // checks if cross referenced between 7 and 14 days
 				console.log('between 7 and 14 cross referenced');
 				return {result: false, labels: statusUpdatedLabel}
 			}
@@ -200,7 +200,7 @@ async function isTimelineOutdated(timeline, issueNum, assignees) {
 			}
 		}
 		else    { // all the events of an issue older than fourteen days will be processed here
-			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.assignee) { // checks if cross referenced older than fourteen days
+			if (moment.event == 'cross-referenced' && isLinkedIssue(moment, issueNum) && assignees == moment.actor.login) { // checks if cross referenced older than fourteen days
 				console.log('14 day event cross referenced');
 				return {result: false, labels: statusUpdatedLabel}
 			}


### PR DESCRIPTION
Fixes #2634 

### What changes did you make and why did you make them ?

  - added condition that linked PR must be from the current assignee of issue
  - added condition that checks if issue was recently assigned
  - added condition that checks for comments between 7-14 days 

Local testing (after pulling branch):
1. Install [nektos/act](https://github.com/nektos/act)
2. Download this [testing file](https://drive.google.com/file/d/1f58MJ0fE5-mDjSjPUyuef5x6fDtBhumd/view?usp=share_link)
3. Drop add-label-testing-pr-review.js into your local website folder (.github-actions/add-update-label-weekly)
4. This should be the same folder as add-label.js
5. In .github/workflows/add-update-label-weekly.yml, change path in line 18 from './github-actions/add-update-label-weekly/add-label.js' to './github-actions/add-update-label-weekly/add-label-testing-pr-review.js'
6. Run the command `act -s GITHUB_TOKEN=[your github token] -j Add-Update-Label-to-Issues-Weekly`
7. You can change the issue to test on line 40 of add-label-testing-pr-review.js

Creating a github token to run the workflow:
1. Go to your profile setting
2. Scroll down and click Developer settings on the left
3. Create a classic Personal access token
4. Check read:org and read:project
5. Copy token and insert into the command above

The testing file and the changes made by this PR should be the same, in terms of the logic in the function isTimelineOutdated()

The cases that this PR should fix is:
- detecting prior PR from a different user
- triggering early from a new assignee picking up an issue that has old activity
- not detecting comments from 7-14 days ago
