### PR TITLE
Add GHA deleting closed and unmerged PRs from Project Board

### DIFF
--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -52,3 +52,16 @@ jobs:
           column: 'test-approved-by-reviewer (Automated Column, do not place items here manually)'            
           repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
           action: delete
+
+  # Removes PRs that are closed and not merged
+  Delete-Closed-And-Unmerged-PRs:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == false && github.event.action == 'closed' }}
+    steps:
+      - name: Delete Closed and Unmerged PRs
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Project Board
+          column: 'PR Needs review (Automated Column, do not place items here manually)'
+          repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
+          action: delete


### PR DESCRIPTION
Fixes #4357 
### What changes did you make and why did you make them ?

  - Added a GitHub Action (GHA) to delete closed but unmerged PRs from the Project Board. This addition was made because we want to optimize the Project Board, but the sheer number of cards are slowing it down.
  - The GHA was tested locally and PRs were successfully removed from the Project Board after being closed. This did not affect other open PRs that were also unmerged.
  - PRs that would be closed were also tested in different columns of the Project Board. The results were the same.

No screenshots are available since there are no visible changes to the website, but reviewers should be able to find the comments I made in the PRs for my "website" repo when I was testing the GHA and should be able to replicate the results using the resources. Let me know if there are any questions though!