### PR TITLE
Updated Criminal Sentencing Title

### DIFF
--- a/_projects/criminal-sentencing.md
+++ b/_projects/criminal-sentencing.md
@@ -1,13 +1,13 @@
 ---
 identification: '157484926'
-title: Los Angeles Criminal Sentencing Project
+title: LA Criminal Sentencing
 description: Our project's goal is to make all criminal sentences administered in LA county into an open dataset. There is a lot of data about when and where crimes are committed - but none about what sentences are passed down in LA County.
 image: /assets/images/projects/criminal-sentencing.jpg
 alt: 'Los Angeles Criminal Sentencing Project'
-links: 
+links:
   - name: GitHub
-    url: "https://github.com/timdef/criminal-sentencing" 
-location: 
+    url: "https://github.com/timdef/criminal-sentencing"
+location:
   # - Downtown LA
   - Remote
 program-area:


### PR DESCRIPTION
Fixes #4081 

### What changes did you make and why did you make them ?

  - changed title in `criminal-sentencing.md` from 'Los Angeles Criminal Sentencing Project' to 'LA Criminal Sentencing' so that name fits in mini-card on the program areas page. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="758" alt="Screen Shot 2023-03-02 at 6 33 59 PM" src="https://user-images.githubusercontent.com/75231870/222617237-fdee9646-0cc0-466a-958b-e4daea0c6f56.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="824" alt="Screen Shot 2023-03-02 at 6 26 46 PM" src="https://user-images.githubusercontent.com/75231870/222617274-b90564c6-74ab-49c5-a912-5ef12f478314.png">
 
</details>
