### PR TITLE
Adjust mobile alignment 4084

### DIFF
--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -89,6 +89,7 @@
 .step-img-intro {
   max-height: 100px;
   text-align: center;
+  margin-top: auto;
 }
 
 .rsvp-button {
@@ -305,7 +306,10 @@
 .step-links {
   padding: 33px;
   margin: 0px auto;
+  display: flex;
+  flex-direction: column;
 }
+
 
 .step-link-img {
   display: flex;

--- a/_sass/components/_getting-started-page.scss
+++ b/_sass/components/_getting-started-page.scss
@@ -310,7 +310,6 @@
   flex-direction: column;
 }
 
-
 .step-link-img {
   display: flex;
   justify-content: space-evenly;


### PR DESCRIPTION
Fixes #4084

### What changes did you make and why did you make them ?

  - Aligns images to bottom of parent container for consistency


### Screenshots of Proposed Changes Of The Website
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="888" alt="image" src="https://user-images.githubusercontent.com/93944737/223319932-3131f48b-c3e4-4c36-9e0e-862d43f0091c.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="879" alt="image" src="https://user-images.githubusercontent.com/93944737/223320086-e81ebad6-5a70-4929-a9a1-3e03004b39cb.png">

</details>
