### PR TITLE
Refactor `tools` data from string to list

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -99,6 +99,7 @@ technologies:
   - Google Apps Script
   - GitHub Actions
   - VRMS API
+tools:
   - Figma
   - Google Drive
   - Zoom

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -99,7 +99,6 @@ technologies:
   - Google Apps Script
   - GitHub Actions
   - VRMS API
-tools:
   - Figma
   - Google Drive
   - Zoom

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -1,7 +1,7 @@
 ---
 identification: '130000551'
 title: Hack for LA Site
-description: The Hack for LA Site (hackforla.org) is our organization's way of communicating with volunteers, stakeholders, and donors. This project is a good place to start for new volunteers looking to polish their git protocol skills (branches, separation of concerns, etc.). We currently have two development paths&#58; growth (building out new pages and guides) and optimization (taking inventory of our code and design systems) to ensure we are consistently delivering value to our users while being scalable in our approach to building the site.
+description: The Hello Hack for LA Site (hackforla.org) is our organization's way of communicating with volunteers, stakeholders, and donors. This project is a good place to start for new volunteers looking to polish their git protocol skills (branches, separation of concerns, etc.). We currently have two development paths&#58; growth (building out new pages and guides) and optimization (taking inventory of our code and design systems) to ensure we are consistently delivering value to our users while being scalable in our approach to building the site.
 image: /assets/images/projects/website.png
 alt: 'Hack for LA Site'
 image-hero: /assets/images/projects/website-hero.jpg
@@ -99,6 +99,7 @@ technologies:
   - Google Apps Script
   - GitHub Actions
   - VRMS API
+tools:
   - Figma
   - Google Drive
   - Zoom

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -99,7 +99,11 @@ technologies:
   - Google Apps Script
   - GitHub Actions
   - VRMS API
-tools: Figma, Google Drive, Zoom, Google Analytics, 1Password
+tools: - Figma
+  - Google Drive
+  - Zoom
+  - Google Analytics
+  - 1Password
 location:
   # - Santa Monica
   # - Downtown LA

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -99,7 +99,7 @@ technologies:
   - Google Apps Script
   - GitHub Actions
   - VRMS API
-tools: - Figma
+  - Figma
   - Google Drive
   - Zoom
   - Google Analytics

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -1,7 +1,7 @@
 ---
 identification: '130000551'
 title: Hack for LA Site
-description: The Hello Hack for LA Site (hackforla.org) is our organization's way of communicating with volunteers, stakeholders, and donors. This project is a good place to start for new volunteers looking to polish their git protocol skills (branches, separation of concerns, etc.). We currently have two development paths&#58; growth (building out new pages and guides) and optimization (taking inventory of our code and design systems) to ensure we are consistently delivering value to our users while being scalable in our approach to building the site.
+description: The Hack for LA Site (hackforla.org) is our organization's way of communicating with volunteers, stakeholders, and donors. This project is a good place to start for new volunteers looking to polish their git protocol skills (branches, separation of concerns, etc.). We currently have two development paths&#58; growth (building out new pages and guides) and optimization (taking inventory of our code and design systems) to ensure we are consistently delivering value to our users while being scalable in our approach to building the site.
 image: /assets/images/projects/website.png
 alt: 'Hack for LA Site'
 image-hero: /assets/images/projects/website-hero.jpg


### PR DESCRIPTION
Fixes #4813

### What changes did you make?
  - Changed the data for `tools` from a string to a list. More specifically, I changed it from comma-separated strings to a bulleted list with hypthens. 

### Why did you make the changes (we will use this info to test)?
  - This change is to contribute to the ongoing effort "to revise the filter menu in the [projects-check](https://www.hackforla.org/projects-check) page to include a dropdown for 'Tools', so that we can see where we might need to move project values from tools to technologies, and vice versa." (quoted from the original issues page)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
</details>

<details>
<summary>Visuals after changes are applied</summary>
 ![image](https://i.imgur.com/0poLdJ5.png)
</details>
