### PR TITLE
add aria-label to nav element

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="main-footer">
   <div class="footer-contain">
-    <nav class="footer-nav">
+    <nav class="footer-nav" aria-label="Secondary">
       <div class="header-links">
         <a href="/donate/" class="btn btn-primary-on-dark btn-md-narrow btn--donate-footer btn--default" title="Go to Donate Page">Donate</a>
         <div class="footer-links">


### PR DESCRIPTION
Fixes #4303

### What changes did you make and why did you make them ?

  - added _aria-label="Secondary"_ to the nav element in the footer
  - for accessibility purposes
  - to identify the footer nav element as secondary to distinguish from the primary nav element

### Screenshots of Proposed Changes Of The Website

Added _aria-label="Secondary"_ label to footer nav element. No visual changes to the website.