### PR TITLE
Changed Write For All image alt text in Projects page

### DIFF
--- a/_projects/writeforall.md
+++ b/_projects/writeforall.md
@@ -5,7 +5,7 @@ description: We want to improve the language used in websites to be
   more inclusive (of all communities) while also educating the public
   about exclusionary language. @writeforallorg&#8482;
 image: /assets/images/projects/writeforall.png
-alt: 'A rainbow document searcher icon, the words &quot;Write for All TM&quot;, and a rainbow-like border.'
+alt: 'Write for All'
 image-hero: /assets/images/projects/writeforall-hero.png
 leadership:
   - name: Joel Parker Henderson


### PR DESCRIPTION
Fixes #4026 

### What changes did you make and why did you make them ?

  - Updated image alt text to "Write For All" to provide clear and descriptive alt text for the Write for All image to adhere to the Web Content Accessibility Guidelines (WCAG)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

Only alt text updated. No visual changes to the website.