### PR TITLE
removed Brian Mui from Site Project Team

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -48,12 +48,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U04J1GBA6QP'
       github: 'https://github.com/christinaor'
     picture: https://avatars.githubusercontent.com/christinaor
-  - name: Brian Mui
-    role: Merge Team
-    links:
-      slack: https://hackforla.slack.com/team/U04MFMMNJRH
-      github: https://github.com/bootcamp-brian
-    picture: https://avatars.githubusercontent.com/bootcamp-brian
   - name: MJ Shelton
     role: Merge Team
     links:


### PR DESCRIPTION
Fixes #4954

### What changes did you make?
I removed the profile of Brian Mui from the Website Leadership page, as directed in the issue


### Why did you make the changes (we will use this info to test)?
There was a 'Good First Issue' requesting to remove this profile

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/127683817/a7282d3b-f251-42f7-9368-fdb4242b7876)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/127683817/c7ff9e9f-1529-4e32-b7b6-6cb17dae4ca0)

</details>
