### PR TITLE
Update Org Images To Render Dynamically

### DIFF
--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -46,14 +46,20 @@ permalink: /citizen-engagement
                         A big thank you to:</p>
                 </div>
                 <div class="organizations-images">
-                    <img class="org-img org-img-large" src="/assets/images/sponsors/code-for-america.svg" alt="Code for America"/>
+                    {% assign partners = site.data.internal.partners %}
+                    {% for partner in partners %}
+                      {% if partner.program-area contains "Citizen Engagement" %}
+                        <img class="org-img org-img-large" src="{{ partner.image }}" alt="{{ partner.name }}"/>
+                      {% endif %}
+                    {% endfor %}
+                    <!-- <img class="org-img org-img-large" src="/assets/images/sponsors/code-for-america.svg" alt="Code for America"/>
                     <img class="org-img" src="/assets/images/citizen-engagement/la_neighborhood_councils.svg" alt="Los Angeles Department of Neighborhood Empowerment">
                     <img class="org-img" src="/assets/images/citizen-engagement/palms_neighborhood_council.svg" alt="Palms Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/echo_park_neighborhood_council.svg" alt="Echo Park Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/la_county_open_data.svg" alt="County of Los Angeles Open Data">
                     <img class="org-img" src="/assets/images/citizen-engagement/voices_neighborhood_council.svg" alt="Voices Neighborhood Council">
                     <img class="org-img" src="/assets/images/citizen-engagement/mid_city_neighborhood_council.svg" alt="Mid-City Neighborhood Council">
-                    <img class="org-img" src="/assets/images/citizen-engagement/mar_vista_community_council.svg" alt="Marvista Community Council">
+                    <img class="org-img" src="/assets/images/citizen-engagement/mar_vista_community_council.svg" alt="Marvista Community Council"> -->
                 </div>
         </div>
     </div>

--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -52,14 +52,6 @@ permalink: /citizen-engagement
                         <img class="org-img org-img-large" src="{{ partner.image }}" alt="{{ partner.name }}"/>
                       {% endif %}
                     {% endfor %}
-                    <!-- <img class="org-img org-img-large" src="/assets/images/sponsors/code-for-america.svg" alt="Code for America"/>
-                    <img class="org-img" src="/assets/images/citizen-engagement/la_neighborhood_councils.svg" alt="Los Angeles Department of Neighborhood Empowerment">
-                    <img class="org-img" src="/assets/images/citizen-engagement/palms_neighborhood_council.svg" alt="Palms Neighborhood Council">
-                    <img class="org-img" src="/assets/images/citizen-engagement/echo_park_neighborhood_council.svg" alt="Echo Park Neighborhood Council">
-                    <img class="org-img" src="/assets/images/citizen-engagement/la_county_open_data.svg" alt="County of Los Angeles Open Data">
-                    <img class="org-img" src="/assets/images/citizen-engagement/voices_neighborhood_council.svg" alt="Voices Neighborhood Council">
-                    <img class="org-img" src="/assets/images/citizen-engagement/mid_city_neighborhood_council.svg" alt="Mid-City Neighborhood Council">
-                    <img class="org-img" src="/assets/images/citizen-engagement/mar_vista_community_council.svg" alt="Marvista Community Council"> -->
                 </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes #2475 

### What changes did you make and why did you make them ?

  - On citizen-engagement page under "Organizations We Work With" section, replaced the hard-coded image elements with a liquid loop so that the images render dynamically based on the data file partner.yml, specifically for organizations that contain "Citizen Engagement" in their program-area property
  - Images count decreased after change, this is due to the partner.yml data file will be updated later after this issue is completed. Confirmed with Justin and Bonnie.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2023-03-01 at 12 46 01 AM](https://user-images.githubusercontent.com/69279538/223900580-1dd00682-7b0a-4d35-9cb2-f9e6e3614793.png)



</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2023-03-01 at 1 22 24 AM](https://user-images.githubusercontent.com/69279538/223900466-d5994629-a908-44a5-a8fc-6c2630e1ae75.png)

</details>
