### PR TITLE
Check dependabot version updates to set-pr-labels.yaml 4828

### DIFF
--- a/.github/workflows/set-pr-labels.yaml
+++ b/.github/workflows/set-pr-labels.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - 'gh-pages'
       - 'feature-homepage-launch'
+      - 'check-version-updates-4828'
 
 jobs:
   generate-labels-artifact:
@@ -16,17 +17,17 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
       SCRIPT_PATH: './github-actions/trigger-pr/set-pr-labels.js'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: parse-pr-body
         name: 'Parse the pull request body for all linked issues'
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const { listIssuesFromPRBody } = require('${{ env.SCRIPT_PATH }}');
             return listIssuesFromPRBody({ context, core });
       - id: compile-labels
         name: 'Compile labels from linked issues'
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const { listLabelsFromIssues } = require('${{ env.SCRIPT_PATH }}');

--- a/.github/workflows/set-pr-labels.yaml
+++ b/.github/workflows/set-pr-labels.yaml
@@ -6,7 +6,6 @@ on:
     branches:
       - 'gh-pages'
       - 'feature-homepage-launch'
-      - 'check-version-updates-4828'
 
 jobs:
   generate-labels-artifact:


### PR DESCRIPTION
Fixes #4828

### What changes did you make and why did you make them ?

  - Tested updating the package version in the file `set-pr-labels.yaml` per the dependabot suggestions:
    - Tested changing `uses: actions/github-script@v4` with `uses: actions/github-script@v6` per 4734
    - Tested changing `uses: actions/checkout@v2` with `uses: actions/checkout@v3` per 4735
    - The test changing both versions at same time passed successfully- the issue labels were transferred to the linked PR as they are supposed to.
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals showing automation executing correctly with updated version numbers</summary>

![4828_set-pr-self_repo2](https://github.com/hackforla/website/assets/40799239/5edda593-658d-4a52-bcb7-358e80a03bed)

</details>

