### PR TITLE
Remove Cathy Cai from leadership variable - Access The Data

### DIFF
--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -34,12 +34,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U9NFW84QK'
       github: 'https://github.com/nyarly'
     picture: https://avatars.githubusercontent.com/nyarly
-  - name: Cathy Cai
-    role: Product Manager
-    links:
-      slack: 'https://hackforla.slack.com/team/U04TUV2FQCU'
-      github: 'https://github.com/Cathyyyyyyyy'
-    picture: https://avatars.githubusercontent.com/Cathyyyyyyyy
   - name: Aparna Gopal
     role: UX Researcher
     links:


### PR DESCRIPTION
Fixes #4605

### What changes did you make and why did you make them ?

- Removed Cathy Cai from the access-the-database.md file. Removed name, role, links and photo. 
- Change made to resolve issue #4605

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)


<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/103082829/5bec0eb0-a30a-4b78-90d1-7470d545d509)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/103082829/cc436796-23eb-4caa-9041-71bccbbd4c1d)

</details>
