### PR TITLE
Removed '/' from the step-img-icon img tag that wraps id.png

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -131,7 +131,7 @@ permalink: /getting-started
                     </div>
                 </br>
                     <div class="list-container">
-                        <img class="step-img-icon" src="assets/images/getting-started/id.png" alt="" />
+                        <img class="step-img-icon" src="assets/images/getting-started/id.png" alt="">
                         <li class="g-s-list">After you have accepted the email invitation to our GitHub organization/repo,
                             mark your Hack for LA membership <a href="https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/publicizing-or-hiding-organization-membership#changing-the-visibility-of-your-organization-membership" target="_blank">
                             public</a>.


### PR DESCRIPTION
Fixes #4400 

### What changes did you make and why did you make them ?

Removed the '/' from the step-img-icon img tag that wraps id.png, to maintain more consistent styling throughout the getting-started.html page

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
N/A, changes are code only.  The id.png file displays correctly during testing in Docker at all screen sizes.
