### PR TITLE
Check dependabot version updates to schedule-fri-0700.yml 4827

### DIFF
--- a/.github/workflows/schedule-fri-0700.yml
+++ b/.github/workflows/schedule-fri-0700.yml
@@ -3,6 +3,7 @@ name: Schedule Friday 0700
 on:
   schedule:
     - cron:  '0 7 * * 5'
+  workflow_dispatch:
 
 jobs:
   Add-Update-Label-to-Issues-Weekly:
@@ -11,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v4
         env:
-          IN_PROGRESS_COLUMN_ID: ${{ secrets.IN_PROGRESS_COLUMN_ID }}
+          IN_PROGRESS_COLUMN_ID: ${{ 19304957 }}
         with:
           script: |
             const { IN_PROGRESS_COLUMN_ID } = process.env;

--- a/.github/workflows/schedule-fri-0700.yml
+++ b/.github/workflows/schedule-fri-0700.yml
@@ -3,15 +3,16 @@ name: Schedule Friday 0700
 on:
   schedule:
     - cron:  '0 7 * * 5'
+  workflow_dispatch:
 
 jobs:
   Add-Update-Label-to-Issues-Weekly:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/github-script@v4
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
         env:
-          IN_PROGRESS_COLUMN_ID: ${{ secrets.IN_PROGRESS_COLUMN_ID }}
+          IN_PROGRESS_COLUMN_ID: ${{ 19304957 }}
         with:
           script: |
             const { IN_PROGRESS_COLUMN_ID } = process.env;

--- a/.github/workflows/schedule-fri-0700.yml
+++ b/.github/workflows/schedule-fri-0700.yml
@@ -3,7 +3,6 @@ name: Schedule Friday 0700
 on:
   schedule:
     - cron:  '0 7 * * 5'
-  workflow_dispatch:
 
 jobs:
   Add-Update-Label-to-Issues-Weekly:
@@ -12,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v4
         env:
-          IN_PROGRESS_COLUMN_ID: ${{ 19304957 }}
+          IN_PROGRESS_COLUMN_ID: ${{ secrets.IN_PROGRESS_COLUMN_ID }}
         with:
           script: |
             const { IN_PROGRESS_COLUMN_ID } = process.env;

--- a/.github/workflows/schedule-fri-0700.yml
+++ b/.github/workflows/schedule-fri-0700.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v5
         env:
           IN_PROGRESS_COLUMN_ID: ${{ 19304957 }}
         with:

--- a/.github/workflows/schedule-fri-0700.yml
+++ b/.github/workflows/schedule-fri-0700.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v4
         env:
           IN_PROGRESS_COLUMN_ID: ${{ 19304957 }}
         with:

--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -7,9 +7,9 @@ var context;
 const statusUpdatedLabel = 'Status: Updated';
 const toUpdateLabel = 'To Update !';
 const inactiveLabel = '2 weeks inactive';
-const updatedByDays = 3; // If there is an update within 3 days, the issue is considered updated
-const inactiveUpdatedByDays = 14; // If no update within 14 days, the issue is considered '2 weeks inactive'
-const commentByDays = 7; // If there is an update within 14 days but no update within 7 days, the issue is considered outdated and the assignee needs 'To Update !' it
+const updatedByDays = 0.002; // If there is an update within 3 days, the issue is considered updated
+const inactiveUpdatedByDays = .006; // If no update within 14 days, the issue is considered '2 weeks inactive'
+const commentByDays = .004; // If there is an update within 14 days but no update within 7 days, the issue is considered outdated and the assignee needs 'To Update !' it
 const threeDayCutoffTime = new Date()
 threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays)
 const sevenDayCutoffTime = new Date()

--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -7,9 +7,9 @@ var context;
 const statusUpdatedLabel = 'Status: Updated';
 const toUpdateLabel = 'To Update !';
 const inactiveLabel = '2 weeks inactive';
-const updatedByDays = 0.002; // If there is an update within 3 days, the issue is considered updated
-const inactiveUpdatedByDays = .006; // If no update within 14 days, the issue is considered '2 weeks inactive'
-const commentByDays = .004; // If there is an update within 14 days but no update within 7 days, the issue is considered outdated and the assignee needs 'To Update !' it
+const updatedByDays = 3; // If there is an update within 3 days, the issue is considered updated
+const inactiveUpdatedByDays = 14; // If no update within 14 days, the issue is considered '2 weeks inactive'
+const commentByDays = 7; // If there is an update within 14 days but no update within 7 days, the issue is considered outdated and the assignee needs 'To Update !' it
 const threeDayCutoffTime = new Date()
 threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays)
 const sevenDayCutoffTime = new Date()


### PR DESCRIPTION
Fixes #4827 

### What changes did you make and why did you make them ?

  - Tested updating the package versions in the file `schedule-fri-0700.yml` per the dependabot suggestions:
    - Tested changing `uses: actions/github-script@v4` with `uses: actions/github-script@v6` per 4734
    - Tested changing `uses: actions/checkout@v2` with `uses: actions/checkout@v3` per 4735
    - The test changing both versions at same time logged a successful run, however the action did not execute as expected. Additional testing showed that updating `uses: actions/github-script@v4` effects the performance of the GHA and we should not update this file to the new version. The other update appears to be OK.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Changes effect GHAs only
