### PR TITLE
Updated project profile for website team to include Roslyn Wythe

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -24,12 +24,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U03UG3VCRK6'
       github: 'https://github.com/plang-psm'
     picture: https://avatars.githubusercontent.com/plang-psm
-  - name: Roslyn Wythe
-    role: Merge Team
-    links:
-      slack: 'https://hackforla.slack.com/team/U046PD8UT55'
-      github: 'https://github.com/roslynwythe'
-    picture: https://avatars.githubusercontent.com/roslynwythe
   - name: Will Gillis
     role: Merge Team
     links:
@@ -96,6 +90,13 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U0596J2AZEE'
       github: 'https://github.com/adrianang'
     picture: https://avatars.githubusercontent.com/adrianang
+  - name: Roslyn Wythe
+    role: Dev Lead
+    links:
+      slack: 'https://hackforla.slack.com/team/U046PD8UT55'
+      github: 'https://github.com/roslynwythe'
+    picture: https://avatars.githubusercontent.com/roslynwythe
+
 links:
   - name: Wiki
     url: 'https://github.com/hackforla/website/wiki'


### PR DESCRIPTION
Fixes #5057
### What changes did you make?
  - Added Roslyn Wythe as a dev lead member to the website leadership team
  - Removed Roslyn Wythe's merge team member entry from the website leadership team

### Why did you make the changes (we will use this info to test)?
  - To keep project information for the website up-to-date

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="960" alt="project-site-before-update" src="https://github.com/hackforla/website/assets/15069166/0ec6a95d-52f2-4801-bdb4-017c1b312be3">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="960" alt="project-site-after-update" src="https://github.com/hackforla/website/assets/15069166/3f0c0a27-88c5-4851-a34c-beeebe5c2cd1">

</details>
