### PR TITLE
edit content field and remove type field from group.yml credits file

### DIFF
--- a/_data/internal/credits/group.yml
+++ b/_data/internal/credits/group.yml
@@ -1,12 +1,11 @@
 ---
 title: Group
 title-link: https://www.flaticon.com/free-icon/group_909337
-content: icon
+content-type: image
 used-in: Getting Started
 artist: Freepik
 provider: Flaticon
 provider-link: 'https://www.flaticon.com/'
 image-url: /assets/images/getting-started/group.png
 alt: 'Icon of Three People'
-type: icon
 ---


### PR DESCRIPTION
Fixes #2833

I changed line 4 from content: icon to content-type: images and deleted line 11 to remove redundancy.

