### PR TITLE
Widen filter div --- edit

### DIFF
--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -35,7 +35,7 @@ a.filter-item {
 }
 
 .filtersDiv {
-  min-width:282px;
+  min-width:330px;
 }
 
 //filter container
@@ -152,7 +152,7 @@ border-radius: 2.5px;
   transform: rotate(135deg);
   transform-origin: 64% 50%;
   bottom: auto;
-  top: 0; 
+  top: 0;
   right: 5%;
   font-size: 24px;
   position: absolute;
@@ -260,8 +260,8 @@ a.clear-filter-tags {
     border: 1px solid $color-mediumgrey;
     border-radius: 5px;
     padding: 5px 8px;
-    font-size: 16px;  
-    font-weight: 400; 
+    font-size: 16px;
+    font-weight: 400;
   }
   .filter-toolbar.show-filters .filters-title {
     width: 100%;
@@ -287,7 +287,7 @@ a.clear-filter-tags {
     display: inline-block;
     border: none;
   }
-  
+
   .filter-toolbar.show-filters ul.filter-list {
     display: flex;
     padding: 0 12px;
@@ -321,7 +321,7 @@ a.clear-filter-tags {
   transform: rotate(-45deg);
   transform-origin: 36% 50%;
   bottom: 0;
-  top: auto; 
+  top: auto;
   font-size: 24px;
   position: absolute;
   right: 21px;


### PR DESCRIPTION
Fixes #4784

### What changes did you make?
  - changed .filtersDiv min-width from 282px to 330px (file: _sass/elements/_dropdown_filters.scss)


### Why did you make the changes (we will use this info to test)?
  - purpose of this is to prevent truncation of filter names when displayed on a filter tag for tablet and smaller screen sizes
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

screen size 768x1250 before changes
![Screenshot 2023-06-23 130021](https://github.com/hackforla/website/assets/95503033/8c628a13-f123-414f-9e06-7efbfab7297c)

screen size 768x835 before changes
![Screenshot 2023-06-23 130051](https://github.com/hackforla/website/assets/95503033/fb2123f0-948f-43f4-82ca-8b4e295f72c4)


</details>

<details>
<summary>Visuals after changes are applied</summary>
screen size 768x1250 after changes

![Screenshot 2023-06-23 130131](https://github.com/hackforla/website/assets/95503033/72ab86dd-c8a1-41c0-af0b-cfc72e972852)

screen size 768x835 after changes

![Screenshot 2023-06-23 130118](https://github.com/hackforla/website/assets/95503033/4d783eba-7e45-4c42-aa00-b0a8974ab34c)



</details>
