### PR TITLE
"Projects" and "Home Page" Edits | pins project filter to top of project list, un-sticky's the Filters on scroll, & centers components

### DIFF
--- a/_includes/current-projects-check.html
+++ b/_includes/current-projects-check.html
@@ -1,6 +1,6 @@
 <a class="anchor" id="projects"></a>
 <section class="content-section projects">
-  <div class="page-contain projects-inner">
+  <div class="page-contain projects-inner curr-projects">
     <h2 class="project-header title2">Current Projects</h2>
     <p class="project-pitch">
       Have an idea?
@@ -13,7 +13,7 @@
     <ul class="filter-list" id="filter-list"></ul>
     <div class="filter-tag-container"></div>
   </div>
-  <div class="page-contain projects-inner" style="clear: left">
+  <div class="page-contain projects-inner curr-projects" style="clear: left">
     <ul class="project-list unstyled-list"></ul>
   </div>
 </section>

--- a/_includes/current-projects.html
+++ b/_includes/current-projects.html
@@ -31,7 +31,7 @@
     </div>
   </nav>
   <div class="projects-and-filters">
-    <div class="filter-tag-container"></div>
+    <div class="filter-tag-container top-filter"></div>
     <div class="page-contain projects-inner" >
       <ul class="project-list unstyled-list"></ul>
     </div>

--- a/_includes/current-projects.html
+++ b/_includes/current-projects.html
@@ -18,7 +18,7 @@
           </svg>
         </button>
       </h3>
-      <div class="filter-tag-container"></div>
+      {% comment %} <div class="filter-tag-container"></div> {% endcomment %}
       <ul class="filter-list" id="filter-list"></ul>
       <div class="mobile-filter-buttons">
         <button class="cancel-mobile-filters btn-md btn-dark">
@@ -30,8 +30,11 @@
       </div>
     </div>
   </nav>
-  <div class="page-contain projects-inner" style="clear: left">
-    <ul class="project-list unstyled-list"></ul>
+  <div class="projects-and-filters">
+    <div class="filter-tag-container"></div>
+    <div class="page-contain projects-inner" >
+      <ul class="project-list unstyled-list"></ul>
+    </div>
   </div>
 </section>
 

--- a/_includes/current-projects.html
+++ b/_includes/current-projects.html
@@ -1,7 +1,7 @@
 <a class="anchor" id="projects"></a>
 <section class="content-section projects filter-content-container">
   <nav class="filter-toolbar" aria-label="Filter Navbar">
-    <div class="stickyDiv">
+    <div class="filtersDiv">
       <h3 class="filters-title">
         Filters
         <button class="show-filters-button" aria-label="Show All Filters">
@@ -18,7 +18,6 @@
           </svg>
         </button>
       </h3>
-      {% comment %} <div class="filter-tag-container"></div> {% endcomment %}
       <ul class="filter-list" id="filter-list"></ul>
       <div class="mobile-filter-buttons">
         <button class="cancel-mobile-filters btn-md btn-dark">

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -39,11 +39,6 @@ a.filter-item {
   height: 100%;
 }
 
