### PR TITLE
Update missing labels for Complexity and size in Communities of Practice information updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
+++ b/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
@@ -2,7 +2,7 @@ name: Communities of Practice information updates
 description: CoP leads use this issue to make changes to Leadership members and contact info
 title: 'Communities of Practice information updates: [INSERT NAME OF Community of
   Practice]'
-labels: ['role: product', 'P-Feature: Communities of Practice', 'time sensitive']
+labels: ['role: product', 'P-Feature: Communities of Practice', 'time sensitive', 'Complexity: Missing', 'size: missing']
 
 body:
   - type: markdown


### PR DESCRIPTION
Fixes #4486

### What changes did you make and why did you make them ?

  - Added missing labels for `'Complexity: Missing'` and `'size: missing'` in `.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml`
  - Change made to avoid the GitHub bot taking off the labels when devs add them to issues.
  - Missing labels are important to know for issue creators. They indicate that a label of a certain series is missing from the issue.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1440" alt="Screen Shot 2023-05-17 at 11 38 46 PM" src="https://github.com/hackforla/website/assets/97702073/ecabdd8c-effc-4de2-88b6-f94852848380">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1440" alt="Screen Shot 2023-05-17 at 11 38 54 PM" src="https://github.com/hackforla/website/assets/97702073/4a54471d-3f35-46d0-9d68-8ea56d6eaa92">

</details>

**For PR Reviewers and Merge Team**
To review this issue, click the link below under "Link for reviewers" and verify that the labels match the updated labels string in the issue.

**Link for Reviewers**
URL of the issue branch on the test Repository: https://github.com/matthewmpan/website/issues/new?assignees=&labels=role%3A+product%2CP-Feature%3A+Communities+of+Practice%2Ctime+sensitive%2CComplexity%3A+Missing%2Csize%3A+missing&projects=&template=communities-of-practice-information-updates.yml&title=Communities+of+Practice+information+updates%3A+%5BINSERT+NAME+OF+Community+of+Practice%5D
