### PR TITLE
fixed alt text for image

### DIFF
--- a/_projects/undebate.md
+++ b/_projects/undebate.md
@@ -3,7 +3,7 @@ identification: "221070186"
 title: Undebate
 description: For down ballot offices like school-board, voters often don’t know the candidates, so they skip it. With declining media attention, candidates for these offices have a hard time being heard by voters. But electing good people is important!<br /><br /> Undebates are automated online video Q&A so candidates can be heard, and voters can quickly decide - for every candidate, for every election, across the US.
 image: /assets/images/projects/undebate.jpg
-alt: 'Undebate with moderator and 4 participants, displayed question as "Why are you running for office?".'
+alt: 'Undebate'
 image-hero: /assets/images/projects/undebate-hero.jpg
 leadership:
   - name: David Fridley
@@ -37,6 +37,6 @@ location:
 partner: EnCiv.org, Ballotpedia.org
 visible: true
 status: Completed
-program-area: 
+program-area:
   - Vote / Representation
 ---


### PR DESCRIPTION
Fixes #4040

### What changes did you make and why did you make them ?

  -  updated alt text to 'Undebate'
  - 
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
