### PR TITLE
Updated alt text for join us footer mobile image for WCAG adherence

### DIFF
--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -76,7 +76,7 @@ permalink: /program-areas
         <img
         class="join-us-footer-img mobile-img"
         src="/assets/images/join-us/volunteer-with-us-icon.svg"
-        alt="join us card image"
+        alt=""
       />
       <div class="join-us-footer-paragraphs">
         <p class="first-paragraph">


### PR DESCRIPTION
Fixes #3878 

### What changes did you make and why did you make them ?

  - Updated the alt text of the image in the join us footer (mobile version) on the Program Areas page to make the HfLA site more inclusive and accessible (ie, adhere to Web Content Accessibility Guidelines, or WCAG)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Updating alt text; no visual changes to the website.
