### PR TITLE
Updated viewport widths

### DIFF
--- a/_sass/variables/_layout.scss
+++ b/_sass/variables/_layout.scss
@@ -17,13 +17,13 @@ $screen-mobile: 480px;
  * anything below a tablet, use $bp-below-tablet.
  */
 $bp-desktop-large-up: '(min-width: #{$screen-desktop-large})';
-$bp-below-desktop-large: '(max-width: #{$screen-desktop-large - 1})';
+$bp-below-desktop-large: '(max-width: #{$screen-desktop-large - .02})';
 $bp-desktop-up: '(min-width: #{$screen-desktop})';
-$bp-below-desktop: '(max-width: #{$screen-desktop - 1})';
+$bp-below-desktop: '(max-width: #{$screen-desktop - .02})';
 $bp-tablet-up: '(min-width: #{$screen-tablet})';
-$bp-below-tablet: '(max-width: #{$screen-tablet - 1})';
+$bp-below-tablet: '(max-width: #{$screen-tablet - .02})';
 $bp-mobile-up: '(min-width: #{$screen-mobile})';
-$bp-below-mobile: '(max-width: #{$screen-mobile - 1})';
+$bp-below-mobile: '(max-width: #{$screen-mobile - .02})';
 
 /**
  * Magic Numbers


### PR DESCRIPTION
Fixes #3975 

In  `Sass/variables/_layout.scss`, I changed the fractional viewport value from `-1` to `-.02` on the following variables:
`$bp-below-desktop-large: '(max-width: #{$screen-desktop-large - .02})'`
`$bp-below-desktop: '(max-width: #{$screen-desktop - .02})';`
`$bp-below-tablet: '(max-width: #{$screen-tablet - .02})';`
`$bp-below-mobile: '(max-width: #{$screen-mobile - .02})';`



### Screenshots of Proposed Changes Of The Website  


<summary>Visuals before changes are applied</summary>

![nav_before_changes](https://github.com/hackforla/website/assets/44750931/e4ab1995-d4e1-4992-bc15-e7e4fc9360cb)









<summary>Visuals after changes are applied</summary>
  
![after_nav_changes](https://github.com/hackforla/website/assets/44750931/f2c586d5-504b-4c7f-9bfe-f11429198cb0)

I continued testing across the website in Docker, loading every route. During testing, I observed no unexpected visual changes. The header and nav displayed correctly with the new changes across every page on the website.


