### PR TITLE
Updated scss to only target h2 on privacy policy page

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,9 +1,5 @@
 {
-  "plugins": [
-    "stylelint-scss"
-  ],
   "rules": {
-    "scss/at-rule-no-unknown": true,
     "color-no-invalid-hex": true,
     "unit-no-unknown": true,
     "property-no-unknown": true,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,7 +2,6 @@
   "plugins": [
     "stylelint-scss"
   ],
-  "extends": "stylelint-config-standard-scss",
   "rules": {
     "scss/at-rule-no-unknown": true,
     "color-no-invalid-hex": true,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,9 @@
 {
+  "plugins": [
+    "stylelint-scss"
+  ],
   "rules": {
+    "scss/at-rule-no-unknown": true,
     "color-no-invalid-hex": true,
     "unit-no-unknown": true,
     "property-no-unknown": true,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,6 +2,7 @@
   "plugins": [
     "stylelint-scss"
   ],
+  "extends": "stylelint-config-standard-scss",
   "rules": {
     "scss/at-rule-no-unknown": true,
     "color-no-invalid-hex": true,

--- a/_sass/components/_privacy-policy.scss
+++ b/_sass/components/_privacy-policy.scss
@@ -49,8 +49,10 @@
   .page-card--privacy-policy {
     padding: 36px 57px;
   }
-  h2 {
-    margin-top: 48px;
+  .content-section--privacy-policy {
+    h2 {
+      margin-top: 48px;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #4864

### What changes did you make?
 - Update ```h2``` selector on lines 52-54 (within ```@media #{$bp-desktop-up}```) to target ```h2```s in ```.content-section--privacy-policy``` class, which corresponds to ```h2```s in the Privacy Policy card

### Why did you make the changes (we will use this info to test)?
- Per #4864 and #4794, the ```h2``` styling should only be targeting the ```h2```s on the Privacy Policy page, but they are targeting every ```h2``` throughout the website. These changes are to specifically style the ```h2```s on the Privacy Policy page.

### Screenshots
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

Join Us page:
<img width="1440" alt="Screen Shot 2023-07-12 at 8 17 32 PM" src="https://github.com/hackforla/website/assets/9537526/f830dcf3-3b47-428b-9c9e-64a21120069e">

Privacy Policy page:
<img width="1440" alt="Screen Shot 2023-07-12 at 8 17 54 PM" src="https://github.com/hackforla/website/assets/9537526/2f946a56-dbba-4883-b617-2c50fb113d5f">

</details>

<details>
<summary>Visuals after changes are applied</summary>

Join Us page (headers here are no longer being affected):
<img width="1440" alt="Screen Shot 2023-07-12 at 8 17 36 PM" src="https://github.com/hackforla/website/assets/9537526/23a9f59d-3aea-4970-81b2-4bbf4043b3f0">

Privacy Policy page (headers here are still affected):
<img width="1440" alt="Screen Shot 2023-07-12 at 8 17 56 PM" src="https://github.com/hackforla/website/assets/9537526/6773c4d5-d4d5-40ed-b955-5e3e57ee7fcf">

</details>
