### PR TITLE
Update the GitHub resource name for the Access the data project

### DIFF
--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -59,7 +59,7 @@ leadership:
       github: 'https://github.com/TonyDelgadoWillis'
     picture: https://avatars.githubusercontent.com/TonyDelgadoWillis
 links:
-  - name: Github
+  - name: GitHub
     url: 'https://github.com/hackforla/access-the-data/'
   - name: Slack
     url: 'https://hackforla.slack.com/archives/C01L2ANCG6M'


### PR DESCRIPTION
Fixes #4685 

### What changes did you make and why did you make them ?

  - inside `_projects/access-the-data.md` file in `links array`, I changed the liquid variable `name` from `- name: Github` to - name: GitHub

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/5314153/237906777-fc8a1b9e-908a-4b9b-b00d-9edea6ab0515.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/5314153/237907238-fd64e92d-8479-4ea2-ad8d-fb3ff1702cda.png)

</details>
