### PR TITLE
Removed ending slash from one img Tag on Program Areas Page

### DIFF
--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -70,7 +70,7 @@ permalink: /program-areas
         class="join-us-footer-img desktop-img"
         src="/assets/images/join-us/volunteer-with-us-icon.svg"
         alt=""
-      />
+      >
       <div class="join-us-footer-description">
         <h3>Join a Project</h3>
         <img


### PR DESCRIPTION
Fixes #5138

### What changes did you make?
  - removed ending slash from only one img tag (img tag with "join-us-footer-img desktop-img)
  - change was made from below 
```
   <img
        class="join-us-footer-img desktop-img"
        src="/assets/images/join-us/volunteer-with-us-icon.svg"
        alt=""
      />
```
  to
```
      <img
        class="join-us-footer-img desktop-img"
        src="/assets/images/join-us/volunteer-with-us-icon.svg"
        alt=""
      >
```
- there was other img tags on 'pages/program-areas.html'. As per instruction on the issue, I made a change only to the above specific img tag.

### Why did you make the changes (we will use this info to test)?
  - We want to change an img HTML tag ending with a slash (<img.../>) to an img tag without an ending slash (<img...>) so that the codebase is consistent with how we use img HTML tags.


### Screenshots of Proposed Changes Of The Website  
- there was no visual changes