### PR TITLE
Update Ops CoP Leadership Information

### DIFF
--- a/_data/internal/communities/ops.yml
+++ b/_data/internal/communities/ops.yml
@@ -19,12 +19,12 @@ leadership:
       slack: https://hackforla.slack.com/team/U02CA3CAK7Z
       github: https://github.com/JasonEb
     picture: https://avatars.githubusercontent.com/u/6300995
-  - name: Nicole Dubin
+  - name: Dean Church
     role: Co-lead
     links:
-      slack: https://hackforla.slack.com/team/U02LL2XK486
-      github: https://github.com/Neecolaa
-    picture: https://avatars.githubusercontent.com/u/7437035
+      slack: https://hackforla.slack.com/team/UJR0UKBN1
+      github: https://github.com/Rankazze
+    picture: https://avatars.githubusercontent.com/Rankazze
 
 links:
   - name: Slack


### PR DESCRIPTION
Fixes #4085
### What changes did you make and why did you make them ?

  - Removed Nicole Dublin from the Ops CoP leadership section and added Dean Church to keep the leadership information up to date.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Ops CoP Section BEFORE](https://user-images.githubusercontent.com/9600508/226073001-7189e82d-9ea5-44a7-9497-86ec7436345c.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Ops CoP Section AFTER](https://user-images.githubusercontent.com/9600508/226073020-44dac77c-9858-4409-a8e4-c6c768ec7ee1.png)

</details>
