### PR TITLE
Added aria-label attribute and role attribute to divs that wrap inline svg elements

### DIFF
--- a/_includes/resource-card.html
+++ b/_includes/resource-card.html
@@ -5,7 +5,7 @@
 <a href='{{ url }}' target="_blank" class='resource-link'>
     <li class='resource-card'>
         <!--Where the images will be-->
-        <div {% if image %} class='resource-img resource-img-provided' {% else %} class='resource-img' {% endif %}>
+        <div {% if image %} class='resource-img resource-img-provided' {% else %} role="img" aria-label="{{name}}" class='resource-img' {% endif %}>
             {% if name == 'GitHub' or name == 'Slack' %}
                 {% include {{ name | prepend: 'svg/icon-' | append: '-color.svg' | downcase }} %}
             {% elsif name == 'Getting Started' %}


### PR DESCRIPTION
Fixes #4291

### What changes did you make and why did you make them ?

  - For images rendered using `<svg>`, I added an `aria-label` attribute with a value of `{{name}}` to the enclosing `div`. Changes were made due to the inline `svg` elements not having alt text, which didn't comply to accessibility rules. To make the svg WCAG compliant, `aria-label` attributes needed to be added to the enclosing `div`.
 
  - I also added a `role` attribute with value of `img` alongside the `aria-label` attribute. I made this change to due guidance given in the ["How to make SVGs and other images WCAG compliant"](https://github.com/hackforla/website/wiki/How-to-make-SVGs-and-other-images-WCAG-compliant#use-an-aria-label-in-the-div-html-tag-wrapping-the-svg:~:text=Use%20an%20ARIA%20label%20in%20the%20div%20HTML%20tag%20wrapping%20the%20SVG) wiki.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No visual changes to website.
