### PR TITLE
Check dependabot version update to vrms-data.yml 4829

### DIFF
--- a/.github/workflows/vrms-data.yml
+++ b/.github/workflows/vrms-data.yml
@@ -10,12 +10,12 @@ jobs:
   vrms_data:
     runs-on: ubuntu-latest
 
-    if: github.repository == 'hackforla/website'
+    if: github.repository == 't-will-gillis/website'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
-        token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
+        token: ${{ secrets.TEST_GHAS }}
 
     # Use an action (`my-action`) in your repository
     - name: Save vrms_data.json

--- a/.github/workflows/vrms-data.yml
+++ b/.github/workflows/vrms-data.yml
@@ -10,12 +10,12 @@ jobs:
   vrms_data:
     runs-on: ubuntu-latest
 
-    if: github.repository == 't-will-gillis/website'
+    if: github.repository == 'hackforla/website'
 
     steps:
     - uses: actions/checkout@v3
       with:
-        token: ${{ secrets.TEST_GHAS }}
+        token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN  }}
 
     # Use an action (`my-action`) in your repository
     - name: Save vrms_data.json

--- a/.github/workflows/vrms-data.yml
+++ b/.github/workflows/vrms-data.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN  }}
+        token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
 
     # Use an action (`my-action`) in your repository
     - name: Save vrms_data.json


### PR DESCRIPTION
Fixes #4829 

### What changes did you make and why did you make them ?

  - Tested updating the package version in the file `vrms-data.yml` per the dependabot suggestions:
    - Tested changing `uses: actions/checkout@v2` with `uses: actions/checkout@v3` per 4735
    - The test changing the `actions/checkout@v2` to `@v3` was successful- the vrms data was created. The previous 'node deprecation' warning is also removed. 
    
 ### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visual of current HfLA VRMS action</summary>

![4829_vrms-data-hfla](https://github.com/hackforla/website/assets/40799239/cc3821be-1728-4733-981b-b09420e75176)

</details>

<details>
<summary>Visual of successful test after version update</summary>
  
![4829_vrms-data](https://github.com/hackforla/website/assets/40799239/37ed0080-60c3-4b16-85dc-4f7fb4db8cfe)

</details>
