### PR TITLE
Fixed overflowing child component #4551

### DIFF
--- a/_sass/components/_program-areas.scss
+++ b/_sass/components/_program-areas.scss
@@ -70,7 +70,7 @@
     font-size: 13px;
     line-height: 15.23px;
     text-align: center;
-
+    overflow: hidden;
 
     .project-card-mini-image{
         width: inherit;


### PR DESCRIPTION
Fixes #4551 

### What changes did you make?
  - Stopped child div from overflowing parent div's border

### Why did you make the changes (we will use this info to test)?
  - modified CSS to include overflow: hidden
  - Docker can be used to test


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<details>
<summary>Current State: </summary>
<img width="405" alt="screenshot of current state of card" src="https://github.com/hackforla/website/assets/104275658/7c22f2d5-b011-423c-b216-e070dccca908">

</details>

<details>
<summary>Figma reference: </summary>
<img width="405" alt="screenshot of figma reference of card" src="https://github.com/hackforla/website/assets/104275658/ae04b11e-bd7c-428a-b8d4-b9730436a47a">
</details>

<details>
<summary>Proposed change: </summary>
<img width="357" alt="screenshot of proposed change on card" src="https://github.com/hackforla/website/assets/104275658/97c50736-4fcc-477c-91ff-b42415e94a11">
</details>