-// @media only screen and (max-width: 1028px) {
-//   .filter-toolbar > .stickyDiv {
-//     top: 75px;
-//   }
-// }
 //filter container
 ul.filter-list {
   display: flex;
@@ -261,9 +256,6 @@ a.clear-filter-tags {
     overflow-y: scroll;
     background: $color-white;
   }
-  // .filter-toolbar > .stickyDiv {
-  //   position: static;
-  // }
   .filters-title {
     background: $color-white;
     border: 1px solid $color-mediumgrey;

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -22,6 +22,16 @@ section.filter-content-container {
 .page-contain.projects-inner {
   margin: 0px 0px;
 }
+
+// I need to find this in the codebase
+.filter-tag-container.top-filter {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0 0 10px 0;
+  max-width: 800px;
+  flex-direction: row;
+}
 // =================TEST==========================
 
 a.filter-item {

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -8,10 +8,22 @@
 .filters-title .hide-filters-button {
   display: none;
 }
+// section.filter-content-container {
+//   display: grid;
+//   grid-template-columns: 377px 1fr;
+// }
+
+// =================TEST==========================
 section.filter-content-container {
-  display: grid;
-  grid-template-columns: 377px 1fr;
+  display: flex;
+  justify-content: center;
 }
+
+.page-contain.projects-inner {
+  margin: 0px 0px;
+}
+// =================TEST==========================
+
 a.filter-item {
   text-decoration: none;
 }
@@ -20,17 +32,17 @@ a.filter-item {
 }
 
 .filter-toolbar {
-  width: 100%;
+  // width: 100%;
   padding: 8px 32px;
   box-sizing: border-box;
-  margin: 0 auto;
+  // margin: 0 auto;
   height: 100%;
 }
-.filter-toolbar > .stickyDiv {
-  position: sticky;
-  position: -webkit-sticky;
-  top: 120px;
-}
+// .filter-toolbar > .stickyDiv {
+//   position: sticky;
+//   position: -webkit-sticky;
+//   top: 120px;
+// }
 @media only screen and (max-width: 1028px) {
   .filter-toolbar > .stickyDiv {
     top: 75px;

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -17,6 +17,9 @@ section.filter-content-container {
 .page-contain.projects-inner {
   margin: 0px 0px;
 }
+.page-contain.projects-inner.curr-projects {
+  margin: 0px auto;
+}
 .filter-tag-container.top-filter {
   display: flex;
   flex-wrap: wrap;
@@ -37,6 +40,10 @@ a.filter-item {
   padding: 8px 32px;
   box-sizing: border-box;
   height: 100%;
+}
+
+.filtersDiv {
+  min-width: 282px;
 }
 
 //filter container

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -8,22 +8,15 @@
 .filters-title .hide-filters-button {
   display: none;
 }
-// section.filter-content-container {
-//   display: grid;
-//   grid-template-columns: 377px 1fr;
-// }
 
-// =================TEST==========================
+// Centered Components and filters up top
 section.filter-content-container {
   display: flex;
   justify-content: center;
 }
-
 .page-contain.projects-inner {
   margin: 0px 0px;
 }
-
-// I need to find this in the codebase
 .filter-tag-container.top-filter {
   display: flex;
   flex-wrap: wrap;
@@ -32,7 +25,6 @@ section.filter-content-container {
   max-width: 800px;
   flex-direction: row;
 }
-// =================TEST==========================
 
 a.filter-item {
   text-decoration: none;
@@ -42,22 +34,16 @@ a.filter-item {
 }
 
 .filter-toolbar {
-  // width: 100%;
   padding: 8px 32px;
   box-sizing: border-box;
-  // margin: 0 auto;
   height: 100%;
 }
-// .filter-toolbar > .stickyDiv {
-//   position: sticky;
-//   position: -webkit-sticky;
-//   top: 120px;
+
+// @media only screen and (max-width: 1028px) {
+//   .filter-toolbar > .stickyDiv {
+//     top: 75px;
+//   }
 // }
-@media only screen and (max-width: 1028px) {
-  .filter-toolbar > .stickyDiv {
-    top: 75px;
-  }
-}
 //filter container
 ul.filter-list {
   display: flex;
@@ -275,9 +261,9 @@ a.clear-filter-tags {
     overflow-y: scroll;
     background: $color-white;
   }
-  .filter-toolbar > .stickyDiv {
-    position: static;
-  }
+  // .filter-toolbar > .stickyDiv {
+  //   position: static;
+  // }
   .filters-title {
     background: $color-white;
     border: 1px solid $color-mediumgrey;

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -381,10 +381,6 @@ function updateFilterTagDisplayState(filterParams){
         })
 
     }
-
-    // if (Object.entries(filterParams). length > 0) {
-    //     document.querySelector('.filter-tag-container').insertAdjacentHTML('afterbegin', `<h4 class="applied-filters">Applied Filters</h4>`)
-    // }
 }
 
     /**

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -382,9 +382,9 @@ function updateFilterTagDisplayState(filterParams){
 
     }
 
-    if (Object.entries(filterParams). length > 0) {
-        document.querySelector('.filter-tag-container').insertAdjacentHTML('afterbegin', `<h4 class="applied-filters">Applied Filters</h4>`)
-    }
+    // if (Object.entries(filterParams). length > 0) {
+    //     document.querySelector('.filter-tag-container').insertAdjacentHTML('afterbegin', `<h4 class="applied-filters">Applied Filters</h4>`)
+    // }
 }
 
     /**


### PR DESCRIPTION
Fixes #4593 

### What changes did you make and why did you make them ?

  - Pinned the projects filters to the top of the projects list to mimic the REI website
       - UX/UI best practice to facilitate user navigation along the page
  - Removed the "sticky" styling for the filters side pane
       - This caused unnecessary scrolling through all project cards to release the filters pane so the user can see the filters at the bottom of the pane
  - Centered the components to the center to mimic the REI website
     - having the components centered can be considered good UX/UI since the user can quickly navigate because there is less distance between components
- Refactored where needed 
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/73868258/290a0235-b877-4ca6-924d-2bf0787eee9d)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](https://github.com/hackforla/website/assets/73868258/5f48a4a2-1972-4024-9d67-8cb35c124297)
  
![image](https://github.com/hackforla/website/assets/73868258/74b60e83-1cf8-48c7-a3ab-c457f0cf07e5)

</details>
