### PR TITLE
Update Alt Text for Work for LA Project Image

### DIFF
--- a/_projects/work-for-la.md
+++ b/_projects/work-for-la.md
@@ -3,7 +3,7 @@ identification: '79977929'
 title: Work for LA
 description: Applying for work should be simple—but the application process for the City of LA is confusing and cumbersome. We’re going to make it easier to find the job of your dreams.
 image: /assets/images/projects/work-for-la.jpg
-alt: 'Los Angeles City Hall building'
+alt: 'Work for LA'
 leadership:
   - name: Hunter Owens
     role: Data Scientist


### PR DESCRIPTION
Fixes #4031

### What changes did you make and why did you make them ?

  - Changed the alt value within `_projects/work-for-la.md` to provide clearer, more descriptive alt text in order to adhere to the Web Content Accessibility Guidelines (WCAG).

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

Updated image alt text. No visual changes to the website.
