### PR TITLE
Update labels: blank-issue-template(role,size,feature,complexity as missing)

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue-template.md
@@ -2,7 +2,7 @@
 name: Blank Issue Template
 about: 'Standard HackforLA issue template '
 title: ''
-labels: []
+labels: ['role missing', 'Feature Missing', 'Complexity: Missing', 'size: missing']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/blank-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue-template.md
@@ -15,6 +15,4 @@ REPLACE THIS TEXT - List the research to be done, or the steps to be completed.
 Note: If the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task.
 
 ### Resources/Instructions
-<!-- REPLACE THIS TEXT - Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc. -->
-HLFA site new issue template labels
-https://docs.google.com/spreadsheets/d/1Gq6obyqDy9wgoymnlP-smQUXEvGfhgjGSCyMvgS4rRA/edit#gid=0
+REPLACE THIS TEXT - Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc.

--- a/.github/ISSUE_TEMPLATE/blank-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue-template.md
@@ -2,7 +2,7 @@
 name: Blank Issue Template
 about: 'Standard HackforLA issue template '
 title: ''
-labels: ''
+labels: []
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/blank-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue-template.md
@@ -15,4 +15,6 @@ REPLACE THIS TEXT - List the research to be done, or the steps to be completed.
 Note: If the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task.
 
 ### Resources/Instructions
-REPLACE THIS TEXT - Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc.
+<!-- REPLACE THIS TEXT - Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc. -->
+HLFA site new issue template labels
+https://docs.google.com/spreadsheets/d/1Gq6obyqDy9wgoymnlP-smQUXEvGfhgjGSCyMvgS4rRA/edit#gid=0


### PR DESCRIPTION
Fixes #4503

### What changes did you make and why did you make them ?

  - added labels for blank-issue-template.md, so that we can avoid GitHub bot taking off the labels when devs add them to issues
  -  added URL of the issue template into the Resources section of the issue, replacing the text: https://github.com/kiwookim/website/issues/new?assignees=&labels=role+missing%2CFeature+Missing%2CComplexity%3A+Missing%2Csize%3A+missing&projects=&template=blank-issue-template.md&title=

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>No visual changes to the website</summary>


</details>


