### PR TITLE
refrac: updated small label to avoid github bot removing the label

### DIFF
--- a/.github/ISSUE_TEMPLATE/creating-a-yml-file-for-a-sdg.md
+++ b/.github/ISSUE_TEMPLATE/creating-a-yml-file-for-a-sdg.md
@@ -2,7 +2,7 @@
 name: Creating a yml file for a SDG
 about: Creating a yml file for a SDG (Sustainable Development Goal)
 title: Creating a yml file for SDG [INSERT SDG NUMBER HERE]
-labels: 'Complexity: Small, p-feature: SDGs, role: front end, size: 0.25pt'
+labels: ['Complexity: Small','p-feature: SDGs','role: front end','size: 0.25pt']
 assignees: ''
 
 ---


### PR DESCRIPTION
Fixes #replace_this_text_with_the_issue_number

### What changes did you make and why did you make them ?

  -made the labels description into an array to avoid the github bot from removing the label

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

-No visual change

