### PR TITLE
Check dependabot version updates to schedule-daily-1100.yml 4826, rev

### DIFF
--- a/.github/workflows/schedule-daily-1100.yml
+++ b/.github/workflows/schedule-daily-1100.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
     


### PR DESCRIPTION
Changes per 4826

Fixes #4826 

### What changes did you make?
- Replacement for previously approved PR #4837
- Tested updating the package version in the file `schedule-daily-1100.yml` per the dependabot suggestions:
  - Tested changing `uses: actions/checkout@v2` with `uses: actions/checkout@v3` per 4735
  - It appears that updating to  `uses: actions/checkout@v3` does not effect the GHA- after the update the action still creates the `github-data.json` as intended.

### Why did you make the changes (we will use this info to test)?
  - This change was suggested as a version update to automation package in the GHA, test was successful. 


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
n/a