### PR TITLE
Added workflow_dispatch: (with colon) for a manual workflow trigger.

### DIFF
--- a/.github/workflows/vrms-data.yml
+++ b/.github/workflows/vrms-data.yml
@@ -4,6 +4,7 @@ name: Update VRMS data
 on:
   schedule:
     - cron: '0 10 * * *'
+  workflow_dispatch:
 
 jobs:
   vrms_data:


### PR DESCRIPTION
Fixes #4392

### What changes did you make and why did you make them ?

  - In website/.github/workflows/vrms-data.yml under "Update VRMS data" I added "workflow_dispatch" as a manual workflow trigger as an option beside the already included automatic scheduled trigger.
  - In order to list multiple triggers, I included a colon after "workflow_dispatch:" "to configure each event separately, including events without configuration". -(https://docs.github.com/en/github-ae@latest/actions/using-workflows/triggering-a-workflow#using-multiple-events)
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Backend only, no visual changes on website. There may be changes as a github action. I followed Matt Pereira's instructions on the comment section of the original issue to try to test changes, but I'm uncertain and as Matt said, "The action is going to fail on your fork because one of the steps uses a token".