### PR TITLE
Move newly created prs 2395

### DIFF
--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -1,9 +1,10 @@
 name: Pull Request Trigger
 on:
   pull_request_target:
-    types: [closed]
+    types: [opened, closed]
     branches:
       - 'gh-pages'
+      - 'move-new-prs-2395'
 
 jobs:
   # Run an echo to confirm that the action was triggered
@@ -12,6 +13,20 @@ jobs:
     steps:
      - run: echo "🍺 This job was automatically triggered by a ${{ github.event_name }} event."
 
+
+  # Move opened PRs onto Project Board
+  PRs-To-Project-Board:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'opened' }}
+    steps:
+      - name: Move Opened PR to Project Board
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Project Board
+          column: 'PR Needs review (Automated Column, do not place items here manually)'
+          repo-token: ${{ secrets.TEST_GHA_TOKEN }}      
+    
+    
   # Gathers merged PRs from every location and moves to column 'test-approved-by-reviewer...'
   Gather-Merged-PRs:
     runs-on: ubuntu-latest
@@ -22,7 +37,7 @@ jobs:
         with:
           project: Project Board
           column: 'test-approved-by-reviewer (Automated Column, do not place items here manually)'
-          repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
+          repo-token: ${{ secrets.TEST_GHA_TOKEN }}
 
   # Deletes merged PRs from column 'test-approved-by-reviewer...' after 'needs: Gather-Merged-PRs'
   Delete-Merged-PRs:
@@ -35,5 +50,5 @@ jobs:
         with:
           project: Project Board
           column: 'test-approved-by-reviewer (Automated Column, do not place items here manually)'            
-          repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
+          repo-token: ${{ secrets.TEST_GHA_TOKEN }}
           action: delete

--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -4,7 +4,6 @@ on:
     types: [opened, closed]
     branches:
       - 'gh-pages'
-      - 'move-new-prs-2395'
 
 jobs:
   # Run an echo to confirm that the action was triggered
@@ -24,7 +23,7 @@ jobs:
         with:
           project: Project Board
           column: 'PR Needs review (Automated Column, do not place items here manually)'
-          repo-token: ${{ secrets.TEST_GHA_TOKEN }}      
+          repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}      
     
     
   # Gathers merged PRs from every location and moves to column 'test-approved-by-reviewer...'
@@ -37,7 +36,7 @@ jobs:
         with:
           project: Project Board
           column: 'test-approved-by-reviewer (Automated Column, do not place items here manually)'
-          repo-token: ${{ secrets.TEST_GHA_TOKEN }}
+          repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
 
 
   # Deletes merged PRs from column 'test-approved-by-reviewer...' after 'needs: Gather-Merged-PRs'
@@ -51,5 +50,5 @@ jobs:
         with:
           project: Project Board
           column: 'test-approved-by-reviewer (Automated Column, do not place items here manually)'            
-          repo-token: ${{ secrets.TEST_GHA_TOKEN }}
+          repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
           action: delete

--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -39,6 +39,7 @@ jobs:
           column: 'test-approved-by-reviewer (Automated Column, do not place items here manually)'
           repo-token: ${{ secrets.TEST_GHA_TOKEN }}
 
+
   # Deletes merged PRs from column 'test-approved-by-reviewer...' after 'needs: Gather-Merged-PRs'
   Delete-Merged-PRs:
     needs: Gather-Merged-PRs

--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -14,7 +14,7 @@ jobs:
      - run: echo "🍺 This job was automatically triggered by a ${{ github.event_name }} event."
 
 
-  # Move opened PRs onto Project Board
+  # Moves newly opened PRs onto Project Board in column 'PR Needs review...'
   PRs-To-Project-Board:
     runs-on: ubuntu-latest
     if: ${{ github.event.action == 'opened' }}

--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -14,7 +14,7 @@ jobs:
 
 
   # Moves newly opened PRs onto Project Board in column 'PR Needs review...'
-  PRs-To-Project-Board:
+  Move-New-PRs-To-Project-Board:
     runs-on: ubuntu-latest
     if: ${{ github.event.action == 'opened' }}
     steps:


### PR DESCRIPTION
Fixes #2395 

### What changes did you make and why did you make them ?

  - Added new job to the `pull-request-trigger.yml` that uses the `alex-page/github-project-automation-plus@v0.8.1` automation. 
  - Automation moves newly opened PR to the Project Board in the 'PR needs review...' column, if the PR creator does not select this themselves.
  - Automation does not interfere with column automation that gathers PRs already on the project board to the same column.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

- No visual changes to the website
