### PR TITLE
Refactor Tools data for open-community-survey.md

### DIFF
--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -62,7 +62,11 @@ location:
   # - Los Angeles
   - Remote
 partner: 'LA Department of Neighborhood Empowerment (DONE), LA Neighborhood Councils (NCs), LA Department of Transportation (LADOT), LA City Planning Department (LACP)'
-tools: 'ArcGIS surveys, Figma, Google Docs, Zoom'
+tools:
+  - ArcGIS surveys
+  - Figma
+  - Google Docs
+  - Zoom
 visible: true
 program-area:
   - Citizen Engagement

--- a/assets/js/current-projects-check.js
+++ b/assets/js/current-projects-check.js
@@ -98,7 +98,7 @@ function retrieveProjectDataFromCollection(){
                             "partner": `{{ project.partner }}`
                             {%- endif -%}
                             {%- if project.tools -%},
-                            "tools": `{{ project.tools | jsonify }}`
+                            "tools": {{ project.tools  | jsonify }}
                             {%- endif -%}
                             {%- if project.looking -%},
                             "looking": {{ project.looking | jsonify }}


### PR DESCRIPTION
Fixes #4811 

### What changes did you make?

- update of open-community-survey.md tools data from a string to a list
- current-projects-check.js the clause where project.tools is set is still in single quotes, removed quotes so json is an array instead of string literal

### Why did you make the changes (we will use this info to test)?

- so it displays correctly on all projects pages for the community survey card

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![refactor-tools-data-4811_0](https://github.com/hackforla/website/assets/5543388/ceb1023c-ae07-4500-b940-671096be54af)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![refactor-tools-data-4811_1](https://github.com/hackforla/website/assets/5543388/697de4c0-2f5a-4945-803e-00769cfe4d6c)
but even with the suggested changes on #4811 tools displays as a string representation of a list, and not a comma separated list. On review of #4861 one of the dependencies for #4811 I discovered that in current-projects-check.js the clause where project.tools is set is still in single quotes. On removing the single quotes tools displays as a comma separated list.

![refactor-tools-data-4811_3](https://github.com/hackforla/website/assets/5543388/42fd6df8-fd4e-40da-92fb-b973cf48f920)

</details>
