### PR TITLE
Fixed bug with GHA where Update labels do not get applied to Issues with Closed PRs 4839

### DIFF
--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -145,11 +145,21 @@ function isTimelineOutdated(timeline, issueNum, assignees) { // assignees is an 
   for (let i = timeline.length - 1; i >= 0; i--) {
     let eventObj = timeline[i];
     let eventType = eventObj.event;
+    // isLinkedIssue checks if the 'body'(comment) of the event mentions fixes/resolves/closes this current issue
+    let isOpenLinkedPullRequest = eventType === 'cross-referenced' && isLinkedIssue(eventObj, issueNum) && eventObj.source.issue.state === 'open';
 
-    // if cross-referenced and fixed/resolved/closed by assignee, remove all update-related labels, remove all three labels
-    if (eventType === 'cross-referenced' && isLinkedIssue(eventObj, issueNum) && assignees.includes(eventObj.actor.login)) { // isLinkedIssue checks if the 'body'(comment) of the event mentioned closing/fixing/resolving this current issue
-      console.log(`Issue #${issueNum} fixed/resolved/closed by assignee, remove all update-related labels`);
+    // if cross-referenced and fixed/resolved/closed by assignee and the pull
+    // request is open, remove all update-related labels
+    // Once a PR is opened, we remove labels because we focus on the PR not the issue.
+    if (isOpenLinkedPullRequest && assignees.includes(eventObj.actor.login)) {
+      console.log(`Assignee fixes/resolves/closes Issue #${issueNum} in with an open pull request, remove all update-related labels`);
       return { result: false, labels: '' } // remove all three labels
+    }
+
+    // If the event is a linked PR and the PR is closed, it will continue through the
+    // rest of the conditions to receive the appropriate label.
+    else if(eventType === 'cross-referenced' && eventObj.source.issue.state === 'closed') {
+      console.log(`Pull request linked to Issue #${issueNum} is closed.`);
     }
 
     let eventTimestamp = eventObj.updated_at || eventObj.created_at;


### PR DESCRIPTION
Fixes #4839 

### What changes did you make?
  - Updated conditions for checking for linked pull requests
    - added a condition to check if linked pull request state is open
    - consolidated the conditions that check for an open linked pull request into the variable `isOpenLinkedPullRequest`
  - Edited and Added log statements to print the state of pull requests linked to the issue
  - Tested issues with various inactivity time frames and linked PR states and verified the intended outcome.  Screenshots included are issues after manual workflow runs with test conditions for the closed linked PR bug described. Other test conditions were to ensure no functionality was lost.

### Why did you make the changes (we will use this info to test)?
  - When there is an open pull request, we switch focus to checking the PR not the issue, so we can remove the update labels. However, when the issue is still in progress and all of the linked PRs are closed, we need to bring our attention back to the issue by adding update labels.  This way we can ensure the issue gets closed if it has been resolved without merging a linked PR or if the issue was not resolved, we can check if the closed PR was a mistake. For that reason, the appropriate update label should be added if the linked PR's are closed.
  -  Before the change, the condition only checked if the event was a linked pull request and not the status of the PR. This change ensures that if there isn't an open PR, the issue receives the appropriate update label based on the assignee's most recent activity.
  - Log edits and additions were made to ensure the the log conveys complete and accurate information.
  - Tested issues with various PR states to ensure that the issue was resolved and that prior functionality was retained.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

Removes all update labels from issue with closed linked PR requests
![image](https://i.ibb.co/sv3d3Sr/Before-Changes-With-Closed-PRs.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>

Issues after manual workflow runs:

All Linked Pull Requests Closed 14 Days or More Condition (correctly adds `2 weeks inactive` label)
![image](https://i.ibb.co/L522Y3N/ClosedPR.png)

Multiple Pull Requests Linked with Last PR Open (correctly removes all update labels, since there is still at least one PR open that we turn our attention to)
![image](https://i.ibb.co/7bxpJTB/OpenLast.png)

Multiple Pull Requests Linked with First PR Open (correctly removes all update labels, since there is still at least one PR open that we turn our attention to)
![image](https://i.ibb.co/bPzrY4H/Open-First.png)

</details>

### Tests Performed
I am including an overview of how I tested as it could be a helpful starting point for creating documentation about testing GHAs in the future. Additionally, the information might help reviewers in catching something I've missed or suggesting improvements for future testing.

The steps used to test were as follows:
- [x] Copied the project board into a test repo (this action requires a classic project board in the test repo)
- [x] Added test issues to the repo with the copied project board
- [x] Moved the all test issue cards to the `In Progress (actively working)` column of the project board
- [x] Copied the `In Progress (actively working)` column link 
- [x] Added a GitHub Action secret called `IN_PROGRESS_COLUMN_ID` with the copied column id number (column id is the number at the end of the URL)
- [x] Edited files for manual testing and testing inactivity timeframes (issues were created the same day as testing)
 - [x] In file `github/workflows/schedule-fri-0700.yml` replaced 
    ```
    on:
      schedule:
    ```
    with
    ```
    on:
      workflow_dispatch:
      schedule:
    ```
  - [x] In file `github/github-actions/trigger-schedule/add-update-label-weekly/add-label.js` cut off times need to be adjusted depending on which inactivity label is being tested
    - [x] To test for `Status: Updated` label condition (this retains the label so the issue must already be labeled `Status: Updated` to begin with. It also requires a comment from the assignee.)
      ```
      threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays)
      ```
      was replaced with
      ```
      threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays + 3)
      ```
    - [x] To test for `To Update !` label condition
      ```
      threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays)
      const sevenDayCutoffTime = new Date()
      sevenDayCutoffTime.setDate(sevenDayCutoffTime.getDate() - commentByDays)
      ```
      was replaced with
      ```
      threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays + 5)
      const sevenDayCutoffTime = new Date()
      sevenDayCutoffTime.setDate(sevenDayCutoffTime.getDate() - commentByDays + 7)
      ```
    - [x] To test for `2 weeks in active` label condition
      ```
      threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays)
      const sevenDayCutoffTime = new Date()
      sevenDayCutoffTime.setDate(sevenDayCutoffTime.getDate() - commentByDays)
      const fourteenDayCutoffTime = new Date()
      fourteenDayCutoffTime.setDate(fourteenDayCutoffTime.getDate() - inactiveUpdatedByDays)
      ```
      was replaced with
      ```
      threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays + 7)
      const sevenDayCutoffTime = new Date()
      sevenDayCutoffTime.setDate(sevenDayCutoffTime.getDate() - commentByDays + 9)
      const fourteenDayCutoffTime = new Date()
      fourteenDayCutoffTime.setDate(fourteenDayCutoffTime.getDate() - inactiveUpdatedByDays + 14)
      ```
- [x] Pushed the test changes to testing repo with project board setting an upstream feature branch 
- [x] Set default branch to the feature branch
- [x] Created branches off the feature branch to create enough test pull requests to link to issues
- [x] Pushed those branches to the test repo
- [x] Linked PRs to issues, closed PRs without merging, and added labels to issues according to test conditions listed below. (Tested with multiple PRs linked to issues because there have been issues with multiple PRs linked before.) 
  - [x] Test conditions:
    - [x] Single open PR linked, inactive issue (removes labels)
    - [x] Open PR linked first with closed PRs, inactive issue (removes labels)
    - [x] Open PR linked last with closed PRs, inactive issue (removes labels)
    - [x] Single closed PR linked, issue inactive inactive 14 days (adds `2 weeks inactive label`)
    - [x] Single closed PR linked, issue inactive inactive 7 days (adds `To Update !` Label)
    - [x] Closed PRs, issue inactive 14 days (adds `2 weeks inactive label`)
    - [x] Closed PRs, issue inactive inactive 7 days (adds `To Update !` Label)
    - [x] Assigned issue no PR, inactive 14 days (adds `2 weeks inactive label`)
    - [x] Assigned issue no PR, inactive 7 days (adds `To Update !` Label)
    - [x] Issue assigned within 7 days (removes all labels)
    - [x] Commented within 3 days (retain `Status: Updated` label)
- [x] Ran the workflow manually
- [x] Checked results 
- [x] Adjusted timeline, issues, and PR state(s) as needed to test any conditions not tested in the first round until all conditions listed were tested.

### Testing Resources
- Copying classic project board
  - https://docs.github.com/en/issues/organizing-your-work-with-project-boards/managing-project-boards/copying-a-project-board
- Copying column link to get column id
  - On the project board page, click the `...` on the upper right hand corner of the column and select `Copy column link` to get the link
  - The column id is the number at the end of the URL when pasted
- Adding an action secret
  - https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
- Changing the default branch
  - https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch
- Running a workflow manually
  - https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow