### PR TITLE
Remove trailing slash from <img> tag in Getting Started page

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -95,7 +95,7 @@ permalink: /getting-started
                 </br>
                     <div class="list-container">
                         <img class="step-img-icon-git" src="assets/images/getting-started/join-2.png" alt="" />
-                        <li class="g-s-list">Receive access to the Google Drive and Github repository by sending a Slack message of your Github username and Gmail address to a CoP lead. <img class="info-icon" src="assets/images/getting-started/information.png" alt="" />
+                        <li class="g-s-list">Receive access to the Google Drive and Github repository by sending a Slack message of your Github username and Gmail address to a CoP lead. <img class="info-icon" src="assets/images/getting-started/information.png" alt="">
                         </li>
                     </div>
                     </br>


### PR DESCRIPTION
Fixes #4396 

### What changes did you make and why did you make them ?

  - Removed the trailing slash from the first information HTML \<img> tag to ensure consistency of \<img> tags across the website.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
(No visual changes)
