### PR TITLE
Check dependabot version updates to lint-scss.yml 4823

### DIFF
--- a/.github/workflows/lint-scss.yml
+++ b/.github/workflows/lint-scss.yml
@@ -2,9 +2,9 @@ name: Lint SCSS
 
 on:
   pull_request:
-    branches: [gh-pages]
+    branches: [gh-pages, check-version-updates-4823]
   push:
-    branches: [gh-pages]
+    branches: [gh-pages, check-version-updates-4823]
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -22,8 +22,8 @@ jobs:
         uses: github/super-linter@v4.8.1
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: gh-pages
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: check-version-updates-4823
+          GITHUB_TOKEN: ${{ secrets.TEST_GHAS }}
 
 
           LINTER_RULES_PATH: /

--- a/.github/workflows/lint-scss.yml
+++ b/.github/workflows/lint-scss.yml
@@ -2,9 +2,9 @@ name: Lint SCSS
 
 on:
   pull_request:
-    branches: [gh-pages, check-version-updates-4823]
+    branches: [gh-pages]
   push:
-    branches: [gh-pages, check-version-updates-4823]
+    branches: [gh-pages]
 
 jobs:
   build:
@@ -22,8 +22,8 @@ jobs:
         uses: github/super-linter@v4.8.1
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: check-version-updates-4823
-          GITHUB_TOKEN: ${{ secrets.TEST_GHAS }}
+          DEFAULT_BRANCH: gh-pages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
           LINTER_RULES_PATH: /


### PR DESCRIPTION
Fixes #4823 

### What changes did you make and why did you make them ?

  - Tested updating the package version in the `lint-scss.yml` file per the dependabot suggestions:
    - Tested changing `uses: actions/checkout@v2` with `uses: actions/checkout@v3` per 4735
    - It appears that updating to  `uses: actions/checkout@v3` does not effect the linter. After the update the linter still ran upon creating a PR and pushing a new issue.
    
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals showing linter running during testing</summary>

![4823_linter successful](https://github.com/hackforla/website/assets/40799239/1430fcc0-26bc-4793-b312-00cf0efc5857)
![4823_linter successful2](https://github.com/hackforla/website/assets/40799239/90819ae6-bb49-437d-9c04-4675d65a6457)
![4823_linter successful3](https://github.com/hackforla/website/assets/40799239/6400288d-f9a2-4fe5-a15d-89a5ac8b9574)

</details>

