### PR TITLE
Removed team member Jieun Ryu from Food Oasis project page

### DIFF
--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -18,12 +18,6 @@ leadership:
       slack: "https://hackforla.slack.com/team/U01PG6RD0T1"
       github: "https://github.com/fancyham"
     picture: https://avatars.githubusercontent.com/fancyham
-  - name: Jieun Ryu
-    role: UX Researcher
-    links:
-      slack: "https://hackforla.slack.com/team/U02LL2DF4HL"
-      github: "https://github.com/ryu-jieun"
-    picture: https://avatars.githubusercontent.com/ryu-jieun
   - name: Gigi Patel
     role: Lead UX Researcher
     links:


### PR DESCRIPTION
Fixes #4238 

### What changes did you make and why did you make them ?

  - Removed team member Jieun Ryu from the Food Oasis project page in order to reflect up-to-date project details on the Hack for LA website
  - Ensured changes were reflected in docker including views on computers, tablets, and phones

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1434" alt="4238 Before" src="https://user-images.githubusercontent.com/106135769/227397722-acdd77cd-b498-4745-bf7b-5a3e32beabd6.png">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1440" alt="4238 After" src="https://user-images.githubusercontent.com/106135769/227397744-1c3877f5-4a4a-42e6-bf07-65be2e658ce2.png">

</details>
