### PR TITLE
added image-hero-credit field and create public-tree-map.yml file

### DIFF
--- a/_data/internal/credits/public-tree-map.yml
+++ b/_data/internal/credits/public-tree-map.yml
@@ -1,0 +1,11 @@
+---
+title: Public Tree Map
+title-link: https://www.davebaiocchi.net/santa-monica-urban-forest/r5drejeht8obbydv2c14krzuglraql
+content-type: image
+used-in: Public Tree Map
+artist: Dave Baiocchi
+provider: Dave Baiocchi
+provider-link: 'https://www.davebaiocchi.net/'
+image-url: /assets/images/projects/public-tree-map-hero.jpeg
+alt: 'Public Tree Map Image'
+---

--- a/_projects/public-tree-map.md
+++ b/_projects/public-tree-map.md
@@ -5,6 +5,7 @@ description: Public Tree Map helps connect people to Santa Monica's urban forest
 image: /assets/images/projects/public-tree-map.png
 alt: 'Zoomed-in map showing ten streets of the neighborhood. Each dot on the map displaying a tree from the urban forest'
 image-hero: /assets/images/projects/public-tree-map-hero.jpeg
+image-hero-credit: 'Coral tree from City of Santa Monica. Photo by Dave Baiocchi www.studiobaiocchi.net'
 leadership: 
   - name: Emily F.
     role: Product Owner


### PR DESCRIPTION
Fixes #3922 

### What changes did you make and why did you make them ?
- A new image-hero-credit field was added to the public-tree-map.md file. The field was added in order to give the photographer credit for the image.

- A public-tree-map.yml file was created and added into data/internal/credits. The file adds the image to the credits page which gives credit to the photographer.