### PR TITLE
Updated inline svg with aria-label 4299

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
           <ul class="inline-list header-list">
             {% for item in site.data.navigation.social %} {% if item.footer %}
             <li>
-              <a href="{{ item.link }}" rel="noopener" target="_blank" class="js-inline-link js-inline-link-{{ item.name | downcase }}">
+              <a href="{{ item.link }}" rel="noopener" target="_blank" class="js-inline-link js-inline-link-{{ item.name | downcase }}" aria-label="{{ item.name }}" >
                 {% if item.icon %}
                 {%- include {{ site.baseurl }}{{ item.icon }} -%}
                 {% endif %}


### PR DESCRIPTION
Fixes #4299

### What changes did you make?
  - At the Footer of the Donate page - added aria-label with the social's name for screen reader accessibility: aria-label="{{ item.name }} 

### Why did you make the changes (we will use this info to test)?
  - Vocalize the links associated with the social media icons per WCAG guidelines
  - Verified fix with Chrome Screen Reader Extension and tabbing over the social icons, so that it audibly reads the list of social media icon's names.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

NA
