### PR TITLE
updated js behind projects-check page to accept tools as an array or a string

### DIFF
--- a/assets/js/current-projects-check.js
+++ b/assets/js/current-projects-check.js
@@ -98,7 +98,7 @@ function retrieveProjectDataFromCollection(){
                             "partner": `{{ project.partner }}`
                             {%- endif -%}
                             {%- if project.tools -%},
-                            "tools": `{{ project.tools }}`
+                            "tools": `{{ project.tools | jsonify }}`
                             {%- endif -%}
                             {%- if project.looking -%},
                             "looking": {{ project.looking | jsonify }}
@@ -463,14 +463,17 @@ return `
             `:""
             }
 
-            ${project.tools ?
-            `
-            <div class="project-tools">
-            <strong>Tools: </strong>
-            ${ project.tools }
-            </div>
-            `:""
-            }
+			${project.tools ?
+			`
+			<div class="project-tools">
+			<strong>Tools: </strong>
+			${(Array.isArray(project.tools) ? project.tools : project.tools.split(','))
+				.map(tool => `<p class='project-card-field-inline'> ${tool}</p>`)
+				.join(", ")
+			}
+			</div>
+			`: ""
+			}
 
             ${project.looking ? "" : ""
             // `


### PR DESCRIPTION
Fixes #4861
### What changes did you make?
  - Updated js to accept tools as a comma separated string or an array


### Why did you make the changes (we will use this info to test)?
  - The code updates were made so the code will work now (with tools as a comma-separated string) and also later (after tools is changed to an array)
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to the website


