### PR TITLE
Reverts red filter tags on "Projects" and "Home Page" to prior location

### DIFF
--- a/_includes/current-projects.html
+++ b/_includes/current-projects.html
@@ -18,6 +18,7 @@
           </svg>
         </button>
       </h3>
+      <div class="filter-tag-container"></div>
       <ul class="filter-list" id="filter-list"></ul>
       <div class="mobile-filter-buttons">
         <button class="cancel-mobile-filters btn-md btn-dark">
@@ -30,7 +31,6 @@
     </div>
   </nav>
   <div class="projects-and-filters">
-    <div class="filter-tag-container top-filter"></div>
     <div class="page-contain projects-inner" >
       <ul class="project-list unstyled-list"></ul>
     </div>

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -35,7 +35,7 @@ a.filter-item {
 }
 
 .filtersDiv {
-  min-width: 390px;
+  width: 390px;
 }
 
 //filter container
@@ -175,7 +175,8 @@ border-radius: 2.5px;
 }
 .filter-tag-container {
   display: flex;
-  flex-direction: column;
+  // flex-direction: column;
+  flex-wrap: wrap;
   list-style: none;
   padding: 0 0 10px 0;
 }

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -43,7 +43,7 @@ a.filter-item {
 }
 
 .filtersDiv {
-  min-width: 282px;
+  min-width: 390px;
 }
 
 //filter container

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -35,7 +35,7 @@ a.filter-item {
 }
 
 .filtersDiv {
-  width: 390px;
+  min-width:282px;
 }
 
 //filter container
@@ -175,8 +175,7 @@ border-radius: 2.5px;
 }
 .filter-tag-container {
   display: flex;
-  // flex-direction: column;
-  flex-wrap: wrap;
+  flex-direction: column;
   list-style: none;
   padding: 0 0 10px 0;
 }

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -20,14 +20,6 @@ section.filter-content-container {
 .page-contain.projects-inner.curr-projects {
   margin: 0px auto;
 }
-.filter-tag-container.top-filter {
-  display: flex;
-  flex-wrap: wrap;
-  list-style: none;
-  padding: 0 0 10px 0;
-  max-width: 800px;
-  flex-direction: row;
-}
 
 a.filter-item {
   text-decoration: none;

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -381,6 +381,10 @@ function updateFilterTagDisplayState(filterParams){
         })
 
     }
+
+    if (Object.entries(filterParams). length > 0) {
+        document.querySelector('.filter-tag-container').insertAdjacentHTML('afterbegin', `<h4 class="applied-filters">Applied Filters</h4>`)
+    }
 }
 
     /**

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -383,7 +383,7 @@ function updateFilterTagDisplayState(filterParams){
     }
 
     if (Object.entries(filterParams). length > 0) {
-        document.querySelector('.filter-tag-container').insertAdjacentHTML('afterbegin', `<h4 class="applied-filters">Applied Filters</h4>`)
+        document.querySelector('.filter-tag-container').insertAdjacentHTML('beforebegin', `<h4 class="applied-filters">Applied Filters</h4>`)
     }
 }
 

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -383,7 +383,7 @@ function updateFilterTagDisplayState(filterParams){
     }
 
     if (Object.entries(filterParams). length > 0) {
-        document.querySelector('.filter-tag-container').insertAdjacentHTML('beforebegin', `<h4 class="applied-filters">Applied Filters</h4>`)
+        document.querySelector('.filter-tag-container').insertAdjacentHTML('afterbegin', `<h4 class="applied-filters">Applied Filters</h4>`)
     }
 }
 


### PR DESCRIPTION
Fixes #4753 

### What changes did you make and why did you make them ?

  - moved the filters tab to the sidebar to allow for a future search bar
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

 /# and /projects

![image](https://github.com/hackforla/website/assets/73868258/577293b7-1354-4d43-a160-e2becc730018)


/projects-check

![image](https://github.com/hackforla/website/assets/73868258/aa6c0b8f-19e7-4fa7-9167-49d3112e8b2c)


</details>

<details>
<summary>Visuals after changes are applied</summary>
 /# and /projects
 
![image](https://github.com/hackforla/website/assets/73868258/dae59b79-8cc3-4fda-80d3-084bb436500e)

/projects-check

![image](https://github.com/hackforla/website/assets/73868258/936a81d0-3454-47c9-a858-28b7d415681b)


</details>
