### PR TITLE
Remove duplicate alt field in youthjusticenav.md

### DIFF
--- a/_projects/youthjusticenav.md
+++ b/_projects/youthjusticenav.md
@@ -3,7 +3,6 @@ identification: '324048462'
 title: Youth Justice Nav
 description: We are creating a know your rights tool for youth and their families when interacting with the Juvenile Justice System.  This interactive tool creates a resource for youth and their families to access information that is relevant to several different parts of the process from knowing your rights when you come into contact with law enforcement, to an explanation of the different types of hearings that take place, to knowing who various people in the courtroom are.
 image: /assets/images/projects/youthjusticenav.png
-alt: "All capital letters spelling out title of project - YOUTH JUSTICE NAV"
 image-hero: /assets/images/projects/youthjusticenav-hero.png
 alt: 'Youth Justice Nav'
 leadership:


### PR DESCRIPTION
Fixes #3746

### What changes did you make and why did you make them ?

  - Removed the duplicate alt field in the youthjusticenav.md file because having duplicate alt fields breaks some yaml interpreters and is non-standard for yaml

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
No visual changes to the website.