### PR TITLE
removed back slash from img tag 4393

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -88,7 +88,7 @@ permalink: /getting-started
 
                 <ol class="column-ol-list">
                     <div class="list-container">
-                        <img class="step-img-icon-cop" src="assets/images/getting-started/proj-4.png" alt="" />
+                        <img class="step-img-icon-cop" src="assets/images/getting-started/proj-4.png" alt="" >
                         <li class="g-s-list"><a href="/communities-of-practice" target="_blank">Join your Community of Practice</a> for access to announcements, meeting zoom links, and helpful resources.
                         </li>
                     </div>


### PR DESCRIPTION
Fixes #4393 

### What changes did you make and why did you make them ?
As per the ticket I deleted the backslash from the img tag on line #91 of getting-started.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

