### PR TITLE
Replaced HTML: Removed Slack self-invite link to redirect to Getting Started page - #4132

### DIFF
--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -16,7 +16,7 @@ permalink: /communities-of-practice
         </p>
             <div class="header-self-invite--communities">
                 <img class="self-invite-img" src="/assets/images/communities-of-practice/slack-self-invite.svg" alt="slack icon" />
-                <p class="alert--communities">To join the Slack channels below, you first need to be a member of our Hack for LA Slack Community – you can self-invite <a href="https://hackforla-slack.herokuapp.com" target="_blank">here</a>.
+                <p class="alert--communities">To join the Slack channels below, you first need to be a member of our Hack for LA Slack Community. If you have not joined yet, please follow the steps in <a href="/getting-started" target="_blank">Getting Started</a>.
             </p></div>
     </div>
     <img class="header-hero-image" src="/assets/images/communities-of-practice/comm-prac-header.svg" alt="commmunity of practice header" />


### PR DESCRIPTION
Fixes #4132 

### What changes did you make and why did you make them ?

  - Removed old paragraph with Slack self-invite link
  - Added in paragraph that redirects to Getting Started page
  - Why: Slack self-invite link no longer active

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Before](https://user-images.githubusercontent.com/76601090/224447425-4bb77d99-5b2b-428b-a2ed-c0e7417fe799.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![After](https://user-images.githubusercontent.com/76601090/224447382-16536443-dd55-48ea-ba34-aeaf2a3d75ac.png)

</details>
