### PR TITLE
created a GHA to list inactive members of website-write team

### DIFF
--- a/.github/workflows/schedule-monthly.yml
+++ b/.github/workflows/schedule-monthly.yml
@@ -2,7 +2,7 @@ name: Schedule Monthly
 
 on:
   schedule:
-    - cron: '0 8 1 * *'
+    - cron: "0 8 1 * *"
 
 jobs:
   list-inactive-members:
@@ -17,9 +17,9 @@ jobs:
         with:
           github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
           script: |
-            const script = require('./github-actions/trigger-schedule/list-inactive-members/get-list.js')
-            const getList = script({g: github, c: context})
-            return getList
+            const script = require('./github-actions/trigger-schedule/list-inactive-members/get-list.js');
+            const getList = script({g: github, c: context});
+            return getList;
 
       # creates a new issue in hackforla/website repo with the list populated above. creates a project card linking to this issue
       - name: Create New Issue
@@ -28,10 +28,10 @@ jobs:
         with:
           github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
           script: |
-            const script = require('./github-actions/trigger-schedule/list-inactive-members/create-new-issue.js')
-            const list = ${{ steps.get-list.outputs.result }}
-            const createNewIssue = script({g: github, c: context}, list)
-            return createNewIssue
+            const script = require('./github-actions/trigger-schedule/list-inactive-members/create-new-issue.js');
+            const list = ${{ steps.get-list.outputs.result }};
+            const createNewIssue = script({g: github, c: context}, list);
+            return createNewIssue;
 
       # comments on issue #2607, notifying leads that the above issue has been created
       - name: Comment Issue
@@ -40,6 +40,6 @@ jobs:
         with:
           github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
           script: |
-            const script = require('./github-actions/trigger-schedule/list-inactive-members/comment-issue.js')
-            const newIssueNumber = ${{ steps.create-new-issue.outputs.result }}
-            script({g: github, c: context}, newIssueNumber)
+            const script = require('./github-actions/trigger-schedule/list-inactive-members/comment-issue.js');
+            const newIssueNumber = ${{ steps.create-new-issue.outputs.result }};
+            script({g: github, c: context}, newIssueNumber);

--- a/.github/workflows/schedule-monthly.yml
+++ b/.github/workflows/schedule-monthly.yml
@@ -36,7 +36,7 @@ jobs:
       # comments on issue #2607, notifying leads that the above issue has been created
       - name: Comment Issue
         uses: actions/github-script@v6
-        id:
+        id: comment-issue
         with:
           github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
           script: |

--- a/.github/workflows/schedule-monthly.yml
+++ b/.github/workflows/schedule-monthly.yml
@@ -1,0 +1,45 @@
+name: Schedule Monthly
+
+on:
+  schedule:
+    - cron: '0 8 1 * *'
+
+jobs:
+  list-inactive-members:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # gets a list of website-write team members with no open issues, returns a list of member's github handles
+      - name: Get List
+        uses: actions/github-script@v6
+        id: get-list
+        with:
+          github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
+          script: |
+            const script = require('./github-actions/trigger-schedule/list-inactive-members/get-list.js')
+            const getList = script({g: github, c: context})
+            return getList
+
+      # creates a new issue in hackforla/website repo with the list populated above. creates a project card linking to this issue
+      - name: Create New Issue
+        uses: actions/github-script@v6
+        id: create-new-issue
+        with:
+          github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
+          script: |
+            const script = require('./github-actions/trigger-schedule/list-inactive-members/create-new-issue.js')
+            const list = ${{ steps.get-list.outputs.result }}
+            const createNewIssue = script({g: github, c: context}, list)
+            return createNewIssue
+
+      # comments on issue #2607, notifying leads that the above issue has been created
+      - name: Comment Issue
+        uses: actions/github-script@v6
+        id:
+        with:
+          github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
+          script: |
+            const script = require('./github-actions/trigger-schedule/list-inactive-members/comment-issue.js')
+            const newIssueNumber = ${{ steps.create-new-issue.outputs.result }}
+            script({g: github, c: context}, newIssueNumber)

--- a/github-actions/trigger-schedule/list-inactive-members/comment-issue.js
+++ b/github-actions/trigger-schedule/list-inactive-members/comment-issue.js
@@ -1,0 +1,26 @@
+// Import modules
+
+// Global variables
+var github;
+var context;
+
+async function main({ g, c }, newIssueNumber) {
+  github = g;
+  context = c;
+
+  let agendaAndNotesIssueNumber = 2607
+  await commentOnIssue(agendaAndNotesIssueNumber, newIssueNumber);
+}
+
+const commentOnIssue = async (agendaAndNotesIssueNumber, newIssueNumber) => {
+  const owner = "hackforla";
+  const repo = "website";
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: agendaAndNotesIssueNumber,
+    body: `**Review Inactive Members:** #${newIssueNumber}`,
+  });
+};
+
+module.exports = main;

