### PR TITLE
update Data Science CoP meeting time

### DIFF
--- a/_data/internal/communities/data-science.yml
+++ b/_data/internal/communities/data-science.yml
@@ -9,7 +9,7 @@ location:
 image: /assets/images/communities-of-practice/data.jpg
 alt: 'A person uses a laptop to review a data dashboard'
 
-meeting-times: Thursdays 8:00-9:00 pm PT
+meeting-times: Mondays 7:00-8:00 pm PT
 
 leadership-type: Mentor Led
 leadership:


### PR DESCRIPTION
Fixes #5131 

### What changes did you make?
  - Updated meeting time for Data Science CoP to Mondays 7:00-8:00 pm PT.
  - Verified that the change is visible via Docker. 

### Why did you make the changes (we will use this info to test)?
  - Update website with correct Data Science CoP meeting time.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/37560463/b4f86410-35de-441a-8b68-b54060d2bd7a)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/37560463/855a6db2-2023-4461-9a83-36229dfea54e)

</details>
