### PR TITLE
Updated credit link to display only if direct link exist

### DIFF
--- a/pages/credits.html
+++ b/pages/credits.html
@@ -36,7 +36,11 @@ permalink: /credits/
                         <p>
                         <strong>Name: </strong>
                         <!-- original-url: 'https://thenounproject.com/kmgdesignid/collection/calendar-time-line/?i=3256421'-->
-                          <a href="{{item[1].title-link}}">{{ item[1].title }}</a>
+                          {%- if item[1].title-link -%}
+                            <a href="{{item[1].title-link}}">{{ item[1].title }}</a>
+                          {%- else -%}
+                            {{ item[1].title }}
+                          {% endif -%}
                         </p>
                       {%- endif -%}
                       {%- if item[1].used-in -%}


### PR DESCRIPTION
Fixes #4351

### What changes did you make and why did you make them ?

  -  Update credits.html so that it only renders a link to the credit's photo if it has a direct link.  Else the title will not display as a link.  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before](https://user-images.githubusercontent.com/25872681/230753336-4e88dd6d-20b3-450c-ba96-c37b6613a903.jpg)
</details>

<details>
<summary>Visuals after changes are applied</summary>

![After](https://user-images.githubusercontent.com/25872681/230753768-d3d9f3cb-1452-4d32-a3d7-074a01dea810.jpg)

</details>

