### PR TITLE
update alt text for .project-card-mini-image images

### DIFF
--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -44,7 +44,7 @@ permalink: /program-areas
               {% if program_areas[1].program-area == project_program %}
               {% assign project_relative_path = project.slug | prepend: "../projects/" %}
               <li class="project-card-mini inline-list" id="{{project.identification}}">
-                  <img class="project-card-mini-image" src="{{project.image}}" alt="{{project.image_alt}}" />
+                  <img class="project-card-mini-image" src="{{project.image}}" alt="" />
                   <a class="project-card-mini-title" href="{{ project_relative_path }}">{{project.title}}</a>
               </li>
               {% endif %}


### PR DESCRIPTION
Fixes #3876 

### What changes did you make and why did you make them ?

  - Updated the img class="project-card-mini-image" alt text from alt="{{project.image_alt}}"  to alt=""
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link)
 to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![program-areas-b4](https://user-images.githubusercontent.com/97845061/226206635-27c86bf3-168d-44c8-aa3e-0ee0b565b612.JPG)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![program-areas-after](https://user-images.githubusercontent.com/97845061/226206754-6ee6e7ed-4049-48f4-a2ad-6998f015e562.JPG)


</details>
