### PR TITLE
fix-bug-add-label-js-4898

### DIFF
--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -309,7 +309,6 @@ function formatComment(assignees, labelString) {
     dateStyle: 'full',
     timeStyle: 'short',
     timeZone: 'America/Los_Angeles',
-    timeZoneName: 'short',
   }
   const cutoffTimeString = threeDayCutoffTime.toLocaleString('en-US', options);
   let completedInstuctions = text.replace('${assignees}', assignees).replace('${cutoffTime}', cutoffTimeString).replace('${label}', labelString);


### PR DESCRIPTION
Fixes #4898 

### What changes did you make?
  - Deleted line 312 from [add-label.js](https://github.com/hackforla/website/blob/gh-pages/github-actions/trigger-schedule/add-update-label-weekly/add-label.js) that is causing the current bug. 

### Why did you make the changes (we will use this info to test)?
  - The logs indicate that this is the source of the error/ why the comments are not printing: 
![error_msg](https://github.com/hackforla/website/assets/40799239/e7495889-fcb9-49cc-8292-90e1191c9126)


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied. Labels are displayed, comments are not</summary>


![before_fix_sch_fri_2](https://github.com/hackforla/website/assets/40799239/fa2087cb-16c2-44e9-9d5d-b79dad59cc59)

</details>

<details>
<summary>Visuals after changes are applied. Both labels and comments are displayed on issue</summary>
  
![after_fix_sch_fri](https://github.com/hackforla/website/assets/40799239/af89a0f0-9f51-46ce-b11c-068e87dcfb9d)

</details>

<details>
<summary>Visuals from four weeks ago. Both labels and comments are displayed on issue, note the time and date info and compare with 'Visuals after changes...'</summary>
  
![after_fix_sch_fri](https://github.com/hackforla/website/assets/40799239/af89a0f0-9f51-46ce-b11c-068e87dcfb9d)

</details>