### PR TITLE
changed alt image tag to simply 'Civic tech Index' found on the _projects page #3948

### DIFF
--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -4,7 +4,7 @@ identification: '241519642'
 title: Civic Tech Index
 description: Our goal of the project is to create a comprehensive, searchable index of all civic tech open source software projects around the world. We have created the framework and an interest list. We are currently working on building out the website and other marketing tools that demonstrate the power of the index.
 image: /assets/images/projects/civic-tech-index.png
-alt: 'Civic Tech Index logo. A magnifying glass over the outline of the world map on the left "Civic Tech Index" on the right.'
+alt: "Civic Tech Index"
 image-hero: /assets/images/projects/civic-tech-index-hero.png
 leadership:
   - name: Bonnie Wolfe


### PR DESCRIPTION
Fixes #3948

### What changes did you make and why did you make them ?

  -The alt image description was "Civic Tech Index logo. A magnifying glass over the outline of the world map on the left "Civic Tech Index" on the right.".
  -The issue #3948 requested the alt image description only say "Civic Tech Index".
  -I also verified the change was made on my docker preview.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual details to the website only alt image tag

<summary>Visuals after changes are applied</summary>
  
![Screenshot 2023-03-17 140751](https://user-images.githubusercontent.com/100797135/226050031-49181d05-445f-4eea-aa20-767c9a655d12.png)

No visual details to the website, but here is the inspect tool showing "Civic Tech Index" as the new alt image tag.
