### PR TITLE
Add redirect for broken links on "Project Team Meetings" page

### DIFF
--- a/assets/js/utility/api-events.js
+++ b/assets/js/utility/api-events.js
@@ -33,6 +33,10 @@ function insertEventSchedule(eventData, page) {
     } else {
       value.forEach((event) => {
         if (event) {
+		  // If a project doesn't have an hflaWebsiteUrl, redirect to the project's Github page
+		  if (event.hflaWebsiteUrl == "") {
+			  event.hflaWebsiteUrl = event.githubUrl
+		  }
           let eventHtml;
 				  // insert the correct html for the current page
 				  if (page === "events") {
@@ -150,6 +154,7 @@ function display_object(item) {
       start: localeTimeIn12Format(item.startTime),
       end: localeTimeIn12Format(item.endTime),
       hflaWebsiteUrl: item.project.hflaWebsiteUrl,
+	  githubUrl: item.project.githubUrl,
 	  };
 	  return rv_object;
   }


### PR DESCRIPTION
Fixes #4906

### What changes did you make?
  - updated api-events.js after if (event) { on Line 35 and before let eventHtml; on Line 36:
  - near the end of the same file in function display_object(item)
  - confirmed that this link and the others work correctly on the [project-meetings](https://www.hackforla.org/project-meetings) and [events](https://www.hackforla.org/events/) pages by clicking through the updated links and those with existing href
  
### Why did you make the changes (we will use this info to test)?
  - so that if event does not have hflaWebsiteUrl, redirect to the event githubUrl
  - so that githubUrl will be populated from the vrms response

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

project-meetings page
People Depot link
![add-redirect-for-broken-links-4906_0](https://github.com/hackforla/website/assets/5543388/08f23829-701c-4a3c-a214-39846ed99c5a)

Tables link
![add-redirect-for-broken-links-4906_1](https://github.com/hackforla/website/assets/5543388/7bbfa3f2-ce56-4b81-a43f-011579b91f28)

events page
People Depot link
![add-redirect-for-broken-links-4906_2](https://github.com/hackforla/website/assets/5543388/48753d8f-f7a9-4ead-a956-4003c84ed90a)

Tables link
![add-redirect-for-broken-links-4906_3](https://github.com/hackforla/website/assets/5543388/0cdb8c95-7263-4028-a7f1-2220e6cdee10)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
project-meetings page
People Depot link
![add-redirect-for-broken-links-4906_4](https://github.com/hackforla/website/assets/5543388/4ec43906-9d42-4323-8c5d-cd140898511a)

Tables link
![add-redirect-for-broken-links-4906_5](https://github.com/hackforla/website/assets/5543388/8712202b-b62a-414b-b311-6dd49e15ca40)

events page
People Depot link
![add-redirect-for-broken-links-4906_6](https://github.com/hackforla/website/assets/5543388/5b6eaced-a9e1-4259-af31-b10efbe608c0)

Tables link
![add-redirect-for-broken-links-4906_7](https://github.com/hackforla/website/assets/5543388/b368182a-61fe-455e-8646-55b67b88596a)

</details>
