### PR TITLE
Added empty alt attribute to hero image within project layout header

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <header class='project-hero'>
-    <img src="/assets/images/projects/gradient-background.png" class="gradient-background">
+    <img src="/assets/images/projects/gradient-background.png" class="gradient-background" alt="">
     <h1 class='hero-inner title1'>{{ page.title }}</h1>
 </header>
 
@@ -173,7 +173,7 @@ layout: default
       height="100%"
       style="margin: 0; border: 2px solid color-mediumdarkcyanblue; box-sizing: border-box">
       </iframe>
-    </div>    
+    </div>
     {% endif %}
 </div>
 


### PR DESCRIPTION
Fixes #4670

### What changes did you make and why did you make them ?

-Added empty alt attribute to an img HTML tag.

-Specific Tag Changed: `<img src="/assets/images/projects/gradient-background.png" class="gradient-background">`

-File: ` _layouts/project.html`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No visual changes to the website. (Confirmed with Docker)
