### PR TITLE
Fixed sdg image grid firefox 

### DIFF
--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -40,13 +40,6 @@
   row-gap: 26px;
 }
 
-// Grid displayed differently in Chrome and Firefox
-// Defining image height fixes the issue in Firefox
-.grid-2-column > img {
-  height: 100%;
-  max-width: 100%;
-}
-
 // Makes the sticky navigation stick
 .stick-it {
   position: fixed;

--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -44,7 +44,6 @@
 
 // Grid displayed differently in Chrome and Firefox
 // Defining image height fixes the issue in Firefox
-
 .grid-2-column > img {
   height: 140px;
   width: auto

--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -38,15 +38,13 @@
   grid-template-rows: repeat(4, 1fr);
   column-gap: 10px;
   row-gap: 26px;
-  justify-items: stretch;
-  align-content: space-between; 
 }
 
 // Grid displayed differently in Chrome and Firefox
 // Defining image height fixes the issue in Firefox
 .grid-2-column > img {
-  height: 140px;
-  width: auto
+  height: 100%;
+  max-width: 100%;
 }
 
 // Makes the sticky navigation stick

--- a/_sass/components/_about.scss
+++ b/_sass/components/_about.scss
@@ -42,6 +42,14 @@
   align-content: space-between; 
 }
 
+// Grid displayed differently in Chrome and Firefox
+// Defining image height fixes the issue in Firefox
+
+.grid-2-column > img {
+  height: 140px;
+  width: auto
+}
+
 // Makes the sticky navigation stick
 .stick-it {
   position: fixed;


### PR DESCRIPTION
Fixes #4574

### What changes did you make and why did you make them ?

- I did some research and found a similar issue on [StackOverflow.](https://stackoverflow.com/questions/41667881/flexbox-items-not-displaying-correctly-on-firefox)  Chrome gives the images a height but Firefox doesn't. 
- In the _about.scss I added lines 47 to 50. I gave the images a height of 140px. This resolved the issue. 
- There might be another solution. You could also remove both the "justified-item: stretch" and "align-item: space-between" from the "grid-2-container" class in _about.scss. Both solutions seem to give similar results. Not sure which is more "Right." 

<details>

Chrome and Firefox were displaying images differently on the [About](https://www.hackforla.org/about/#sustainability) page. In Firefox the images in the container were shifted down and not completely visible.

<summary>Before the changes</summary>

![image](https://i.imgur.com/0Q6dMYF.png)

</details>

<details>
<summary>After the changes the images render correctly and are consistent with how Chrome renders the same page.</summary>
  
![image](https://i.imgur.com/PCxeRZy.png)

</details>
