### PR TITLE
feat: automation for moving ice box items to new issue approval column

### DIFF
--- a/.github/workflows/new-issue-from-ice-box.yml
+++ b/.github/workflows/new-issue-from-ice-box.yml
@@ -1,0 +1,109 @@
+name: New Issue Approval From Ice Box
+
+on:
+  issues:
+    types: [edited]
+    filters:
+      project_column:
+        project: "Project Board"
+        column: "Ice Box"
+
+jobs:
+  Log-Trigger:
+    runs-on: ubuntu-latest
+    steps:
+     - run: echo "🎉 The job was triggered"
+
+
+  Check_Dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check dependencies
+        id: check
+        uses: actions/github-script@v3
+        with:
+          # Script finds the "Dependency" section and extracts the task list. 
+          # If there is no list then the job stops and nothing happens
+          # If everything on the list is linked to an issue and checked off then the job procceeds 
+          script: |
+            const issueText = context.payload.issue.body;
+            console.log("The issue body is:", issueText);
+            
+            function extractDependencySection(markdownText) {
+              const lines = markdownText.split('\n');
+              let isDependencySection = false;
+              const dependencies = [];
+
+              for (const line of lines) {
+                if (line.startsWith('### Dependency')) {
+                  isDependencySection = true;
+                } else if (line.startsWith('###')) {
+                  break;
+                } else if (isDependencySection && line.trim().startsWith('- [')) {
+                  dependencies.push(line.trim());
+                }
+              }
+
+              return dependencies;
+            }
+            
+            function checkTasksCompletion(dependencies) {
+              if (dependencies.length === 0) {
+                return false
+              }
+            
+              for (const dependency of dependencies) {
+                const isComplete = /- \[x\]/.test(dependency);
+                const hasIssueLinked = /#(\d+)/.test(dependency);
+
+                if (!isComplete || !hasIssueLinked) {
+                    console.log("Dependency:", dependency)
+                    console.log("iscomplete:", isComplete)
+                    console.log("LinkedIssue:", hasIssueLinked)
+                  return false;
+                }
+              }
+              return true;
+            } 
+            
+            const dependencies = extractDependencySection(issueText);
+            console.log("dependencies:", dependencies);
+            
+            const areTasksComplete = checkTasksCompletion(dependencies);
+            console.log("completion:", areTasksComplete)
+            
+            if( areTasksComplete == true) {
+                core.setOutput('run_next_job', 'yes');
+            }
+    outputs:
+      run_next_job: ${{steps.check.outputs.run_next_job}}
+      
+  Add_Ready_For_Dev_Lead_Label:
+    needs: Check_Dependencies
+    if: needs.Check_Dependencies.outputs.run_next_job == 'yes'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add Ready For Dev Lead Label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["ready for dev lead"]
+            })
+            
+  Move_To_New_Issue_Approval_Column:
+    needs: Check_Dependencies
+    if: needs.Check_Dependencies.outputs.run_next_job == 'yes'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move To New Issue Approval Column
+        uses: alex-page/github-project-automation-plus@v0.8.3
+        with:
+          project: Project Board
+          column: New Issue Approval
+          repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}


### PR DESCRIPTION
Fixes #3732

### What changes did you make?
Made a workflow to move Ice Box items to the New Issue Approval column under the following circumstances:
  - In the dependency section, all enumerated action items are checked off
  - Cannot contain action items that are comments 

### Why did you make the changes (we will use this info to test)?
  - To increase productivity, issues with completed dependencies from the Ice Box are automatically moved to the New Issue Approval column along with adding the "ready for dev lead" label
  - The script checks for the dependency section's action list. Since a Template is for the issue approval process, the script looks for "### Dependency".
  -  A separate check is used to verify all action items are linked to an issue using regex since they're made using markdown.
  - If there are no action items in this section then the workflow is aborted since there is nothing to check for.
  - If all of the above pass the the issue is moved to the new issue approval column & the "ready for dev lead" label is added to streamline the issue approval process. 
  - A local secret token had to be made for local testing. This has been changed to use the hack for la token as seen on other workflow files.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Demo Of Workflow in local enviroment</summary>

![issue_mover_demo](https://github.com/hackforla/website/assets/104275658/0bccd2f5-55ab-4681-b4e0-ae865d1a8977)

Three test were made to follow the testing guidelines. 
"Pass Tester" contains only an enumerated action list and should pass to moving to the new issue approval column.
"Fail Tester" contains no list and only a comment. This test should fail. 
"Fail Tester2" contains an action list with enumerated and comment action items. This test should fail.

</details>

### Test Performed 

I am including the process I used to test this github action so that it can be replicated on review.

- [ ]  Copy the project board into a test repo. It is important to do this step since Hack For La uses the classic project board. Making a classic project is no longer an option unless it is copied. This [Link](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/managing-project-boards/copying-a-project-board) shows how to do that.
- [ ] Check for a "ready for dev lead" label. If the copied project does not have one, then one should be made.
- [ ]  A personal access token has to be made for the project. Make sure to save the generated code for the next step. This [Link](https://docs.github.com/en/enterprise-server@3.6/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) shows how to do that. Make sure the following permissions are checked "Repo", "Workflow", and "Project".
- [ ] Make a repository secret by going to the settings in the test repo. 
   - [ ] Click on "Secrets & Variables". 
   - [ ] Under this tab click "Actions". 
   - [ ] Click on "New repository secret".
   - [ ] Name your secret and add the generated token from step 2.
- [ ] Add the secret to "repo-token" in the "Move_To_New_Issue_Approval_Column:" job. It should look like this 
$ {{ secrets.YOUR_SECRET_NAME }} .
- [ ] Make at least 2 issues to use on the copied project board.
- [ ] Four tests are made in the Ice Box column.
   - [ ]  An issue using the "Blank Issue Form with Dependency" template. It should contain at least 1 checkbox item that links an issue (one of the ones you made earlier). [Example Issue](https://github.com/hackforla/website/issues/1742)
   - [ ] An issue using the "Blank Issue Form with Dependency" template. It should contain at least 1 checkbox item that links an issue (one of the ones you made earlier) and a checkbox item that is a comment. [Example Issue](https://github.com/hackforla/website/issues/2108)
   - [ ] An issue using the "Blank Issue Form with Dependency" template. It should only contain a comment. [Example Issue](https://github.com/hackforla/website/issues/609)
   - [ ] An issue using any template that doesn't have a "Dependency" template. 
- [ ]  The action is triggered when an icebox item's body is edited. 
   - [ ] For each test that has a "Dependency" section checkbox list, check off every item.
   - [ ] For each test that does not have a checkbox list or no "Dependency" section, edit the body of the issue.
- [ ] Each test has now been triggered. The only one that should pass is the test that only actions checkbox items with a linked issue. The item will be moved from the Ice Box column to the New Issue Approval column and should have a "ready for dev lead" label