### PR TITLE
Check dependabot suggested version updates to GHA issue-trigger.yml

### DIFF
--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -27,7 +27,7 @@ jobs:
           username: ${{ github.actor }}
           organization: 'hackforla'
           team: 'website-write'
-          GITHUB_TOKEN: ${{ secrets.TEAMS }}
+          GITHUB_TOKEN: ${{ secrets.TEST_GHAS }}
           
       # Checks if user is on the website-write-team
       - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}

--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -9,7 +9,7 @@ jobs:
     # Only trigger this action when an issue is newly created
     if: ${{ github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'transferred')}}
     steps:
-      - uses: actions/checkout@v2      
+      - uses: actions/checkout@v3    
       # Check if the issue has required labels
       - name: Check Labels
         uses: actions/github-script@v4
@@ -21,7 +21,7 @@ jobs:
             return checkLabels
             
       #Checks which teams the user is on 
-      - uses: tspascoal/get-user-teams-membership@v1
+      - uses: tspascoal/get-user-teams-membership@v2
         id: checkUserMember
         with:
           username: ${{ github.actor }}
@@ -47,7 +47,7 @@ jobs:
     #Triggers when the issue is newly assigned
     if: ${{ github.event_name == 'issues' && github.event.action == 'assigned'}}
     steps:
-      - uses: actions/checkout@v2  
+      - uses: actions/checkout@v3  
 
       # Check if the issue has the required roles
       - name: Check Labels Prelim


### PR DESCRIPTION
Fixes #4822 

### What changes did you make?
  - Successfully tested revising "issue-trigger.yml" lines 12, 50 from `actions/checkout@v2` to  `actions/checkout@v3` per #4735, these changes are OK
  - Successfully tested revising "issue-trigger.yml" line  24 from `tspascoal/get-user-teams-membership@v1` to  `tspascoal/get-user-teams-membership@v2` per #4737, this change is OK
  - Tested revising revising "issue-trigger.yml" lines 15,36,54,66  24 from `tactions/github-script@v4` to  `actions/github-script@v6` per #4734, this change is NG and should not be made

### Why did you make the changes (we will use this info to test)?
  - These tests were for checking whether we should accepts the Dependabot-suggested updates to misc. packages in the "issue-trigger.yml" file.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Screenshot showing successful run of "issue-trigger.yml" accepting the revisions per 4735 and 4737: The labels and message are added.</summary>

![4822_run_4735+4737_1](https://github.com/hackforla/website/assets/40799239/9201147a-ac99-47f8-a950-e0abc7b56756)

</details>
<details>
<summary>Screenshot showing successful run of "issue-trigger.yml" accepting the revisions per 4735 and 4737 post-assignee: the update reminder message is added to the issue.</summary>

![4822_run_4735+4737_2](https://github.com/hackforla/website/assets/40799239/c6246985-0603-4aa6-9896-a41b4da6e9c5)


</details>
<details>
<summary>Screenshot showing failed run of "issue-trigger.yml" when accepting revisions per 4734: The labels and message are not added.</summary>

![4822_run_4735+4737_part_ 4734](https://github.com/hackforla/website/assets/40799239/2a449d78-997c-4759-a3d8-47f4eae76745)

</details>
