### PR TITLE
Check dependabot version updates to wr-pr-instructions.yml 4830

### DIFF
--- a/.github/workflows/wr-pr-instructions.yml
+++ b/.github/workflows/wr-pr-instructions.yml
@@ -44,7 +44,7 @@ jobs:
             const artifactJSON = JSON.parse(artifact);
             return artifactJSON
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Create the message to post
       - name: Post Comment
         uses: actions/github-script@v4


### PR DESCRIPTION
Fixes #4830 

### What changes did you make and why did you make them ?

  - Tested updating the package version in the file `wr-pr-instructions.yml` per the dependabot suggestions:
    - Tested changing `uses: actions/github-script@v4` with `uses: actions/github-script@v6` per 4734
    - Tested changing `uses: actions/checkout@v2` with `uses: actions/checkout@v3` per 4735
    - The test for updating `uses: actions/github-script@v4` FAILS. Updating this package breaks the GHA and therefore this should not be updated. The test changing `uses: actions/checkout@v2` with `uses: actions/checkout@v3` appears to be successful.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
None