### PR TITLE
Check dependabot version updates to pr-instructions.yml 4825

### DIFF
--- a/.github/workflows/pr-instructions.yml
+++ b/.github/workflows/pr-instructions.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'gh-pages'
       - 'feature-homepage-launch'
-      - 'check-version-updates-4825'
 
 jobs:
   Add-Pull-Request-Instructions:

--- a/.github/workflows/pr-instructions.yml
+++ b/.github/workflows/pr-instructions.yml
@@ -5,16 +5,17 @@ on:
     branches:
       - 'gh-pages'
       - 'feature-homepage-launch'
+      - 'check-version-updates-4825'
 
 jobs:
   Add-Pull-Request-Instructions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Create the message to post
       - name: Create Instruction
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         id: instruction
         with:
           script: |


### PR DESCRIPTION
Fixes #4825 

### What changes did you make and why did you make them ?

  - Tested updating the package version in the file `pr-instructions.yml` per the dependabot suggestions:
    - Tested changing `uses: actions/github-script@v4` with `uses: actions/github-script@v6` per 4734
    - Tested changing `uses: actions/checkout@v2` with `uses: actions/checkout@v3` per 4735
    - The test changing both versions at same time passed successfully- the PR instructions were added to newly created PR as they are supposed to.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Changes effect GHAs only