### PR TITLE
add-sdg-background-4233

### DIFF
--- a/_sass/elements/_background-sdg-colors.scss
+++ b/_sass/elements/_background-sdg-colors.scss
@@ -1,0 +1,18 @@
+/**
+ * Sustainable Development Goal (SDG) Background Colors
+ *
+ * These background color classes match the colors of the SDG icons provided by the United Nations (UN):
+ * https://www.un.org/sustainabledevelopment/news/communications-material/
+ */
+
+ .background-color-sdg2 { background-color: $color-sdg2; }
+ .background-color-sdg3 { background-color: $color-sdg3; }
+ .background-color-sdg4 { background-color: $color-sdg4; }
+ .background-color-sdg5 { background-color: $color-sdg5; }
+ .background-color-sdg8 { background-color: $color-sdg8; }
+ .background-color-sdg9 { background-color: $color-sdg9; }
+ .background-color-sdg10 { background-color: $color-sdg10; }
+ .background-color-sdg11 { background-color: $color-sdg11; }
+ .background-color-sdg13 { background-color: $color-sdg13; }
+ .background-color-sdg16 { background-color: $color-sdg16; }
+ .background-color-sdg17 { background-color: $color-sdg17; }

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -4,6 +4,7 @@
 
 // This is the original reset included when we used bourbon.sass
 @import 'normalize.scss';
+@import 'elements/background-sdg-colors';
 
 /**
  * General Settings and Utilities


### PR DESCRIPTION
Fixes #4344 

### What changes did you make and why did you make them ?

  - created `_background-sdg-colors.scss` file inside the `_sass/elements` folder
  - added the following code to `_background-sdg-colors.scss` 
```
/**
 * Sustainable Development Goal (SDG) Background Colors
 *
 * These background color classes match the colors of the SDG icons provided by the United Nations (UN):
 * https://www.un.org/sustainabledevelopment/news/communications-material/
 */

.background-color-sdg2 { background-color: $color-sdg2; }
.background-color-sdg3 { background-color: $color-sdg3; }
.background-color-sdg4 { background-color: $color-sdg4; }
.background-color-sdg5 { background-color: $color-sdg5; }
.background-color-sdg8 { background-color: $color-sdg8; }
.background-color-sdg9 { background-color: $color-sdg9; }
.background-color-sdg10 { background-color: $color-sdg10; }
.background-color-sdg11 { background-color: $color-sdg11; }
.background-color-sdg13 { background-color: $color-sdg13; }
.background-color-sdg16 { background-color: $color-sdg16; }
.background-color-sdg17 { background-color: $color-sdg17; }
``` 
  - Inside `_scass/main.scss` I went ahead and added the following import statement
```
@import 'elements/background-sdg-colors';
``` 


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes made as of this moment as all the changes were code changes.
