### PR TITLE
Make Program Area Consistent on About Us Page

### DIFF
--- a/_includes/about-page/about-card-platform.html
+++ b/_includes/about-page/about-card-platform.html
@@ -32,7 +32,7 @@
                     </p>
                 </div>
                 <div class="platform-sec-diversity">
-                    <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/diversity.svg" alt=""></span><span class="sub-head-text color-chocolate">Diversity, Equity, and Inclusion</div>
+                    <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/diversity.svg" alt=""></span><span class="sub-head-text color-chocolate">Diversity, Equity & Inclusion</div>
                     <p class="sub-card-content border-chocolate">
                         The diverse experiences of all of our members help us create a better civic tech ecosystem, by bringing 
                         their lived experience to our org. Our diversity includes race, sexual orientation, learning modalities, 


### PR DESCRIPTION
Fixes #4286

### What changes did you make and why did you make them ?

  -Changes made: 
  Change the corresponding <span> element on the [about-card-platform.html](https://github.com/hackforla/website/blob/gh-pages/_includes/about-page/about-card-platform.html) file so that Diversity, Equity & Inclusion is displayed.
  -Reason:
  We want our website to use terms consistently when referring to program areas. On the [About Us](https://www.hackforla.org/about/) page, in the 'Hack for LA Platform' section, we need to change the title of the Diversity, Equity, and Inclusion subsection to Diversity, Equity & Inclusion.
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://i.imgur.com/LRr3DD1.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://i.imgur.com/McqtEQn.png)

</details>
