### PR TITLE
Update Img Alt Text In Jobs-For-Hope.md

### DIFF
--- a/_projects/jobs-for-hope.md
+++ b/_projects/jobs-for-hope.md
@@ -3,7 +3,7 @@ identification: '140512203'
 title: Jobs for Hope
 description: We compiled job listings from 60+ different non-profit organization websites for the LA County Homeless Initiative and consolidated them into a single database so that it is easier for job-seekers to search and filter for jobs.
 image: /assets/images/projects/jobs-for-hope.png
-alt: 'LA county homelessness initiative logo.'
+alt: 'Jobs for Hope'
 image-hero: /assets/images/projects/jobs-for-hope-hero.png
 links:
   - name: GitHub


### PR DESCRIPTION
Fixes #4013 

### What changes did you make and why did you make them?

  - Changed img alt from 'LA county homelessness initiative logo.' to 'Jobs for Hope'
  - Changed img alt text to adhere to the Web Content Accessibility Guidelines (WCAG)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screenshot code changes)

Only alt text is changed. No visual changes to the website.