--- a/github-actions/trigger-schedule/list-inactive-members/comment-issue.js
+++ b/github-actions/trigger-schedule/list-inactive-members/comment-issue.js
@@ -8,7 +8,7 @@ async function main({ g, c }, newIssueNumber) {
   github = g;
   context = c;
 
-  let agendaAndNotesIssueNumber = 2607
+  let agendaAndNotesIssueNumber = 2607;
   await commentOnIssue(agendaAndNotesIssueNumber, newIssueNumber);
 }
 

--- a/github-actions/trigger-schedule/list-inactive-members/create-new-issue.js
+++ b/github-actions/trigger-schedule/list-inactive-members/create-new-issue.js
@@ -1,0 +1,83 @@
+// Import modules
+
+// Global variables
+var github;
+var context;
+
+async function main({ g, c }, list) {
+  github = g;
+  context = c;
+
+  const owner = "hackforla";
+  const repo = "website";
+
+  // create a new issue in repo, return the issue id for later: creating the project card linked to this issue
+  const issue = await createIssue(owner, repo, list);
+  const issueId = issue.id;
+  const issueNumber = issue.number;
+  // get project id, in order to get the column id of `New Issue Approval` in `Project Board`
+  const projectId = await getProjectId(owner, repo);
+  // get column id, in order to create a project card in `Project Board` and place in `New Issue Approval`
+  const columnId = await getColumnId(projectId);
+  // create the project card, which links to the issue created on line 16
+  await createProjectCard(issueId, columnId);
+  // return issue number: going to be using this number to link the issue when commenting on the `Dev/PM Agenda and Notes`
+  return issueNumber;
+}
+
+const createIssue = async (owner, repo, list) => {
+  let listWithNewLine = list.join("\n");
+  let body = "**Inactive Members:**\n\n" + listWithNewLine;
+  let labels = [
+    "Ready for dev lead",
+    "Ready for product",
+    "Complexity: Small",
+    "Size: 0.5pt",
+    "bug",
+  ];
+  const title = "Review Inactive Members";
+  const issue = await github.rest.issues.create({
+    owner,
+    repo,
+    title,
+    body,
+    labels,
+  });
+  return issue.data;
+};
+
+const getProjectId = async (owner, repo) => {
+  // get all projects for the repo
+  let projects = await github.rest.projects.listForRepo({
+    owner,
+    repo,
+  });
+  // select project with name `Project Board`, access the `id`
+  let projectId = projects.data.filter((project) => {
+    return (project.name = "Project Board");
+  })[0].id;
+  return projectId;
+};
+
+const getColumnId = async (projectId) => {
+  // get all columns in the project board
+  let columns = await github.rest.projects.listColumns({
+    project_id: projectId,
+  });
+  // select column with name `New Issue Approval`, access the `id
+  let columnId = columns.data.filter((column) => {
+    return column.name === "New Issue Approval";
+  })[0].id;
+  return columnId;
+};
+
+const createProjectCard = async (issueId, columnId) => {
+  const card = await github.rest.projects.createCard({
+    column_id: columnId,
+    content_id: issueId,
+    content_type: "Issue",
+  });
+  return card.data;
+};
+
+module.exports = main;

