### PR TITLE
Updated meeting day on cop-engr #5003.

### DIFF
--- a/_data/internal/communities/engineering.yml
+++ b/_data/internal/communities/engineering.yml
@@ -9,7 +9,7 @@ location:
 image: /assets/images/communities-of-practice/engineering.jpg
 alt: 'A computer screen shows a diagram used to manage code development'
 
-meeting-times: Wednesdays 6:00-7:00 pm PT
+meeting-times: Thursdays 6:00-7:00 pm PT
 
 leadership-type: Peer Led
 leadership:


### PR DESCRIPTION
Fixes #5003 

### What changes did you make?
  - Updated the meeting day on the CoP Engr section per issue.

Change:

```
meeting-times: Wednesdays 6:00-7:00 pm PT

to

meeting-times: Thursdays 6:00-7:00 pm PT
```

### Why did you make the changes (we will use this info to test)?
  - Updating meet day to the accurate meeting date for all new visitors on the CoP page.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image (4)](https://github.com/hackforla/website/assets/113082803/96c9d158-f4b6-4b3c-b8c5-868ef493ce24)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image (5)](https://github.com/hackforla/website/assets/113082803/fc38afeb-9830-497d-8149-696fcf3e4798)

</details>
