### PR TITLE
Use image instead of card-image-src

### DIFF
--- a/_includes/program-area-pages-cards.html
+++ b/_includes/program-area-pages-cards.html
@@ -7,11 +7,10 @@
                 item.solution.size > 0 and
                 item.impact.size > 0 and
                 item.sdg.size > 0 and
-                item.card-image-src.size > 0 and
                 item.sdg-image-src.size > 0
                 -%}
                   <div class="page-card card-primary page-card-lg program-area" data-dropdown>
-                        <img class="card-image" src="{{ item.card-image-src }}" alt="{{ item.card-image-alt }}"/>
+                        <img class="card-image" src="{{ item.image }}" alt=""/>
                            <div class="mobile-card-info-container">
                                <div class="mobile-card-nav">
                                 {% assign project_relative_path = item.slug | prepend: "../projects/" %}

--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -73,8 +73,6 @@ problem: The city produces a data set from all the 311 tickets placed. This data
 solution: We partnered with the Los Angeles Department of Neighborhood Empowerment and LA Neighborhood Councils to co-create and iterate analysis and tools (see 311-Data.org) to provide neighborhoods with actionable information at the local level through real time visualizations and comparison tools.
 impact: Neighborhood Councils are able to use visualizations to demonstrate and discuss the city service levels with constituents and determine where to send mailings to target information to those parts of their community not availing themselves of specific city services.
 sdg: '<strong>16.8:</strong> Broaden and strengthen the awareness and participation of City and local communities, especially those traditionally underserved and marginalized, in the institutions of local and global governance.'
-card-image-src: /assets/images/projects/311.jpg
-card-image-alt:
 sdg-image-src: /assets/images/about/sdg-elements/peace-justice.svg
 sdg-image-alt: '16: peace, justice and strong institutions'
 ---

--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -99,8 +99,6 @@ problem: Policies that impact the public are increasingly advised by surveys and
 solution: Hack for LA’s Access the Data team, in partnership with the Los Angeles Department of Neighborhood Empowerment, Neighborhood Councils, and the Los Angeles Mayor’s office, will be developing modules to address those areas.
 impact: Citizens will be empowered to advocate for change in their communities by using publicly available data and asking for data to be made available when it is required for advocacy.
 sdg: '<strong>16.8:</strong> Broaden and strengthen the awareness and participation of City and local communities, especially those traditionally underserved and marginalized, in the institutions of local and global governance.'
-card-image-src: /assets/images/projects/access-the-data.png
-card-image-alt:
 sdg-image-src: /assets/images/about/sdg-elements/peace-justice.svg
 sdg-image-alt: '16: peace, justice and strong institutions'
 ---

--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -66,8 +66,6 @@ problem: Everyone should be able to have a voice in their community’s issues, 
 solution: On Engage, all users can view, read, and comment on agenda items their city council is currently debating. This makes it much easier to participate in discussions on government policies.
 impact: Our platform will make important local conversations much more representative of the actual community, boosting the representation of the most marginalized and underserved members. Being able to hear their perspective will lead to more inclusive, considerate decision-making that will truly benefit all of us rather than just some.
 sdg: '<strong>16.8:</strong> Broaden and strengthen the awareness and participation of City and local communities, especially those traditionally underserved and marginalized, in the institutions of local and global governance.'
-card-image-src: /assets/images/projects/engage.jpg
-card-image-alt: 
 sdg-image-src: /assets/images/about/sdg-elements/peace-justice.svg
 sdg-image-alt: '16: peace, justice and strong institutions'
 

--- a/_projects/lucky-parking.md
+++ b/_projects/lucky-parking.md
@@ -145,8 +145,6 @@ problem: Parking citations are distributed unevenly across different socio-econo
 solution: Hack for LA’s Lucky Parking project seeks to map the 12.5 million parking citations on a web app that is easy to use yet powerful enough to make meaningful insights about parking citations accessible to the public at large.
 impact: Our project seeks to educate and inform city leaders and the community about the effects of Los Angeles’ parking policies, hopefully serving as a tool in discussing more equitable solutions to our transportation problems.
 sdg: '<strong>11.2:</strong> By 2030, provide access to safe, affordable, accessible and sustainable transport systems for all, improving road safety, notably by expanding public transport, with special attention to the needs of those in vulnerable situations, women, children, persons with disabilities and older persons.'
-card-image-src: /assets/images/projects/lucky-parking.png
-card-image-alt:
 sdg-image-src: /assets/images/about/sdg-elements/sustainable-cities.svg
 sdg-image-alt: '11: sustainable cities and communities'
 ---

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -72,8 +72,6 @@ problem: Most Neighborhood Councils do not have access or resources to hire tech
 solution: The Open Community Survey project creates transparent reports supported by a direct collection of personal perspectives from LA residents to help The LA Department of Neighborhood Empowerment (empowerla.org) and the Los Angeles Neighborhood Councils to understand how constituents are interacting with, and what they need from, their websites.
 impact: <i>We are currently drafting the Impact statement for this project.</i>
 sdg: '<strong>16.8:</strong> Broaden and strengthen the awareness and participation of City and local communities, especially those traditionally underserved and marginalized, in the institutions of local and global governance.'
-card-image-src: /assets/images/projects/open-community-survey.jpg
-card-image-alt:
 sdg-image-src: /assets/images/about/sdg-elements/peace-justice.svg
 sdg-image-alt: '16: peace, justice and strong institutions'
 ---


### PR DESCRIPTION
Fixes #4159

### What changes did you make and why did you make them ?
Changes made:
Remove the card-image-src: and card-image-alt: fields and the content of each of those fields in the following files:
 - _projects/311-data.md
 - _projects/access-the-data.md
 - _projects/engage.md
 - _projects/lucky-parking.md
 - _projects/open-community-survey.md
 
In `_includes/program-area-pages-cards.html`, do the following:
- change
    ```
    <img class="card-image" src="{{ item.card-image-src }}" alt="{{ item.card-image-alt }}"/>
    ```
    to
    ```
    <img class="card-image" src="{{ item.image }}" alt="">
    ```
 - In the if statement, remove the line: 
    ```
    item.card-image-src.size > 0 and
    ```
Why:
- The image and card-image-src fields both have the path to the project's logo image. Since this information is the same, we don't need both fields. So, we will be removing the card-image-src fields from the Markdown files in _projects directory.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- Removed card-image-src and card-image-alt.  No visual changes to the website.
