### PR TITLE
Update Labels: Issue Template: wiki--research-plan-review

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-form-with-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form-with-dependency.yml
@@ -1,6 +1,6 @@
 name: 'Blank Issue Form with Dependency'
 description: 'Standard HackforLA issue form with dependency'
-
+labels: ['role missing', 'Complexity: Missing', 'Feature Missing', 'size: missing','Draft']
 body:
   - type: textarea
     id: dependency
@@ -31,4 +31,3 @@ body:
       description: "Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc."
     validations:
       required: true
-  

--- a/.github/ISSUE_TEMPLATE/blank-issue-form-with-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form-with-dependency.yml
@@ -1,6 +1,6 @@
 name: 'Blank Issue Form with Dependency'
 description: 'Standard HackforLA issue form with dependency'
-labels: ['role missing', 'Complexity: Missing', 'Feature Missing', 'size: missing','Draft']
+
 body:
   - type: textarea
     id: dependency
@@ -31,3 +31,4 @@ body:
       description: "Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc."
     validations:
       required: true
+  

--- a/.github/ISSUE_TEMPLATE/wiki--research-plan-review----replace-with-name-of-page-.md
+++ b/.github/ISSUE_TEMPLATE/wiki--research-plan-review----replace-with-name-of-page-.md
@@ -2,7 +2,7 @@
 name: 'Wiki: Research Plan Review:  [REPLACE WITH NAME OF PAGE]'
 about: Research Plan Review
 title: 'Wiki: Research Plan Review:  [REPLACE WITH NAME OF PAGE]'
-labels: 'Feature: Wiki, role: user research, size: 0.5pt'
+labels: ['Feature: Wiki', 'role: user research', 'size: 0.5pt', 'Complexity: Missing']
 assignees: sacamp
 
 ---
@@ -17,17 +17,17 @@ We need to make all the research pages in the wiki uniform so that we can determ
 - [ ] Order the items the same way that they exist in the format template below
 - [ ] Take Inventory of Assets
    - [ ] Name of Research
-   - [ ] Research Date: 
+   - [ ] Research Date:
    - [ ] Current Status
    - [ ] Outstanding task items
    - [ ] Research Plan (including Audience Identification documentation)
    - [ ] Scripts
    - [ ] Interview recordings & Transcripts
    - [ ] Synthesis (Miro or Figjam)
-   - [ ] Presentation of Findings	
+   - [ ] Presentation of Findings
    - [ ] Action Items Spreadsheet
 - [ ] Check to see if there are more assets or assets (in the folder) from related research that are needed on this page, and add them
-- [ ] Check all the issues labeled research that do not have an RP label already assigned, to see if they are connected to this issue.  
+- [ ] Check all the issues labeled research that do not have an RP label already assigned, to see if they are connected to this issue.
   - [ ] add RP[replace with number] to this issue and any issues that need it
 - [ ] Evaluate all the research assets and summarize the status of the research under  "Current Status"
 - [ ] List out next steps under "Outstanding Task Items"
@@ -44,7 +44,7 @@ We need to make all the research pages in the wiki uniform so that we can determ
 ```
 # [Name of Research]
 
-## Research Date: 
+## Research Date:
 
 ## Current Status
 
@@ -60,7 +60,7 @@ We need to make all the research pages in the wiki uniform so that we can determ
 
 ### Synthesis (Miro or Figjam)
 
-### Presentation of Findings	
+### Presentation of Findings
 
 ### Action Items Spreadsheet
 ```


### PR DESCRIPTION
Fixes #4488

### What changes did you make?
  - replaced labels with: ['Feature: Wiki', 'role: user research', 'size: 0.5pt', 'Complexity: Missing'] in this file path .github/ISSUE_TEMPLATE/wiki--research-plan-review----replace-with-name-of-page-.md
  

### Why did you make the changes (we will use this info to test)?
  - To avoid GitHub bot taking off the labels when dev adds them to issues
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
 - No Visual Changes to the website






For PR Reviewers and Merge Team
To review this issue, click the link below under "Link for reviewers" and verify that the labels match the updated labels string in the issue.

Link for Reviewers
This URL will be inserted by the dev during the test process and will be used by reviewers to preview the updated template.
URL of the issue branch on the test Repository: https://github.com/kiwookim/website/issues/new?assignees=sacamp&labels=Feature%3A+Wiki%2Crole%3A+user+research%2Csize%3A+0.5pt%2CComplexity%3A+Missing&projects=&template=wiki--research-plan-review----replace-with-name-of-page-.md&title=Wiki%3A+Research+Plan+Review%3A++%5BREPLACE+WITH+NAME+OF+PAGE%5D

For PM, Merge Team, or Tech Lead

 Once the pull request associated with this issue is approved and merged, please update and edit epic https://github.com/hackforla/website/issues/4307 by
 Checking off the dependency for this issue
 If all dependencies are checked off, please move issue to the New Issue Approval column and remove the Dependency label
File and Code links you will need to work on this issue
Directory to find the page in once you have it in your IDE: .github/ISSUE_TEMPLATE/wiki--research-plan-review----replace-with-name-of-page-.md
This issue is part of epic https://github.com/hackforla/website/issues/4307