### PR TITLE
Removed ending slash from header-hero img tag in Program Areas page

### DIFF
--- a/pages/program-areas.html
+++ b/pages/program-areas.html
@@ -12,7 +12,7 @@ permalink: /program-areas
           from environmental justice to voter representation, in Los Angeles and far beyond.
       </p>
   </div>
-  <img class="header-hero-image" src="/assets/images/toolkit/toolkit-hero.svg" alt="" />
+  <img class="header-hero-image" src="/assets/images/toolkit/toolkit-hero.svg" alt="">
 </div>
 
 <section class="content-section content--program-areas">


### PR DESCRIPTION
Fixes #5137

### What changes did you make?
  - Updated header-hero img tag with no ending slash in Program Areas page.

### Why did you make the changes (we will use this info to test)?
  - So that the code base is consistent with how we use img HTML tags.
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
