### PR TITLE
Updated the alt text for the Public Tree Map image

### DIFF
--- a/_projects/public-tree-map.md
+++ b/_projects/public-tree-map.md
@@ -3,7 +3,7 @@ identification: '128148093'
 title: Public Tree Map
 description: Public Tree Map helps connect people to Santa Monica's urban forest. The map includes information about each of the 35,000 trees (and vacant tree sites) in Santa Monica's publicly-owned urban forest (compiled from open datasets, digitized city records, and federal ecosystem services values), as well as tools for users to share favorite trees. To reflect tree plantings and removals, the map updates every day.
 image: /assets/images/projects/public-tree-map.png
-alt: 'Zoomed-in map showing ten streets of the neighborhood. Each dot on the map displaying a tree from the urban forest'
+alt: 'Public Tree Map'
 image-hero: /assets/images/projects/public-tree-map-hero.jpeg
 leadership: 
   - name: Emily F.


### PR DESCRIPTION
Fixes #4044

### What changes did you make and why did you make them ?

  - Updated alt value to `Public Tree Map`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Changed the the alt value for the `Public Tree Map` image. No visual changes to the website.
