### PR TITLE
updated slack link #4642

### DIFF
--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -25,7 +25,7 @@ leadership:
   - name: AJ Price
     role: Product Manager
     links:
-      slack: 'https://hackforla.slack.com/team/D02USE0EPSS'
+      slack: 'https://hackforla.slack.com/team/U02UZ5BK8UB'
       github: 'https://github.com/mxajPrice'
     picture: https://avatars.githubusercontent.com/mxajPrice
   - name: Judson Lester


### PR DESCRIPTION
Fixes #4642 

### What changes did you make and why did you make them ?

  - Updated file _projects/access-the-data.md
  - changed AJ Price's slack link from "https://hackforla.slack.com/team/D02USE0EPSS"
  - to "https://hackforla.slack.com/team/U02UZ5BK8UB"

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
Before the link would take you here
<img width="1482" alt="Screenshot 2023-05-15 at 3 27 12 PM" src="https://github.com/hackforla/website/assets/98275292/9b4ffc54-5f6d-4179-b9f2-879be2c07257">


</details>

<details>
<summary>Visuals after changes are applied</summary>
 After my changes it takes you to slack

<img width="398" alt="Screenshot 2023-05-15 at 3 29 43 PM" src="https://github.com/hackforla/website/assets/98275292/78ff60fe-8271-474c-b262-881906824569">


</details>
