### PR TITLE
Update the value of title and description in not-today.md

### DIFF
--- a/_projects/not-today.md
+++ b/_projects/not-today.md
@@ -1,7 +1,7 @@
 ---
 identification: '202051333'
-title: Not Today - Self-Defense Against Suicidal Thoughts
-description:  Not Today is an app intended to help people wait out periods of suicidal thinking without acting on their thoughts.
+title: Not Today
+description: Not Today - the self-defense against suicidal thoughts app is intended to help people wait out periods of suicidal thinking without acting on their thoughts.
 image: /assets/images/projects/not-today.png
 alt: 'Not Today logo. A person embrace another person with full support. Art by C.W. Moss'
 image-hero: /assets/images/projects/not-today-hero.png


### PR DESCRIPTION
Fixes #4082

### What changes did you make and why did you make them ?

  - Changed the value of title to `Not Today`. Reason for change is to make sure that the title fits on `Not Today` mini-card located on the [program areas page](https://www.hackforla.org/program-areas). Before the change, the title runs off the mini-card (see visual changes below).
  - Changed the value of description to `Not Today - the self-defense against suicidal thoughts app is intended to help people wait out periods of suicidal thinking without acting on their thoughts.` Reason for change is to describe the project in a more inviting way.
  - Confirmed in local environment that the title does not run off the mini-card.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="95" alt="mini-card-before" src="https://user-images.githubusercontent.com/73557586/223284860-02fe5e54-bb77-431b-92ef-b80a45268634.png">

<img width="919" alt="description-before" src="https://user-images.githubusercontent.com/73557586/223284886-0fce7c92-4d6a-41b2-8675-c519e8cc8223.png">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="95" alt="mini-card-after" src="https://user-images.githubusercontent.com/73557586/223284899-a2169ca7-31fe-4e04-9622-5c1a9309aff8.png">

<img width="919" alt="description-after" src="https://user-images.githubusercontent.com/73557586/223284919-428b06bb-9845-4deb-905c-4bcaf763c983.png">


</details>
