### PR TITLE
Add SDG background color classes

### DIFF
--- a/_sass/elements/_background-sdg-colors.scss
+++ b/_sass/elements/_background-sdg-colors.scss
@@ -1,0 +1,18 @@
+/**
+ * Sustainable Development Goal (SDG) Background Colors
+ *
+ * These background color classes match the colors of the SDG icons provided by the United Nations (UN):
+ * https://www.un.org/sustainabledevelopment/news/communications-material/
+ */
+
+ .background-color-sdg2 { background-color: $color-sdg2; }
+ .background-color-sdg3 { background-color: $color-sdg3; }
+ .background-color-sdg4 { background-color: $color-sdg4; }
+ .background-color-sdg5 { background-color: $color-sdg5; }
+ .background-color-sdg8 { background-color: $color-sdg8; }
+ .background-color-sdg9 { background-color: $color-sdg9; }
+ .background-color-sdg10 { background-color: $color-sdg10; }
+ .background-color-sdg11 { background-color: $color-sdg11; }
+ .background-color-sdg13 { background-color: $color-sdg13; }
+ .background-color-sdg16 { background-color: $color-sdg16; }
+ .background-color-sdg17 { background-color: $color-sdg17; }

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -23,6 +23,7 @@
 // /**
 //  * Elements
 //  */
+@import 'elements/background-sdg-colors';
 @import 'elements/accordion';
 @import 'elements/buttons';
 @import 'elements/forms';


### PR DESCRIPTION
Fixes #4344 

### What changes did you make and why did you make them ?

WHAT CHANGES:
  - In the _sass/elements, create a new file: _background-sdg-colors.scss
  - In the _background-sdg-colors.scss file, I added the following:
```
.background-color-sdg2 { background-color: $color-sdg2; }
.background-color-sdg3 { background-color: $color-sdg3; }
.background-color-sdg4 { background-color: $color-sdg4; }
.background-color-sdg5 { background-color: $color-sdg5; }
.background-color-sdg8 { background-color: $color-sdg8; }
.background-color-sdg9 { background-color: $color-sdg9; }
.background-color-sdg10 { background-color: $color-sdg10; }
.background-color-sdg11 { background-color: $color-sdg11; }
.background-color-sdg13 { background-color: $color-sdg13; }
.background-color-sdg16 { background-color: $color-sdg16; }
.background-color-sdg17 { background-color: $color-sdg17; }
```
  -In the _sass/main.scss, under the Elements section, add the following import statement under the Elements section
`@import 'elements/background-sdg-colors';`

WHY WERE CHANGES MADE:
These changes were made so we can use these classes with their corresponding, matching SDG icons.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Only scss file was created and imported. Code changes made had no impact on look of website.
