### PR TITLE
Update Instructions Posted when GitHub Actions applies update labels

### DIFF
--- a/github-actions/trigger-schedule/add-update-label-weekly/update-instructions-template.md
+++ b/github-actions/trigger-schedule/add-update-label-weekly/update-instructions-template.md
@@ -7,6 +7,6 @@ Please add update using the below template (even if you have a pull request). Af
 4. ETA: "When do you expect this issue to be completed?"
 5. Pictures (optional): "Add any pictures of the visual changes made to the site so far."
 
-If you need help, be sure to either: 1) place your issue in the developer meeting discussion column and ask for help at your next meeting, 2) put a "Status: Help Wanted" label on your issue and pull request, or 3) put up a request for assistance on the #hfla-site channel. Please note that including your questions in the issue comments- along with screenshots, if applicable- will help us to help you. [Here](https://github.com/hackforla/website/issues/1619#issuecomment-897315561) and [here](https://github.com/hackforla/website/issues/1908#issuecomment-877908152) are examples of well-formed questions.
+If you need help, be sure to either: 1) place your issue in the `Questions/In Review` column of the Project Board and ask for help at your next meeting, 2) put a "Status: Help Wanted" label on your issue and pull request, or 3) put up a request for assistance on the #hfla-site channel. Please note that including your questions in the issue comments- along with screenshots, if applicable- will help us to help you. [Here](https://github.com/hackforla/website/issues/1619#issuecomment-897315561) and [here](https://github.com/hackforla/website/issues/1908#issuecomment-877908152) are examples of well-formed questions.
 
 <sub>You are receiving this comment because your last comment was before ${cutoffTime} PST.</sub>


### PR DESCRIPTION
Fixes #4887

### What changes did you make?
  - I updated the update-instructions-template.md file with the new text
  - I tested changes on my cloned repo by manually triggering the workflow


To be able to test this GitHub action on your own local repo, you can update the schedule-fri-0700.yml file.

  workflow_dispatch: <--- add this line to be able to manually trigger the workflow

<img width="395" alt="CleanShot 2023-07-10 at 11 35 12@2x" src="https://github.com/hackforla/website/assets/95109313/3d0bf2cb-860b-4e66-9117-7d63878f6fb1">

<img width="1813" alt="CleanShot 2023-07-10 at 11 33 03@2x" src="https://github.com/hackforla/website/assets/95109313/0d459f80-1e34-499d-9ee1-966cf1a17018">

Edit the file located at github-actions/trigger-schedule/add-update-label-weekly/add-label.js
If you modify the numbers, you can artificially simulate seven days and 14 days.

```js
const threeDayCutoffTime = new Date()
threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays + 3) <--
const sevenDayCutoffTime = new Date()
sevenDayCutoffTime.setDate(sevenDayCutoffTime.getDate() - commentByDays + 7) <-- 
const fourteenDayCutoffTime = new Date()
fourteenDayCutoffTime.setDate(fourteenDayCutoffTime.getDate() - inactiveUpdatedByDays + 14) <--
```

### You will need to add this secret for the secret key to your local repository for schedule-fri-0700.yml file.
  - Make sure your secret is labeled IN_PROGRESS_COLUMN_ID to match what is referenced in the yml file.
  - Make sure you only copy the ID/numbers for the value.

[How to add a Secret](https://scribehow.com/shared/How_to_Add_a_Secret_to_a_GitHub_Repository__3DwuRQDbSiizAMtUsqSoHw)


### Why did you make the changes (we will use this info to test)?
  - I made this change because the developer meeting column isn't currently being monitored or used anymore.

<details>
<summary>Visuals before changes are applied</summary>

<img width="1139" alt="CleanShot 2023-07-09 at 23 32 09@2x" src="https://github.com/hackforla/website/assets/95109313/51c25bc8-affa-41be-b933-2528e49c2edf">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1075" alt="CleanShot 2023-07-09 at 22 09 25@2x" src="https://github.com/hackforla/website/assets/95109313/167f0b4f-4d75-4c63-bc52-d4514c663391">

<img width="1086" alt="CleanShot 2023-07-09 at 22 09 51@2x" src="https://github.com/hackforla/website/assets/95109313/8f96dfb4-ff1c-41b9-8aa4-1c3f53f90046">

</details>

### This links to my repo/project board, where I tested the GitHub actions.

  - [Issue](https://github.com/ronaldpaek/website/issues/10)
  - [Action](https://github.com/ronaldpaek/website/actions)
  - [How to Copy a Project Board in GitHub](https://scribehow.com/shared/How_to_Copy_a_Project_Board_in_GitHub__d220g8-6QIuF8J_j1cqOTw)