### PR TITLE
Pulls languages from multiple repos

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -189,6 +189,7 @@ layout: default
         src="/assets/js/project.js"
         type="module"
         projectId="{{ page.identification }}"
+        moreProjectIds="{{ page.additional-repo-ids }}"
         imageHero="{{ page.image-hero }}"
         projectTitle="{{ page.title }}">
 </script>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -189,7 +189,7 @@ layout: default
         src="/assets/js/project.js"
         type="module"
         projectId="{{ page.identification }}"
-        moreProjectIds="{{ page.additional-repo-ids }}"
+        secRepoId="{{ page.secondRepoId }}"
         imageHero="{{ page.image-hero }}"
         projectTitle="{{ page.title }}">
 </script>

--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -1,6 +1,8 @@
 ---
 # 'identification' is the 9 digit ID for your repo in the GitHub API.
-identification: '241519642, 275296439'
+identification: '241519642'
+# separate additional repo ids with a comma then a space ex) '112233, 445566'
+additional-repo-ids: '275296439'
 title: Civic Tech Index
 description: Our goal of the project is to create a comprehensive, searchable index of all civic tech open source software projects around the world. We have created the framework and an interest list. We are currently working on building out the website and other marketing tools that demonstrate the power of the index.
 image: /assets/images/projects/civic-tech-index.png

--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -1,6 +1,6 @@
 ---
 # 'identification' is the 9 digit ID for your repo in the GitHub API.
-identification: '241519642'
+identification: '241519642, 275296439'
 title: Civic Tech Index
 description: Our goal of the project is to create a comprehensive, searchable index of all civic tech open source software projects around the world. We have created the framework and an interest list. We are currently working on building out the website and other marketing tools that demonstrate the power of the index.
 image: /assets/images/projects/civic-tech-index.png

--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -1,8 +1,7 @@
 ---
 # 'identification' is the 9 digit ID for your repo in the GitHub API.
 identification: '241519642'
