### PR TITLE
removed ending slash for IMG tag-issue #5027

### DIFF
--- a/_includes/about-page/about-card-accomplishments.html
+++ b/_includes/about-page/about-card-accomplishments.html
@@ -26,7 +26,7 @@
                 <p class="eliptical align-left coming-soon"><a href="https://hackforla.org/wins">View Volunteer Wins</a></p>
             </div>
             <div class="bottom-right-column wins-column-width-right">
-                <div class="wins-card-mobile"><a href="https://hackforla.org/wins" target="_blank" rel="noopener noreferrer"><img src="/assets/images/about/wins-card-mobile.svg" alt="Wins card: contributors' names, teams and roles, and testimonials of their accomplishments." /></a></div>
+                <div class="wins-card-mobile"><a href="https://hackforla.org/wins" target="_blank" rel="noopener noreferrer"><img src="/assets/images/about/wins-card-mobile.svg" alt="Wins card: contributors' names, teams and roles, and testimonials of their accomplishments." ></a></div>
                 <div class="wins-card-desktop"><a href="https://hackforla.org/wins" target="_blank" rel="noopener noreferrer"><img src="/assets/images/about/wins-card-desktop.svg" alt="Wins card: contributors' names, teams and roles, and testimonials of their accomplishments." /></a></div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #5027

### What changes did you make?
Removed a closing slash from an IMG tag for `<img` src="/assets/images/about/wins-card-mobile.svg" alt="Wins card: contributors' names, teams and roles, and testimonials of their `accomplishments.">`

### Why did you make the changes (we will use this info to test)?
Action was requested for a good first issue to make code consistent

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

There were no visual changes after the code edit since it was only an HTML tag formatting change to create consistency with the rest of the code..



</details>

<details>
<summary>Visuals after changes are applied</summary>
  
See comment above


</details>
