### PR TITLE
Updated the Getting Started Page, removing the Self-invite to Hack For LA Slack step.

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -57,12 +57,6 @@ permalink: /getting-started
                 <ol class="column-ol-list">
                     <p class="strong-text"><strong>Before the Meeting:</strong></p>
                     <div class="list-container">
-                        <img class="step-img-icon-attend-slack" src="assets/images/getting-started/proj-4.png" alt="" />
-                        <li class="g-s-list">Self-invite to the <a href="https://hackforla-slack.herokuapp.com/" target="_blank">Hack for LA Slack</a>.
-                        </li>
-                    </div>
-                </br>
-                    <div class="list-container">
                         <img class="step-img-icon-attend-git" src="assets/images/getting-started/join-2.png" alt="" />
                         <li class="g-s-list">Read the <a href="https://github.com/hackforla/codeofconduct" target="_blank">Hack for LA Code of Conduct</a>.
                         </li>


### PR DESCRIPTION
Fixes #4083

### What changes did you make and why did you make them ?

  - Removed the `Self-invite to Hack For LA Slack.` step. Reason for removing this step is due to the Heroku App that the `Hack For LA Slack` link lead to is no longer functioning: leading user's to a dead-linked page.
  - `Read the Hack for LA Code of Conduct.` is now step 1 under `Before the Meeting:`. Reason for moving this from step 2 to step 1 is due to removing the original step 1.
  - `Complete our Onboarding Survey.` is now step 2 under `After the Meeting:`. Reason for moving this from step 3 to step 2 is due to the original step 2 moving to step 1.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="919" alt="getting-started-before" src="https://user-images.githubusercontent.com/73557586/225153277-f8a3b5d2-cb25-4c25-ba65-b647e74cf1fb.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>

<img width="919" alt="getting-started-after" src="https://user-images.githubusercontent.com/73557586/225153345-7cea7264-6fb2-4d3f-bcbd-bee90fb5274a.png">

</details>