-# separate additional repo ids with a comma then a space ex) '112233, 445566'
-additional-repo-ids: '275296439'
+secondRepoId: '275296439'
 title: Civic Tech Index
 description: Our goal of the project is to create a comprehensive, searchable index of all civic tech open source software projects around the world. We have created the framework and an interest list. We are currently working on building out the website and other marketing tools that demonstrate the power of the index.
 image: /assets/images/projects/civic-tech-index.png

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -101,7 +101,7 @@ function retrieveProjectDataFromCollection(){
                 "project": {
                             'id': "{{project.id | default: 0}}",
                             'identification': {{project.identification | default: 0}},
-                            'additional-repo-ids': {{project.additional-repo-ids | default: 0}},
+                            'secondRepoId': {{project.secondRepoId | default: 0}},
                             "status": "{{ project.status }}"
                             {%- if project.image -%},
                             "image": '{{ project.image }}'
@@ -142,11 +142,12 @@ function retrieveProjectDataFromCollection(){
     projectData.forEach((data,i) => {
         const { project } = data;
         const matchingProject = projectLanguagesArr.find(x=> x.id === project.identification);
-        const secMatchingProject = projectLanguagesArr.find(x=> x.id === project['additional-repo-ids']);
+        console.log(project)
         if(matchingProject) {
             project.languages = matchingProject.languages;
-            
-            if(project['additional-repo-ids'] !== 0){
+            console.log(project.secondRepoId)
+            if(project.secondRepoId != 0){
+                const secMatchingProject = projectLanguagesArr.find(x=> x.id === project.secondRepoId);
                 const langArr = [...matchingProject.languages, ...secMatchingProject.languages];
                 let set = new Set(langArr);
                 project.languages = Array.from(set);

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -101,6 +101,7 @@ function retrieveProjectDataFromCollection(){
                 "project": {
                             'id': "{{project.id | default: 0}}",
                             'identification': {{project.identification | default: 0}},
+                            'additional-repo-ids': {{project.additional-repo-ids | default: 0}},
                             "status": "{{ project.status }}"
                             {%- if project.image -%},
                             "image": '{{ project.image }}'
@@ -141,8 +142,15 @@ function retrieveProjectDataFromCollection(){
     projectData.forEach((data,i) => {
         const { project } = data;
         const matchingProject = projectLanguagesArr.find(x=> x.id === project.identification);
+        const secMatchingProject = projectLanguagesArr.find(x=> x.id === project['additional-repo-ids']);
         if(matchingProject) {
-            project.languages = matchingProject.languages
+            project.languages = matchingProject.languages;
+            
+            if(project['additional-repo-ids'] !== 0){
+                const langArr = [...matchingProject.languages, ...secMatchingProject.languages];
+                let set = new Set(langArr);
+                project.languages = Array.from(set);
+            }
         }
     })
     return projectData;

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -142,10 +142,8 @@ function retrieveProjectDataFromCollection(){
     projectData.forEach((data,i) => {
         const { project } = data;
         const matchingProject = projectLanguagesArr.find(x=> x.id === project.identification);
-        console.log(project)
         if(matchingProject) {
             project.languages = matchingProject.languages;
-            console.log(project.secondRepoId)
             if(project.secondRepoId != 0){
                 const secMatchingProject = projectLanguagesArr.find(x=> x.id === project.secondRepoId);
                 const langArr = [...matchingProject.languages, ...secMatchingProject.languages];

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -13,7 +13,8 @@ let projects = JSON.parse(decodeURIComponent("{{ projects | jsonify | uri_escape
   https://www.gun.io/blog/pass-arguments-to-embedded-javascript-tutorial-example
 */
 const scriptTag = document.getElementById("projectScript");
-const projectId = scriptTag.getAttribute("projectId").split(", ");
+const projectId = scriptTag.getAttribute("projectId");
+const moreProjectIds = scriptTag.getAttribute("moreProjectIds").split(", ");
 // Search for correct project
 let projectArr = [];
 // Checks if more than one repo id

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -15,20 +15,29 @@ let projects = JSON.parse(decodeURIComponent("{{ projects | jsonify | uri_escape
 const scriptTag = document.getElementById("projectScript");
 const projectId = scriptTag.getAttribute("projectId").split(", ");
 // Search for correct project
-let project = [];
-
+let projectArr = [];
+// Checks if more than one repo id
 for (let i = 0; i < projectId.length; i++){
     // Starts at 1 now since the first element is a time stamp
     for (let k = 1; k < projects.length; k++){
         let itemId = projects[k].id.toString();
         if(itemId == projectId[i]){
-            project.push(projects[k])
+            projectArr.push(projects[k])
         }
     }
 }
 
-console.log(project);
+let project = projectArr[0];
 
+// Merge the language sections
+if (projectArr.length > 1){
+    let languagesArr = [];
+    for (let i = 0; i < projectArr.length; i++) {
+        languagesArr = languagesArr.concat(projectArr[i].languages) 
+    }
+    let set = new Set(languagesArr);
+    project.languages = Array.from(set);
+}
 /*
   Assign hero background image
 */

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -15,26 +15,29 @@ let projects = JSON.parse(decodeURIComponent("{{ projects | jsonify | uri_escape
 const scriptTag = document.getElementById("projectScript");
 const projectId = scriptTag.getAttribute("projectId");
 const moreProjectIds = scriptTag.getAttribute("moreProjectIds").split(", ");
+const projectIdArr = [projectId, ...moreProjectIds];
+
 // Search for correct project
-let projectArr = [];
-// Checks if more than one repo id
-for (let i = 0; i < projectId.length; i++){
+const projectObjArr = [];
+
+// loops through projectIdArr and pushes project obj to projectObjArr 
+for (let i = 0; i < projectIdArr.length; i++){
     // Starts at 1 now since the first element is a time stamp
     for (let k = 1; k < projects.length; k++){
         let itemId = projects[k].id.toString();
-        if(itemId == projectId[i]){
-            projectArr.push(projects[k])
+        if(itemId == projectIdArr[i]){
+            projectObjArr.push(projects[k])
         }
     }
 }
 
-let project = projectArr[0];
+const project = projectObjArr[0];
 
 // Merge the language sections
-if (projectArr.length > 1){
+if (projectObjArr.length > 1){
     let languagesArr = [];
-    for (let i = 0; i < projectArr.length; i++) {
-        languagesArr = languagesArr.concat(projectArr[i].languages) 
+    for (let i = 0; i < projectObjArr.length; i++) {
+        languagesArr = languagesArr.concat(projectObjArr[i].languages) 
     }
     let set = new Set(languagesArr);
     project.languages = Array.from(set);

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -13,17 +13,21 @@ let projects = JSON.parse(decodeURIComponent("{{ projects | jsonify | uri_escape
   https://www.gun.io/blog/pass-arguments-to-embedded-javascript-tutorial-example
 */
 const scriptTag = document.getElementById("projectScript");
-const projectId = scriptTag.getAttribute("projectId");
+const projectId = scriptTag.getAttribute("projectId").split(", ");
 // Search for correct project
-let project = null;
-// Starts at 1 now since the first element is a time stamp
-for (let i = 1; i < projects.length; i++){
-    let itemId = projects[i].id.toString();
-    if(itemId == projectId){
-        project = projects[i];
-        break;
+let project = [];
+
+for (let i = 0; i < projectId.length; i++){
+    // Starts at 1 now since the first element is a time stamp
+    for (let k = 1; k < projects.length; k++){
+        let itemId = projects[k].id.toString();
+        if(itemId == projectId[i]){
+            project.push(projects[k])
+        }
     }
 }
+
+console.log(project);
 
 /*
   Assign hero background image

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -30,7 +30,8 @@ for (let i = 0; i < projectIdArr.length; i++){
         }
     }
 }
-
+/* data other than languages is taken from the project whose 
+ repo id is paired with key "identification" on the md file */
 const project = projectObjArr[0];
 
 // Merge the language sections

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -35,7 +35,6 @@ if (scriptTag.getAttribute("secRepoId")){
     let languagesArr = [...firstLangs, ...secLangs];
     let set = new Set(languagesArr);
     project.languages = Array.from(set);
-    console.log(typeof scriptTag.getAttribute("secRepoId"));
 }
 /*
   Assign hero background image

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -14,34 +14,28 @@ let projects = JSON.parse(decodeURIComponent("{{ projects | jsonify | uri_escape
 */
 const scriptTag = document.getElementById("projectScript");
 const projectId = scriptTag.getAttribute("projectId");
-const moreProjectIds = scriptTag.getAttribute("moreProjectIds").split(", ");
-const projectIdArr = [projectId, ...moreProjectIds];
+const project = findProjectById(projectId);
 
-// Search for correct project
-const projectObjArr = [];
-
-// loops through projectIdArr and pushes project obj to projectObjArr 
-for (let i = 0; i < projectIdArr.length; i++){
+function findProjectById(identification){
     // Starts at 1 now since the first element is a time stamp
-    for (let k = 1; k < projects.length; k++){
-        let itemId = projects[k].id.toString();
-        if(itemId == projectIdArr[i]){
-            projectObjArr.push(projects[k])
+    for (let i = 1; i < projects.length; i++){
+        let itemId = projects[i].id.toString();
+        if(itemId == identification){
+            return projects[i]
         }
     }
-}
-/* data other than languages is taken from the project whose 
- repo id is paired with key "identification" on the md file */
-const project = projectObjArr[0];
+} 
 
-// Merge the language sections
-if (projectObjArr.length > 1){
-    let languagesArr = [];
-    for (let i = 0; i < projectObjArr.length; i++) {
-        languagesArr = languagesArr.concat(projectObjArr[i].languages) 
-    }
+// Merge the language sections if there's a second repo
+if (scriptTag.getAttribute("secRepoId")){
+    const secRepoId = scriptTag.getAttribute("secRepoId");    
+    const firstLangs = project.languages;
+    const secLangs = findProjectById(secRepoId).languages;
+
+    let languagesArr = [...firstLangs, ...secLangs];
     let set = new Set(languagesArr);
     project.languages = Array.from(set);
+    console.log(typeof scriptTag.getAttribute("secRepoId"));
 }
 /*
   Assign hero background image


### PR DESCRIPTION
Fixes #3805

### What changes did you make?
  -allow for 2 repo ids to be scraped
  -merge lanaguages array from both repos without duplicates
  -added CTI backend repo id to md file

### Why did you make the changes (we will use this info to test)?
  -the languages section now shows languages used in both CTI Frontend and CTI Backend 
 
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot from 2023-07-26 02-19-53](https://github.com/hackforla/website/assets/65173070/04b98b9f-6f98-4ddb-ae61-518c282d9ef2)

![Screenshot from 2023-07-26 02-21-10](https://github.com/hackforla/website/assets/65173070/cc01722a-4d52-41c1-9bfb-f3e5fe9f0df2)

</details>

<details>

![Screenshot from 2023-07-26 02-22-32](https://github.com/hackforla/website/assets/65173070/4c892b81-085b-4347-b563-e136ac3bee0c)

![Screenshot from 2023-07-26 02-22-38](https://github.com/hackforla/website/assets/65173070/cb7d79c5-aa3a-47e8-9949-699258b7a4e4)

<summary>Visuals after changes are applied</summary> 
 


</details>
