### PR TITLE
Removed slash at ending tag for step-img-icon-board

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -65,7 +65,7 @@ permalink: /getting-started
                     </br>
                     <p class="strong-text"><strong>After the Meeting:</strong></p>
                     <div class="list-container">
-                        <img class="step-img-icon-board" src="assets/images/getting-started/board.png" alt="" >
+                        <img class="step-img-icon-board" src="assets/images/getting-started/board.png" alt="">
                         <li class="g-s-list">Complete our <a href="https://docs.google.com/forms/d/e/1FAIpQLScXnJSyCXgO_RCAuCyOkG4sqGILpAepTlJ0HOaK4H_ccEVmNw/viewform" target="_blank">Onboarding Survey</a>.
                         </li>
                     </div>

--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -65,7 +65,7 @@ permalink: /getting-started
                     </br>
                     <p class="strong-text"><strong>After the Meeting:</strong></p>
                     <div class="list-container">
-                        <img class="step-img-icon-board" src="assets/images/getting-started/board.png" alt="" />
+                        <img class="step-img-icon-board" src="assets/images/getting-started/board.png" alt="" >
                         <li class="g-s-list">Complete our <a href="https://docs.google.com/forms/d/e/1FAIpQLScXnJSyCXgO_RCAuCyOkG4sqGILpAepTlJ0HOaK4H_ccEVmNw/viewform" target="_blank">Onboarding Survey</a>.
                         </li>
                     </div>


### PR DESCRIPTION
Fixes #4382 

### What changes did you make and why did you make them ?

  - Removed a slash at ending tag for step-img-icon-board
  - This was done because <img> tags don't need a closing slash
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes.