### PR TITLE
Img Tag Refactor: Getting Started Page - #4395

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -100,7 +100,7 @@ permalink: /getting-started
                     </div>
                     </br>
                     <div class="list-container">
-                        <img class="step-img-icon-cop-small" src="assets/images/getting-started/group.png" alt="" />
+                        <img class="step-img-icon-cop-small" src="assets/images/getting-started/group.png" alt="">
                         <li class="g-s-list">Network with your peers and attend your CoP meetings weekly. See <a href="/project-meetings" target="_blank">here</a> for schedule.
                         </li>
                     </div>


### PR DESCRIPTION
Fixes #4395

### What changes did you make and why did you make them?

  - As requested in instructions for the issue, changed image syntax to remove the forward slash from the end of the tag

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/99108792/230441855-0ba931fa-3c84-41e0-b531-e8cd937b9b45.png)
</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/99108792/230442594-94942781-15dd-4cb7-bc04-f87dc547fd3b.png)
</details>