### PR TITLE
Hide projects that should not be visible in Program Areas page #4220

### DIFF
--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -41,7 +41,7 @@ permalink: /program-areas
           <ul class="project-card-mini-list-alignment">
               {% for project in site.projects %}
               {% for project_program in project.program-area %}
-              {% if program_areas[1].program-area == project_program %}
+              {% if program_areas[1].program-area == project_program and project.visible %}
               {% assign project_relative_path = project.slug | prepend: "../projects/" %}
               <li class="project-card-mini inline-list" id="{{project.identification}}">
                   <img class="project-card-mini-image" src="{{project.image}}" alt="" />


### PR DESCRIPTION
Fixes #4220 

### What changes did you make and why did you make them ?

  - Hid projects that should not be visible in Program Areas page to keep the information up to date
  - Used Liquid to only render projects that have the `visible` attribute set to `true`
  - Projects that have `visible: false` or no `visible` attribute will not render, as per the issue

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Before](https://user-images.githubusercontent.com/43795498/226690155-bd3e3122-0b0d-4c34-b4e7-c9de600a4799.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![After](https://user-images.githubusercontent.com/43795498/226690206-7ca660a3-1447-433e-9b38-f6d790874f32.png)

</details>