### PR TITLE
Getting Started page - step-img-intro solidarity.png - #4376

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -18,7 +18,7 @@ permalink: /getting-started
         <div class="step-links">
             <a class="gs-link" href='getting-started#step-2'>Step 2</a>
             <p class="getting-started-step-title-overview-no-padding">Join a Community of Practice</p>
-            <img class="step-img-intro" src="./assets/images/getting-started/solidarity.png" alt="" />
+            <img class="step-img-intro" src="./assets/images/getting-started/solidarity.png" alt="" >
         </div>
         <div class="step-links">
             <a class="gs-link" href='getting-started#step-3'>Step 3</a>


### PR DESCRIPTION
Fixes #4376 

### What changes did you make and why did you make them ?

  - Removed closing tag from solidarity img element for src="./assets/images/getting-started/solidarity.png" in getting-started.html

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes to the website.
