### PR TITLE
Changed alt value for HFLA website image

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -3,7 +3,7 @@ identification: '130000551'
 title: Hackforla.org Website
 description: The hackforla.org website is our organization's way of communicating with volunteers, stakeholders, and donors. This project is a good place to start for new volunteers looking to polish their git protocol skills (branches, separation of concerns, etc.). We currently have two development paths&#58; growth (building out new pages and guides) and optimization (taking inventory of our code and design systems) to ensure we are consistently delivering value to our users while being scalable in our approach to building the site.
 image: /assets/images/projects/website.png
-alt: 'Wireframe sample from new website.'
+alt: 'Hackforla.org Website'
 image-hero: /assets/images/projects/website-hero.jpg
 leadership:
   - name: Bonnie Wolfe


### PR DESCRIPTION
Fixes #4036 

### What changes did you make and why did you make them ?

- Changed the alt value within `_projects/website.md` from `alt: 'Wireframe sample from new website.'` to `alt: 'Hackforla.org Website'` 
- Update adheres to the Web Content Accessibility Guidelines (WCAG) and furthers HFLA's mission of inclusivity 
- Issue is part of epic https://github.com/hackforla/website/issues/3866

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes to the website.
