### PR TITLE
Remove trailing slash from <img> tag in Citizen Engagement page

### DIFF
--- a/pages/citizen-engagement.html
+++ b/pages/citizen-engagement.html
@@ -22,7 +22,7 @@ permalink: /citizen-engagement
         </p>
     </div>
     <img class="header-hero-image" src="/assets/images/citizen-engagement/citizen-engagement-header.svg"
-        alt="" />
+        alt="">
 </div>
 <!-- Header banner -->
 


### PR DESCRIPTION
Fixes #4447 

### What changes did you make and why did you make them ?

- Removed the trailing slash from the hero \<img> tag.
- The tag was removed to ensure consistency with other HTML \<img> tags across the site.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

(No visual changes)