### PR TITLE
Update alt text to adhere to WCAG - Issue 3869

### DIFF
--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -3,7 +3,7 @@ identification: '190321758'
 title: 311 Data
 description: The 311 Data project seeks to empower local Neighborhood Councils to improve the ideation and analysis of their initiatives using the wealth of publicly available 311 data.
 image: /assets/images/projects/311_data.png
-alt: '311 data logo.'
+alt: '311 Data'
 image-hero: /assets/images/projects/311data-beta.png
 leadership:
   - name: Eric Cho


### PR DESCRIPTION
Fixes #3869 

### What changes did you make and why did you make them ?

  - Updated img alt text
  - Updated to adhere to Web Content Accessibility Guidelines (WCAG)
  - WCAG: Provide clear and descriptive alt text

**Before:**
```
alt: '311 data logo.'
```  
**After:**
```
alt: '311 Data'
```

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Updating img alt text. No visual changes to the website.
