### PR TITLE
Updated leadership role for Matt Pereira

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -31,7 +31,7 @@ leadership:
       github: 'https://github.com/jdingeman'
     picture: https://avatars.githubusercontent.com/jdingeman
   - name: Matt Pereira
-    role: Technical Lead
+    role: Merge Team
     links:
       slack: 'https://hackforla.slack.com/team/U045XKKB5DH'
       github: 'https://github.com/MattPereira'


### PR DESCRIPTION
Fixes #4219 

### What changes did you make and why did you make them ?

  - Updated Matt Pereira's role on the HfLA.org Website's Project Page to reflect his new leadership role
  - Changed his role from "Technical Lead" to "Merge Team" in the leadership variable of the website.md file
  - Ensured changes could be viewed on docker including with the inspection tool and didn't create unexpected problems elsewhere.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<br/>
<em>Find Matt Pereira's card in the middle on left-hand side</em>
<img width="721" alt="4219 Before" src="https://user-images.githubusercontent.com/106135769/226804954-49bb9c1f-f957-4c4b-8d99-9ae2609e2e00.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
<br/>
<em>Find Matt Pereira's card in the middle on left-hand side</em>
<img width="1438" alt="4219 After" src="https://user-images.githubusercontent.com/106135769/226805006-13416d93-617b-4fa2-abd3-297da7cb1356.png">


</details>
