### PR TITLE
Migration to GA4 - 3863

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-  
+    gtag('config', 'UA-167506267-1'); 
     gtag('config', 'G-QNFX2EYZC8');
   </script>
   <!-- End Google tag -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167506267-1">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167506267-1"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-QNFX2EYZC8"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167506267-1">
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,14 @@
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-QNFX2EYZC8"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+  
+    gtag('config', 'G-QNFX2EYZC8');
+  </script>
+  <!-- End Google tag -->
   <!-- Google Tag Manager -->
   <script>
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -8,7 +18,6 @@
     })(window,document,'script','dataLayer','GTM-PMQK7VL');
   </script>
   <!-- End Google Tag Manager -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167506267-1"></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'UA-167506267-1'); </script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,6 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', 'UA-167506267-1'); 
-    gtag('config', 'G-QNFX2EYZC8');
   </script>
   <!-- End Google tag -->
   <!-- Google Tag Manager -->

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -7,7 +7,6 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-167506267-1'); 
         gtag('config', 'G-QNFX2EYZC8');
     </script>
     <!-- End Google tag -->

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -8,7 +8,6 @@
       function gtag(){dataLayer.push(arguments);}  
       gtag('js', new Date());  
       gtag('config', 'UA-167506267-1'); 
-      gtag('config', 'G-QNFX2EYZC8');
     </script>
     <!-- End Google tag -->
     <link rel="canonical" href="{{ page.redirect_to }}"/>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -3,11 +3,11 @@
 <head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167506267-1"></script>
-    <script>  
-      window.dataLayer = window.dataLayer || [];   
-      function gtag(){dataLayer.push(arguments);}  
-      gtag('js', new Date());  
-      gtag('config', 'UA-167506267-1'); 
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-167506267-1');
     </script>
     <!-- End Google tag -->
     <link rel="canonical" href="{{ page.redirect_to }}"/>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,7 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167506267-1"></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'UA-167506267-1'); </script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-QNFX2EYZC8"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-QNFX2EYZC8');
+    </script>
+    <!-- End Google tag -->
     <link rel="canonical" href="{{ page.redirect_to }}"/>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -7,6 +7,7 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
+        gtag('config', 'UA-167506267-1'); 
         gtag('config', 'G-QNFX2EYZC8');
     </script>
     <!-- End Google tag -->

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-QNFX2EYZC8"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'G-QNFX2EYZC8');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167506267-1"></script>
+    <script>  
+      window.dataLayer = window.dataLayer || [];   
+      function gtag(){dataLayer.push(arguments);}  
+      gtag('js', new Date());  
+      gtag('config', 'UA-167506267-1'); 
+      gtag('config', 'G-QNFX2EYZC8');
     </script>
     <!-- End Google tag -->
     <link rel="canonical" href="{{ page.redirect_to }}"/>


### PR DESCRIPTION
Fixes #3863 

### NOTE: To be reviewed only by Product Manager. 
> As of 9 pm on 6/30/23, by creating the new GA4 property and linking it to the UA, plus the goal conversions, it appears that the website is already connecting to GA4 _**without making the suggested changes.**_ Assuming that the data keeps flowing correctly, we may not want to make the proposed changes.

![Migration_015](https://github.com/hackforla/website/assets/40799239/8ecd537e-9b31-4e61-ad1f-791d79447d1a)

### What changes did you make?
  - Goals in UA were automatically converted to GA4
  - The position of the `Google tag (gtag.js)` property has been placed above `Google Tag Manager` as recommended by Google. 
  - The `Google tag (gtag.js)` has been identified and reformatted for easier reading.
  - A new GA4 property has been setup for the HfLA website. Because this new GA4 property is tied to the previous UA property, we can continue using the previous property.
  - The `Google Tag Manager` has not been changed- Google indicates that if `Google Tag Manager` is already setup it can continue to be used without changes. 

### Why did you make the changes (we will use this info to test)?
  - Google has discontinued Universal Analytics (UA), now using Google Analytics 4 (GA4)


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to website.

Post migration, will need to monitor Google Analytics to confirm data is being collected as previously.
Data should be available until the end of the year, but will save remaining data.
  