### PR TITLE
Update alt text for Railstats LA image

### DIFF
--- a/_projects/metro-ontime.md
+++ b/_projects/metro-ontime.md
@@ -3,7 +3,7 @@ identification: '155295655'
 title: Railstats LA
 description: Railstats LA tracks LA Metro trains and generates punctuality reports. Our website enables both Metro officials and the public to easily review up-to-date statistics for LA's 6 train lines.
 image: /assets/images/projects/metro-ontime.png
-alt: 'LA Metro Rail logo'
+alt: 'Railstats LA'
 image-hero: /assets/images/projects/metro-ontime-hero.png
 leadership:
   - name: Cameron Sexton


### PR DESCRIPTION
Fixes #4045

### What changes did you make and why did you make them ?

  - Updated alt text for Railstats LA image to adhere to WCAG.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="999" alt="Screenshot 2023-03-02 at 8 38 38 PM" src="https://user-images.githubusercontent.com/97621864/222641213-515650b7-11d7-4d3a-a4ba-8473cf2bb1b8.png">
</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="933" alt="Screenshot 2023-03-02 at 8 46 08 PM" src="https://user-images.githubusercontent.com/97621864/222641250-0bf4da91-47cf-4aa3-af20-6752a0d7f6ef.png">
</details>
