### PR TITLE
Updates issue trigger 4933

### DIFF
--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3    
       # Check if the issue has required labels
       - name: Check Labels
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         id: check-labels
         with:
           script: |
@@ -27,13 +27,13 @@ jobs:
           username: ${{ github.actor }}
           organization: 'hackforla'
           team: 'website-write'
-          GITHUB_TOKEN: ${{ secrets.TEST_GHAS }}
+          GITHUB_TOKEN: ${{ secrets.TEAMS }}
           
       # Checks if user is on the website-write-team
       - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
       # Post comment based on the previous action's results
         name: Post Comment
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         id: post-comment
         with:
           script: |
@@ -51,7 +51,7 @@ jobs:
 
       # Check if the issue has the required roles
       - name: Check Labels Prelim
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         id: check-labels-prelim
         with:
           script: |
@@ -63,7 +63,7 @@ jobs:
       # Post the comment based on the result of the previous step
       - name: Post assigning issue comment
         id: assigned-comment
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           script: |
             const results = ${{ steps.check-labels-prelim.outputs.result }}

--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -27,7 +27,7 @@ jobs:
           username: ${{ github.actor }}
           organization: 'hackforla'
           team: 'website-write'
-          GITHUB_TOKEN: ${{ secrets.TEAMS }}
+          GITHUB_TOKEN: ${{ secrets.TEST_GHAS }}
           
       # Checks if user is on the website-write-team
       - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}

--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -27,7 +27,7 @@ jobs:
           username: ${{ github.actor }}
           organization: 'hackforla'
           team: 'website-write'
-          GITHUB_TOKEN: ${{ secrets.TEST_GHAS }}
+          GITHUB_TOKEN: ${{ secrets.TEAMS }}
           
       # Checks if user is on the website-write-team
       - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}

--- a/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
@@ -96,7 +96,7 @@ async function addLabels(labelsToAdd, currentLabels) {
   ])]
 
   try {
-    const results = await github.issues.setLabels({
+    const results = await github.rest.issues.setLabels({
       owner: owner,
       repo: repo,
       issue_number: issueNum,

--- a/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
@@ -89,7 +89,7 @@ function makeComment(labels) {
  */
  async function postComment(issueNum, comment) {
   try {
-    await github.issues.createComment({
+    await github.rest.issues.createComment({
       owner: context.repo.owner,
       repo: context.repo.repo,
       issue_number: issueNum,

--- a/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
@@ -41,7 +41,7 @@ async function main({ g, c }, { shouldPost, issueNum }){
 	let page = 1
   while (true) {
     try {
-      const results = await github.issues.listEventsForTimeline({
+      const results = await github.rest.issues.listEventsForTimeline({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: issueNum,
@@ -120,7 +120,7 @@ function formatComment({ replacementString, placeholderString, filePathToFormat,
 
 async function postComment(issueNum, comment){
   try{
-    await github.issues.createComment({
+    await github.rest.issues.createComment({
       owner: context.repo.owner,
       repo: context.repo.repo,
       issue_number: issueNum,


### PR DESCRIPTION
Fixes #4933 

### What changes did you make?
  - Corrected the name of the GitHub token on `issue-trigger.yml`
  - Updated `actions/github-script@v4` to `actions/github-script@v6`
  - When updating the above, github REST methods requests needed to change from `github.issues` to `github.rest.issues`

### Why did you make the changes (we will use this info to test)?
  - Changes were made so that  `actions/github-script` version can be updated to latest

### Comments for testing
In an earlier issue, the update to `actions/github-script@v6` caused this GHA to fail in couple of ways. The changes in this PR should fix the automations for the update. Here is what failed in the previous issue that should be working properly now:
 1. This GHA should add missing labels to newly created issues. To test this, use one of the new issue templates, **_then before creating the issue_**, be sure to delete `Complexity: missing`, `role missing`, and `feature missing`. Then make certain that you select “Project Board” from the Projects. This is the only way to know if the GHA is working or not.
<details>
<summary>Demo of first step function</summary>
  
![issue-trigger-test1](https://github.com/hackforla/website/assets/40799239/e207fef4-cd16-4d9b-875c-2c0039736f69)

</details>

 2. After the issue is created and you have checked the above, add the label `role: front end` and/or `role: back end` to the issue. Now you can assign yourself to the issue- this GHA should add a comment to the assignee. (You have seen this note before.)
<details>
<summary>Demo of second step function</summary>
  
![issue-trigger-test2](https://github.com/hackforla/website/assets/40799239/372560a0-c64c-480c-ade9-7f00f356551c)

</details>