### PR TITLE
Renamed citizen engagement file

### DIFF
--- a/_includes/program-area-pages-cards.html
+++ b/_includes/program-area-pages-cards.html
@@ -1,3 +1,5 @@
+<!-- These are the cards found on a program area page, such as the cards on https://www.hackforla.org/citizen-engagement webpage. -->
+
 {% assign visible_projects = site.projects | where: "program-area", "Citizen Engagement" | where: "visible", "true" %}
              {% for item in visible_projects %}
              {%- if 

--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -36,7 +36,7 @@ permalink: /citizen-engagement
         <!-- Specifically I have added data attributes to the page-card container, and the dropdown arrow.
              We use the data attributes in JS to expand and close the cards. -->
 
-            {% include citizen-engagement-cards.html %}
+            {% include program-area-pages-cards.html %}
 
             <div class="page-card card-primary page-card-lg organizations">
                 <div class="organizations-info">


### PR DESCRIPTION
Fixes #3756 

### What changes did you make and why did you make them ?

  - In the folder `_includes`, renamed the `citizen-engagement-cards.html` to `program-area-pages-cards.html` so that the name of the file reflects the purpose of the card better.
  - Inside `_includes/program-area-pages-cards.html`, a new comment has been added to clarify what the elements in that file are:
  ```
  <!-- These are the cards found on a program area page, such as the cards on https://www.hackforla.org/citizen-engagement webpage. -->
  ```
  -  Inside `pages/citizen-engagement.html`, this line
```
{% include citizen-engagement-cards.html %}
```
is changed to
```
{% include program-area-pages-cards.html %}
```

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Only the file name and the markup were changed. No visual changes to the website. Looks good on desktop, tablet and mobile, and functions like before.