### PR TITLE
Fix position of first paragraph on Getting Started

### DIFF
--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -7,6 +7,8 @@
   font-weight: 700;
   padding-top: 20px;
   font-family: "Roboto"sans-serif;
+  max-width: 580px;
+  margin: 0 auto;
 
   @media #{$bp-below-tablet} {
     font-size: 18px;

--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -8,13 +8,14 @@
   padding-top: 20px;
   font-family: "Roboto"sans-serif;
   max-width: 580px;
-  margin: 0 auto;
+  margin: 0 auto 23px;
 
   @media #{$bp-below-tablet} {
     font-size: 18px;
     text-align: left;
   }
 }
+
 .header-p {
   display: flex;
   max-width: 580px;

--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -8,11 +8,12 @@
   padding-top: 20px;
   font-family: "Roboto"sans-serif;
   max-width: 580px;
-  margin: 0 auto 23px;
+  margin: 0 auto 16px;
 
   @media #{$bp-below-tablet} {
     font-size: 18px;
     text-align: left;
+    margin-bottom: 23px;
   }
 }
 


### PR DESCRIPTION
Fixes #3973

### What changes did you make and why did you make them ?

  - Repositioned the first paragraph on the Getting Started paged so that it is visually consistent with the other paragraphs on the page.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![ezgif com-video-to-gif (7)](https://user-images.githubusercontent.com/95109313/222878480-48a48264-78d5-4252-9dd5-43bce6b7eecb.gif)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![ezgif com-video-to-gif (8)](https://user-images.githubusercontent.com/95109313/222878613-ff545b60-0f90-48f4-824b-e0d269dcab80.gif)

</details>
