### PR TITLE
changed link value

### DIFF
--- a/_data/navigation/social.yml
+++ b/_data/navigation/social.yml
@@ -11,7 +11,7 @@
   footer: true
 
 - name: Slack
-  link: https://hackforla-slack.herokuapp.com/
+  link: https://hackforla.slack.com
   icon: /svg/icon-slack.svg
   header: false
   footer: true


### PR DESCRIPTION
Fixes #4141

### What changes did you make and why did you make them ?
We changed the self-invite link previously hosted by Heroku to the Hack for LA Slack channel. We made the change because the Heroku link is no longer active.
