### PR TITLE
Refactored HTML to remove space slash for shield.png img element alt

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -124,7 +124,7 @@ permalink: /getting-started
 
                 <ol class="column-ol-list">
                     <div class="list-container">
-                        <img class="step-img-icon" src="assets/images/getting-started/shield.png" alt="" />
+                        <img class="step-img-icon" src="assets/images/getting-started/shield.png" alt="">
                         <li class="g-s-list">Set up GitHub <a href="/guide-pages/2FA.html" target="_blank">two-factor
                             authentication</a>.
                         </li>


### PR DESCRIPTION
Fixes #4399

### What changes did you make and why did you make them ?

-Changed an img HTML tag ending with a slash (<img.../>) to an img tag without an ending slash (<img...>) so that the codebase is consistent with how we use img HTML tags.

-Specific Tag Changed: `<img class="step-img-icon" src="assets/images/getting-started/shield.png" alt="" />`

-File: pages/getting-started.html

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No visual changes to the website. (Confirmed with Docker)

