### PR TITLE
Changed img alt text - issue 3951

### DIFF
--- a/_projects/civic-tech-structure.md
+++ b/_projects/civic-tech-structure.md
@@ -7,7 +7,7 @@ description: "The Civic Tech Structure project seeks to improve existing structu
 Our Civic Tech Structure project is responsible for publishing all of our guides and other reference materials that we hope will help other people and organizations to stand on the shoulders of those who contributed before them."
 
 image: /assets/images/projects/civic-tech-structure.png
-alt: "A network of lines and nodes, and the lines converge to a large dot in the center."
+alt: "Civic Tech Structure"
 image-hero: /assets/images/projects/civic-tech-structure-hero.png
 leadership:
   - name: Bonnie Wolfe


### PR DESCRIPTION
Fixes #3951 

### What changes did you make and why did you make them?

  - Changed/updated img alt text
  - Updated to adhere to Web Content Accessibility Guidelines (WCAG)
  - WCAG: Provide clear and descriptive alt text

 
**Before:**
```
alt:  "A network of lines and nodes, and the lines converge to a large dot in the center."
```  
**After:**
```
alt:  "Civic Tech Structure"
```

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Updating img alt text. No visual changes to the website.
