### PR TITLE
Updated alt text for LA TDM calculator image to adhere to WCAG

### DIFF
--- a/_projects/tdm-calculator.md
+++ b/_projects/tdm-calculator.md
@@ -3,7 +3,7 @@ identification: '197452459'
 title: LA TDM Calculator
 description: The LA TDM Calculator is a web app, created in conjunction with the L.A. Department of Transportation (LADOT) and Los Angeles City Planning, to help real estate developers design better projects for Los Angeles. The Calculator is being implemented alongside a new ordinance reducing over-parking and improving the infrastructure to incentivize public transportation and discourage single occupancy vehicle trips.
 image: /assets/images/projects/tdm-calculator.jpg
-alt: 'LA TDM Calculator Landing Page (Mock Up)'
+alt: 'LA TDM Calculator'
 image-hero: /assets/images/projects/TDM-calculator-hero.png
 leadership:
   - name: Bonnie Wolfe


### PR DESCRIPTION
Fixes #4041 

### What changes did you make, and why did you make them?

  -Changed the image alt property value within _projects/tdm-calculator.md to adhere to WCAG
 **From:**
```
alt: 'LA TDM Calculator Landing Page (Mock Up)'
```
**To:**
```
alt: 'LA TDM Calculator'
```

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

- no visual changes
