### PR TITLE
Updated Label in External Resource Markdown File

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest-an-external-resource.md
+++ b/.github/ISSUE_TEMPLATE/suggest-an-external-resource.md
@@ -2,7 +2,7 @@
 name: Suggest an external resource
 about: For resources that could be listed on the toolkit page.
 title: Add this resource to the ToolKit External Resources section
-labels: 'P-Feature: Toolkit, role: front end, size: 0.5pt'
+label: ['P-Feature: Toolkit','role: front end','size: 0.5pt','Complexity: Missing']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/suggest-an-external-resource.md
+++ b/.github/ISSUE_TEMPLATE/suggest-an-external-resource.md
@@ -2,7 +2,7 @@
 name: Suggest an external resource
 about: For resources that could be listed on the toolkit page.
 title: Add this resource to the ToolKit External Resources section
-label: ['P-Feature: Toolkit','role: front end','size: 0.5pt','Complexity: Missing']
+labels: ['P-Feature: Toolkit','role: front end','size: 0.5pt','Complexity: Missing']
 assignees: ''
 
 ---


### PR DESCRIPTION
Fixes #4476

### What changes did you make and why did you make them ?

  - I updated the label in suggest-an-external-resource.md by adding 'Complexity:Missing' to indicate that a label of a certain series is missing from an issue. 
  - This prevents the GitHub bot from taking off the labels when devs add them to issues.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Updating suggest external resource markdown file. No visual changes to the website.
