### PR TITLE
refactored img tag - removed slash from join us card/volunteer

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -51,7 +51,7 @@ permalink: /join
     <a class="anchor" id="volunteer"></a>
     <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
       <h2 class="title4 page-card--large-icon-header">Volunteer with Us</h2>
-      <img class="join-us-card-img" src="/assets/images/join-us/volunteer-with-us-icon.svg" alt="" />
+      <img class="join-us-card-img" src="/assets/images/join-us/volunteer-with-us-icon.svg" alt="">
       <div class="join-us-card-body page-card--large-icon-body">
         <p class="join-us-remove-p-padding">
           Hack for LA projects are currently recruiting for activists, coders, designers, researchers, testers, business


### PR DESCRIPTION
Fixes #5032

### What changes did you make?
Refactored volunteer img tag by removing closing slash.

### Why did you make the changes (we will use this info to test)?
To make the codebase consistent so that img tags are not self closing.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2023-07-27 at 4 51 41 PM](https://github.com/hackforla/website/assets/20288105/a23768c5-72ff-4cb6-ae54-8043ed15b205)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2023-07-27 at 5 01 26 PM](https://github.com/hackforla/website/assets/20288105/40b5047d-e541-4ea9-bcdb-b75115756293)


</details>