### PR TITLE
Update Project Profile: Hackforla.org Website to correct leadership order

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -12,6 +12,12 @@ leadership:
       slack: 'https://hackforla.slack.com/team/UE1UG1YFP'
       github: 'https://github.com/ExperimentsInHonesty'
     picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
+  - name: Justin Dingeman
+    role: Technical Lead
+    links:
+      slack: 'https://hackforla.slack.com/team/U03P33YE2PQ'
+      github: 'https://github.com/jdingeman'
+    picture: https://avatars.githubusercontent.com/jdingeman
   - name: Sarah Sanger
     role: Merge Team
     links:
@@ -24,12 +30,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U02LQ20MEDU'
       github: 'https://github.com/arpitapandya'
     picture: https://avatars.githubusercontent.com/arpitapandya
-  - name: Justin Dingeman
-    role: Technical Lead
-    links:
-      slack: 'https://hackforla.slack.com/team/U03P33YE2PQ'
-      github: 'https://github.com/jdingeman'
-    picture: https://avatars.githubusercontent.com/jdingeman
   - name: Matt Pereira
     role: Merge Team
     links:


### PR DESCRIPTION
Fixes #4358

### What changes did you make and why did you make them ?

  - Move the information for Justin Dingeman so that it is between Bonnie Wolfe and Sarah Sanger so that leadership is in the correct order

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before](https://user-images.githubusercontent.com/92824407/229946771-69b563a2-545d-443b-b69d-191a19583b90.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after](https://user-images.githubusercontent.com/92824407/229946861-d31956de-e868-4786-b31b-0592e8eb4e82.png)

</details>
