### PR TITLE
Update Project Profile Card Review & Update template

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-profile-card-review-and-update.yml
+++ b/.github/ISSUE_TEMPLATE/project-profile-card-review-and-update.yml
@@ -314,7 +314,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        If you need to update your meeting times, names, dates, or frequency, please see the [VRMS User Guide](https://github.com/hackforla/VRMS/wiki/User-Guide).  The HackforLA.org website gets the meeting times from the updates the Project PM makes to the projet's meeting data in vrms.io
+        If you need to update your meeting times, names, dates, or frequency, please see the [VRMS User Guide](https://github.com/hackforla/VRMS/wiki/User-Guide).  The HackforLA.org website gets the meeting times from the updates the Project PM makes to the project's meeting data in vrms.io
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/project-profile-card-review-and-update.yml
+++ b/.github/ISSUE_TEMPLATE/project-profile-card-review-and-update.yml
@@ -307,21 +307,6 @@ body:
         - "On Hold"
     validations:
       required: true
-      
-  - type: dropdown
-    id: update-meeting-times-yes-no
-    attributes: 
-      label: Update your meeting times?
-      options:
-        - "YES"
-        - "NO"
-    validations:
-      required: true
-  - type: input
-    id: update-meeting-times-vrms-issue-link
-    attributes:
-      label: "If YES on update meeting times, open an issue on VRMS to update the meeting times and provide the link to the new issue"
-      placeholder: "VRMS issue link"
 
   - type: markdown
     attributes:
@@ -329,7 +314,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        [VRMS Add/edit team meeting time template issue](https://github.com/hackforla/VRMS/issues/new?assignees=&labels=1+week+change+request&template=add-edit-team-meeting-time.md&title=Meeting+time+change+request+for+%5BProject+Name%5D)
+        If you need to update your meeting times, names, dates, or frequency, please see the [VRMS User Guide](https://github.com/hackforla/VRMS/wiki/User-Guide).  The HackforLA.org website gets the meeting times from the updates the Project PM makes to the projet's meeting data in vrms.io
 
   - type: markdown
     attributes:


### PR DESCRIPTION
Fixes #4268

### What changes did you make and why did you make them ?

Changes made:
  - Replaced the content in the value field on line 332 with "If you need to update your meeting times, names, dates, or frequency, please see the [VRMS User Guide](https://github.com/hackforla/VRMS/wiki/User-Guide).  The HackforLA.org website gets the meeting times from the updates the Project PM makes to the projet's meeting data in vrms.io"
  - Remove lines 311 - 324

Reason:  
  - PMs are now able to directly change the meeting times for their teams in VRMS. We need to change the [Project Profile Card review and update](https://github.com/hackforla/website/blob/gh-pages/.github/ISSUE_TEMPLATE/project-profile-card-review-and-update.yml) template so that PMs are redirected to the [VRMS User Guide](https://docs.google.com/presentation/d/1bv9QH-d5qKtFCaecgCvsv608IoeLIpHfW7cEEqijHyE/preview?slide=id.g20628192ba7_0_93) if they need to change certain things about their meetings.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- Modified codes of HackForLA github Issue Template.  No visual changes to the website.
