### PR TITLE
Widen filter div to prevent truncation of filter names

### DIFF
--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -43,7 +43,7 @@ a.filter-item {
 }
 
 .filtersDiv {
-  min-width: 282px;
+  min-width: 330px;
 }
 
 //filter container
@@ -160,7 +160,7 @@ border-radius: 2.5px;
   transform: rotate(135deg);
   transform-origin: 64% 50%;
   bottom: auto;
-  top: 0; 
+  top: 0;
   right: 5%;
   font-size: 24px;
   position: absolute;
@@ -268,8 +268,8 @@ a.clear-filter-tags {
     border: 1px solid $color-mediumgrey;
     border-radius: 5px;
     padding: 5px 8px;
-    font-size: 16px;  
-    font-weight: 400; 
+    font-size: 16px;
+    font-weight: 400;
   }
   .filter-toolbar.show-filters .filters-title {
     width: 100%;
@@ -295,7 +295,7 @@ a.clear-filter-tags {
     display: inline-block;
     border: none;
   }
-  
+
   .filter-toolbar.show-filters ul.filter-list {
     display: flex;
     padding: 0 12px;
@@ -329,7 +329,7 @@ a.clear-filter-tags {
   transform: rotate(-45deg);
   transform-origin: 36% 50%;
   bottom: 0;
-  top: auto; 
+  top: auto;
   font-size: 24px;
   position: absolute;
   right: 21px;


### PR DESCRIPTION
Fixes #4784

### What changes did you make?
  - changed .filtersDiv min-width from 282 to 330px  (file-->_sass/elements/_dropdown_filters.scss)
  
### Why did you make the changes (we will use this info to test)?
  - For preventing truncation of filter names when displayed on a filter tag, for tablet and smaller screen sizes
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
screen size 768 x 835 b/f changes

![Screenshot 2023-06-23 123507](https://github.com/hackforla/website/assets/95503033/bbec381c-0327-493c-a657-385012b26351)

screen size 768 x 1250 b/f changes
![Screenshot 2023-06-23 124751](https://github.com/hackforla/website/assets/95503033/27bab80f-ac14-4a68-a610-b61d7cb18608)



</details>

<details>
<summary>Visuals after changes are applied</summary>
screen size 768 x 835 after changes

![Screenshot 2023-06-23 123410](https://github.com/hackforla/website/assets/95503033/73f6d651-8d7f-4954-acc7-a34f7e606da7)

screen size 768 x 1250 after changes
![Screenshot 2023-06-23 125041](https://github.com/hackforla/website/assets/95503033/8f09a416-448f-4510-8834-9ae462efc4d8)


</details>
