### PR TITLE
Add sdg color vars 4233

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="main-footer">
   <div class="footer-contain">
-    <nav class="footer-nav">
+    <nav class="footer-nav" aria-label="Secondary">
       <div class="header-links">
         <a href="/donate/" class="btn btn-primary-on-dark btn-md-narrow btn--donate-footer btn--default" title="Go to Donate Page">Donate</a>
         <div class="footer-links">

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -13,6 +13,7 @@
 @import 'variables/layout';
 @import 'variables/typography';
 @import 'variables/utilities';
+@import 'variables/colors-sdg';
 
 // /**
 //  * Base global styles.

--- a/_sass/variables/_colors-sdg.scss
+++ b/_sass/variables/_colors-sdg.scss
@@ -1,0 +1,19 @@
+/**
+ * Sustainable Development Goal (SDG) Colors
+ *
+ * The hex color values for these variables match the SDG color icons provided by the United Nations (UN).
+ * These hex values are from the last the page in the SDG Guidelines provided by the UN:
+ * https://www.un.org/sustainabledevelopment/wp-content/uploads/2019/01/SDG_Guidelines_AUG_2019_Final.pdf
+ */
+
+ $color-sdg2: #DDA63A;
+ $color-sdg3: #4C9F38;
+ $color-sdg4: #C5192D;
+ $color-sdg5: #FF3A21;
+ $color-sdg8: #A21942;
+ $color-sdg9: #FD6925;
+ $color-sdg10: #DD1367;
+ $color-sdg11: #FD9D24;
+ $color-sdg13: #3F7E44;
+ $color-sdg16: #00689D;
+ $color-sdg17: #19486A;


### PR DESCRIPTION
Fixes #4233

### What changes did you make and why did you make them ?

  - create new file _colors-sdg.scss with sdg-color variables
  - import _colors-sdg.scss to _sass/main.scss
  - add this allows us to use these colors with their corresponding, matching SDG icons.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Added scss background color variables. No visual changes.