### PR TITLE
Check dependabot version updates to wr-set-pr-labels.yml 4831

### DIFF
--- a/.github/workflows/set-pr-labels.yaml
+++ b/.github/workflows/set-pr-labels.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - 'gh-pages'
       - 'feature-homepage-launch'
+      - 'check-version-updates-4831'
 
 jobs:
   generate-labels-artifact:
@@ -16,17 +17,17 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
       SCRIPT_PATH: './github-actions/trigger-pr/set-pr-labels.js'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: parse-pr-body
         name: 'Parse the pull request body for all linked issues'
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const { listIssuesFromPRBody } = require('${{ env.SCRIPT_PATH }}');
             return listIssuesFromPRBody({ context, core });
       - id: compile-labels
         name: 'Compile labels from linked issues'
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const { listLabelsFromIssues } = require('${{ env.SCRIPT_PATH }}');

--- a/.github/workflows/set-pr-labels.yaml
+++ b/.github/workflows/set-pr-labels.yaml
@@ -6,7 +6,6 @@ on:
     branches:
       - 'gh-pages'
       - 'feature-homepage-launch'
-      - 'check-version-updates-4831'
 
 jobs:
   generate-labels-artifact:
@@ -17,17 +16,17 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
       SCRIPT_PATH: './github-actions/trigger-pr/set-pr-labels.js'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       - id: parse-pr-body
         name: 'Parse the pull request body for all linked issues'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v5
         with:
           script: |
             const { listIssuesFromPRBody } = require('${{ env.SCRIPT_PATH }}');
             return listIssuesFromPRBody({ context, core });
       - id: compile-labels
         name: 'Compile labels from linked issues'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v5
         with:
           script: |
             const { listLabelsFromIssues } = require('${{ env.SCRIPT_PATH }}');

--- a/.github/workflows/wr-set-pr-labels.yaml
+++ b/.github/workflows/wr-set-pr-labels.yaml
@@ -24,10 +24,10 @@ jobs:
       ARTIFACT_NAME: 'pr-labels'
       SCRIPT_PATH: './github-actions/trigger-pr/set-pr-labels.js'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: download-artifact
         name: 'Download artifact'
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const { downloadLabelsArtifact } = require('${{ env.SCRIPT_PATH }}');
@@ -37,7 +37,7 @@ jobs:
         run: unzip '${{ env.ARTIFACT_NAME }}.zip'
       - id: set-pr-labels
         name: 'Set labels on the pull request'
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const { setLabelsOnPR } = require('${{ env.SCRIPT_PATH }}');


### PR DESCRIPTION
Fixes #4831 

### What changes did you make and why did you make them ?

  - Tested updating the package version in the file `wr-set-pr-labels.yml` per the dependabot suggestions:
    - Tested changing `uses: actions/github-script@v4` with `uses: actions/github-script@v6` per 4734
    - Tested changing `uses: actions/checkout@v2` with `uses: actions/checkout@v3` per 4735
    - The test changing both versions at same time passed successfully- the PR labels were added to newly created PR as they are supposed to.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
None