### PR TITLE
updated-alt-text-two

### DIFF
--- a/_projects/spare.md
+++ b/_projects/spare.md
@@ -3,7 +3,7 @@ identification: '127079094'
 title: Spare
 description: A fun new project project that connects people in need of clothing and other essentials with people in the community who have things to spare. It's kind of like one on one Goodwill. The main objective is to foster interactions between the housed and unhoused. The donation is the mechanism for building these connections throughout our community.
 image: /assets/images/projects/spare.png
-alt: 'Spare logo. Different article of clothing icons surrounds "What can you spare?"'
+alt: 'Spare'
 image-hero: /assets/images/projects/spare-hero.png
 links:
   - name: GitHub


### PR DESCRIPTION
Fixes #4042


### What changes did you make and why did you make them ?

-I had to update the branch to make a new pull request and replace the number #4137 

  -as part of the Web Content Accessibility Guidelines (WCAG i made  these changes Change the alt value within _projects/spare.md:
From:

alt: 'Spare logo. Different article of clothing icons surrounds "What can you spare?"'

To:

alt: 'Spare'


 

 

 
