### PR TITLE
Add bottom margin to arrow element to fix alignment of paragraph

### DIFF
--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -112,7 +112,7 @@
   color: $color-black;
   font-weight: normal;
   font-size: 18px;
-  margin: 0 6px 60px 6px;
+  margin: 0 6px 65px 6px;
 
   @media #{$bp-below-desktop} {
     content: "\226A";

--- a/_sass/components/_events.scss
+++ b/_sass/components/_events.scss
@@ -112,7 +112,7 @@
   color: $color-black;
   font-weight: normal;
   font-size: 18px;
-  margin: 0 6px;
+  margin: 0 6px 60px 6px;
 
   @media #{$bp-below-desktop} {
     content: "\226A";


### PR DESCRIPTION
Fixes #4552 

### What changes did you make and why did you make them ?

  - added a bottom margin to the arrow w/ id `#head-content::before` which solved the issue where the paragraph text appeared under the arrow when the dimensions of the window changed

### Screenshots of Proposed Changes Of The Website  

<details>
<summary>Visuals before changes are applied - GIF </summary>

![before_changes](https://github.com/hackforla/website/assets/92699502/a6632520-becd-46b7-9e16-502961c1d54e)

</details>

<details>
<summary>Visuals after changes are applied - GIF </summary>

![after_changes](https://github.com/hackforla/website/assets/92699502/5ba0e4fe-4226-4b25-9cbf-7715132960d5)

</details>