--- a/github-actions/trigger-schedule/list-inactive-members/create-new-issue.js
+++ b/github-actions/trigger-schedule/list-inactive-members/create-new-issue.js
@@ -33,7 +33,6 @@ const createIssue = async (owner, repo, list) => {
     "Ready for product",
     "Complexity: Small",
     "Size: 0.5pt",
-    "bug",
   ];
   const title = "Review Inactive Members";
   const issue = await github.rest.issues.create({

--- a/github-actions/trigger-schedule/list-inactive-members/get-list.js
+++ b/github-actions/trigger-schedule/list-inactive-members/get-list.js
@@ -1,0 +1,69 @@
+// Import modules
+
+// Global variables
+var github;
+var context;
+
+async function main({ g, c }) {
+  github = g;
+  context = c;
+
+  const org = "hackforla";
+  const teamSlug = "website-write";
+  const owner = "hackforla";
+  const repo = "website";
+
+  // get number of team members for the website-write team (need this number to determine amount of page numbers to fetch from Github API)
+  // Github API limits 100 max results per request
+  let pageNumbers = await getNumberOfPages(org, teamSlug, github);
+  let allTeamMembers = await getAllMembers(org, teamSlug, pageNumbers);
+
+  return await selectMembersWithNoIssues(allTeamMembers, owner, repo)
+}
+
+const getNumberOfPages= async (org, teamSlug) => {
+  // get number of pages, needed for `getMembersWithoutIssues` function. GithubAPI has a return limit of 100 results => over 300 team members in website-write
+  let websiteWriteTeam = await github.rest.teams.getByName({
+    org,
+    team_slug: teamSlug,
+  });
+
+  let membersCount = websiteWriteTeam.data.members_count;
+  let pageNumbers = Math.ceil(membersCount / 100);
+  return pageNumbers;
+};
+
+const getAllMembers = async (org, teamSlug, pageNumbers) => {
+  // get all team members
+  let allTeamMembers = [];
+  for (let currPage = 1; currPage <= pageNumbers; currPage += 1) {
+    let teamMembers = await github.rest.teams.listMembersInOrg({
+      org,
+      team_slug: teamSlug,
+      per_page: 100,
+      page: currPage,
+    });
+    allTeamMembers = allTeamMembers.concat(teamMembers.data);
+  }
+  return allTeamMembers
+};
+
+const selectMembersWithNoIssues = async (allTeamMembers, owner, repo) => {
+    // select team members without open issues
+    let inactiveMembers = [];
+    for (let member of allTeamMembers) {
+        let assignee = member.login;
+        let memberIssues = await github.rest.issues.listForRepo({
+            owner,
+            repo,
+            state: "open",
+            assignee,
+        });
+        if (memberIssues.data.length === 0) {
+            inactiveMembers.push(assignee);
+        }
+    }
+    return inactiveMembers
+}
+
+module.exports = main;

--- a/github-actions/trigger-schedule/list-inactive-members/get-list.js
+++ b/github-actions/trigger-schedule/list-inactive-members/get-list.js
@@ -18,10 +18,10 @@ async function main({ g, c }) {
   let pageNumbers = await getNumberOfPages(org, teamSlug, github);
   let allTeamMembers = await getAllMembers(org, teamSlug, pageNumbers);
 
-  return await selectMembersWithNoIssues(allTeamMembers, owner, repo)
+  return await selectMembersWithNoIssues(allTeamMembers, owner, repo);
 }
 
-const getNumberOfPages= async (org, teamSlug) => {
+const getNumberOfPages = async (org, teamSlug) => {
   // get number of pages, needed for `getMembersWithoutIssues` function. GithubAPI has a return limit of 100 results => over 300 team members in website-write
   let websiteWriteTeam = await github.rest.teams.getByName({
     org,
@@ -45,25 +45,25 @@ const getAllMembers = async (org, teamSlug, pageNumbers) => {
     });
     allTeamMembers = allTeamMembers.concat(teamMembers.data);
   }
-  return allTeamMembers
+  return allTeamMembers;
 };
 
 const selectMembersWithNoIssues = async (allTeamMembers, owner, repo) => {
-    // select team members without open issues
-    let inactiveMembers = [];
-    for (let member of allTeamMembers) {
-        let assignee = member.login;
-        let memberIssues = await github.rest.issues.listForRepo({
-            owner,
-            repo,
-            state: "open",
-            assignee,
-        });
-        if (memberIssues.data.length === 0) {
-            inactiveMembers.push(assignee);
-        }
+  // select team members without open issues
+  let inactiveMembers = [];
+  for (let member of allTeamMembers) {
+    let assignee = member.login;
+    let memberIssues = await github.rest.issues.listForRepo({
+      owner,
+      repo,
+      state: "open",
+      assignee,
+    });
+    if (memberIssues.data.length === 0) {
+      inactiveMembers.push(assignee);
     }
-    return inactiveMembers
-}
+  }
+  return inactiveMembers;
+};
 
 module.exports = main;


### PR DESCRIPTION
Fixes #4158

### What changes did you make and why did you make them ?

  - Created a new file `schedule-monthly.yml` in the `.github/workflows` directory. This is a new GHA (Github Actions) workflow file containing one job named `list-inactive-members` that will run on the first on the month at 1 AM Pacific (8AM UTC). The decision was made to run the action on the 1st of every month instead of on the last of the month for every month. Doing so eliminated the need to account for creating cron schedules that run from the 28th - 31th every month and corresponding scripts to check if the current day was actually the last day of the month.
  
  - The `list-inactive-members` job created contains three GHA `steps` that correspond with their respective javascript file located within  `github-actions/trigger-schedule/list-inactive-members`. The three javascript files are outlined below.
 
1. `github-actions/trigger-schedule/list-inactive-members/get-list.js` is a newly created Javascript file that corresponds to the step named `Get List` located in the `.github/workflows/schedule-monthly.yml` file. This script calls the Github API in various ways and gets a list of website-write team members who do not have any active issues.

2. `github-actions/trigger-schedule/list-inactive-members/create-new-issue.js` is a newly created Javascript file that corresponds to the step named `Create New Issue` located in the `.github/workflows/schedule-monthly.yml` file. This script takes the list of nonactive members created from `get-list.js` and creates a new issue within the hackforla repo that contains the list of nonactive members. The issue is then moved to the project board by creating a new project card linked to this issue. I could not find a way to programmatically move the issue to the project board without specifying a specific column; the issue is moved to the `New Issue Approval` column without using the existing automation.

3. `github-actions/trigger-schedule/list-inactive-members/comment-issue.js` is a newly created Javascript file that corresponds to the step named `Comment Issue` located in the `.github/workflows/schedule-monthly.yml` file. This script comments on issue #2607 so that dev leads and PMs can review the list of non active members during planning.

- This GHA was tested using my own local project board and token. I am available to help if this action ends up breaking when testing it against the real project board. Let me know if anything is needed!

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No visual Changes to the website.
