### PR TITLE
Update Slack link on join us page

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -39,7 +39,7 @@ permalink: /join
         </p>
         <p class='join-us-remove-p-padding'>How to get involved:</p>
         <ol>
-          <li>Join our <a href="https://hackforla-slack.herokuapp.com/" target="_blank">Slack</a></li>
+          <li>Follow the steps on our <a href="/getting-started" target="_blank">Getting Started</a> page</li>
           <li>
             Connect with our leadership team on the <strong>#admin</strong> <a href="https://hackforla.slack.com/messages/admin"
               target="_blank">channel</a>


### PR DESCRIPTION
Fixes #4145

### What changes did you make and why did you make them ?

  - Updated Slack link on Join Us page to redirect to Getting Started page instead.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>

<summary>Visuals before changes are applied</summary>

![Before](https://user-images.githubusercontent.com/43795498/225979087-91f3c5ac-313d-4872-994e-39c2cc2197a9.png)

</details>

<details>

<summary>Visuals after changes are applied</summary>
  
![After](https://user-images.githubusercontent.com/43795498/225979238-c78f6864-40a5-4a66-a1cf-f5206dc3bd8f.png)

</details>

