### PR TITLE
Removed img Closing Tag in Getting Started Page

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -105,7 +105,7 @@ permalink: /getting-started
                         </li>
                     </div>
                 </ol>
-                <p class="github-sign-up-text"><img class="info-icon" src="assets/images/getting-started/information.png" alt="" /> &nbsp If you do not have a GitHub account, <a href="https://github.com/" target="_blank">sign up here</a>. Membership is free.</p>
+                <p class="github-sign-up-text"><img class="info-icon" src="assets/images/getting-started/information.png" alt=""> &nbsp If you do not have a GitHub account, <a href="https://github.com/" target="_blank">sign up here</a>. Membership is free.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes #4397

### What changes did you make and why did you make them ?

  - Changed img HTML tag ending with a slash (<img.../>) to an img tag without an ending slash (<img...>) 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/36951879/229956211-1ee27877-de1b-479e-b729-0cbf0ba92e76.png)

![image](https://user-images.githubusercontent.com/36951879/229956304-2876a92f-aa2f-4240-b152-879283edeffb.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/36951879/229956345-48c28a9d-0f20-49d6-99bb-d9514f13266f.png)

![image](https://user-images.githubusercontent.com/36951879/229956368-65aca1f4-c87b-4c26-ac28-83329a1c86ba.png)
</details>
