### PR TITLE
Added labels to gha-issues-template

### DIFF
--- a/.github/ISSUE_TEMPLATE/gha-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/gha-issue-template.yml
@@ -1,6 +1,6 @@
 name: "Github Actions"
 description: This is to create a new GHA
-labels: ['role missing', 'Complexity: Missing', 'Feature Missing', 'size: missing','Draft']
+labels: [role missing, Complexity: Missing, Feature Missing, size: missing, Draft]
 title: "Sample form for GitHub actions "
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/gha-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/gha-issue-template.yml
@@ -1,5 +1,6 @@
 name: "Github Actions"
 description: This is to create a new GHA
+labels: ['role missing', 'Complexity: Missing', 'Feature Missing', 'size: missing','Draft']
 title: "Sample form for GitHub actions "
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/gha-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/gha-issue-template.yml
@@ -1,6 +1,6 @@
 name: "Github Actions"
 description: This is to create a new GHA
-labels: [role missing, Complexity: Missing, Feature Missing, size: missing, Draft]
+labels: ['role missing', 'Complexity: Missing', 'Feature Missing', 'size: missing', 'Draft']
 title: "Sample form for GitHub actions "
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/gha-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/gha-issue-template.yml
@@ -1,6 +1,6 @@
 name: "Github Actions"
 description: This is to create a new GHA
-labels: ['role missing', 'Complexity: Missing', 'Feature Missing', 'size: missing', 'Draft']
+labels: ['role missing', 'Complexity: Missing', 'Feature: Board/GitHub Maintenance', 'Feature Missing', 'size: missing', 'Draft']
 title: "Sample form for GitHub actions "
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/gha-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/gha-issue-template.yml
@@ -1,6 +1,6 @@
 name: "Github Actions"
 description: This is to create a new GHA
-labels: ['role missing', 'Complexity: Missing', 'Feature: Board/GitHub Maintenance', 'Feature Missing', 'size: missing', 'Draft']
+labels: ['role missing', 'Complexity: Missing', 'Feature: Board/GitHub Maintenance', 'size: missing', 'Draft']
 title: "Sample form for GitHub actions "
 body:
   - type: input


### PR DESCRIPTION
Fixes #4475 

### What changes did you make?
Added `labels: ['role missing', 'Complexity: Missing', 'Feature: Github Board/ Maintenance', 'size: missing','Draft']` under `description:` in the `gha-issues-template` file found at `.github/gha-issues-template.yml`

### Why did you make the changes (we will use this info to test)?
  To prevent Github Action bots from removing labels when moved to a different column in the project board

### Testing

[Click here](https://github.com/one2code/website/issues/new?assignees=&labels=role+missing%2CComplexity%3A+Missing%2CFeature%3A+Board%2FGitHub+Maintenance%2Csize%3A+missing%2CDraft&projects=&template=gha-issue-template.yml&title=Sample+form+for+GitHub+actions+)  to test the labels on the gha-issues-template in my repo. And refer to [this comment](https://github.com/hackforla/website/issues/4475#issuecomment-1610674971) if you would like to push this branch up to your repo and test it there as well.

- [ ] Copy these sections from the Issue into the PR 
  - [ ] "For PR Reviewers and Merge Team"
  - [ ] "Link for Reviewers"
  - [ ] "For PM, Merge Team, or Tech Lead"