### PR TITLE
Update citizen engagement card data comment

### DIFF
--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -68,7 +68,7 @@ program-area:
   - Citizen Engagement
 visible: true
 status: Active
-# citizen engagement card data
+# program area card data
 problem: The city produces a data set from all the 311 tickets placed. This data is useful if you are a data scientist, but for citizens without this training it has little value.
 solution: We partnered with the Los Angeles Department of Neighborhood Empowerment and LA Neighborhood Councils to co-create and iterate analysis and tools (see 311-Data.org) to provide neighborhoods with actionable information at the local level through real time visualizations and comparison tools.
 impact: Neighborhood Councils are able to use visualizations to demonstrate and discuss the city service levels with constituents and determine where to send mailings to target information to those parts of their community not availing themselves of specific city services.

--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -94,7 +94,7 @@ visible: true
 # project-homepage: false
 # For completed projects. Uncomment and add contact info if provided
 # completed-contact:
-# citizen engagement card data
+# program area card data
 problem: Policies that impact the public are increasingly advised by surveys and other means of data collection. To ensure that citizens are empowered advocates of their community, we are looking to identify the areas where data literacy education within our communities is needed most.
 solution: Hack for LA’s Access the Data team, in partnership with the Los Angeles Department of Neighborhood Empowerment, Neighborhood Councils, and the Los Angeles Mayor’s office, will be developing modules to address those areas.
 impact: Citizens will be empowered to advocate for change in their communities by using publicly available data and asking for data to be made available when it is required for advocacy.

--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -61,7 +61,7 @@ program-area:
 partner: Various Los Angeles Neighborhood Councils
 visible: true
 status: On Hold
-# citizen engagement card data
+# program area card data
 problem: Everyone should be able to have a voice in their community’s issues, but not everyone has access or is easily able to follow an issue’s details. For example, not everyone has time to attend a city council meeting!
 solution: On Engage, all users can view, read, and comment on agenda items their city council is currently debating. This makes it much easier to participate in discussions on government policies.
 impact: Our platform will make important local conversations much more representative of the actual community, boosting the representation of the most marginalized and underserved members. Being able to hear their perspective will lead to more inclusive, considerate decision-making that will truly benefit all of us rather than just some.

--- a/_projects/lucky-parking.md
+++ b/_projects/lucky-parking.md
@@ -140,7 +140,7 @@ program-area:
   - Citizen Engagement
 visible: true
 status: Active
-# citizen engagement card data
+# program area card data
 problem: Parking citations are distributed unevenly across different socio-economic strata of the city's residents as they use public parking during the course of business or because enough off-street parking is not provided at their residence. The current publicly available Los Angeles parking citation dataset can be used as a basis for discussions about this disparity, but the unwieldy size and inconsistency of this data has been enough of a barrier to make it inaccessible to non-researchers.
 solution: Hack for LA’s Lucky Parking project seeks to map the 12.5 million parking citations on a web app that is easy to use yet powerful enough to make meaningful insights about parking citations accessible to the public at large.
 impact: Our project seeks to educate and inform city leaders and the community about the effects of Los Angeles’ parking policies, hopefully serving as a tool in discussing more equitable solutions to our transportation problems.

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -67,7 +67,7 @@ visible: true
 program-area:
   - Citizen Engagement
 status: Active
-# citizen engagement card data
+# program area card data
 problem: Most Neighborhood Councils do not have access or resources to hire technical experts necessary to create a citywide survey so that they can use the data to create inclusive websites targeted towards the needs of their specific communities.
 solution: The Open Community Survey project creates transparent reports supported by a direct collection of personal perspectives from LA residents to help The LA Department of Neighborhood Empowerment (empowerla.org) and the Los Angeles Neighborhood Councils to understand how constituents are interacting with, and what they need from, their websites.
 impact: <i>We are currently drafting the Impact statement for this project.</i>


### PR DESCRIPTION
Fixes #3966

### What changes did you make and why did you make them?

  - Changed comment from `# citizen engagement card data` to `# program area card data` in the project Markdown files to better reflect the data's purpose as it will be used in various program area pages
  - Affected files: `311-data.md`, `access-the-data.md`, `engage.md`, `lucky-parking.md`, and `open-community-survey.md`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screenshot code changes)

No visual changes to the website.