### PR TITLE
Updated partner variable on project profile: Food Oasis

### DIFF
--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -99,7 +99,7 @@ tools:
   - Usabilityhub.com surveys
 program-area:
   - Social Safety Net
-partner:
+partner: UCLA (CESC 50XP)
 visible: true
 status: Active
 iframe:


### PR DESCRIPTION
Fixes #4248

### What changes did you make?
  - Updated the partner variable to UCLA (CESC 50XP), on the front matter block, inside of the _projects/food-oasis.md file

### Why did you make the changes (we will use this info to test)?
  - The Food Oasis project page needed to be updated to reflect accurate partner information

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary> Verified change on the Food Oasis project page</summary>

![food-oasis-partner](https://github.com/hackforla/website/assets/42459347/ff000235-1f9c-41ef-a996-cb1284b36170)

</details>

<details>
<summary>Verified change on the Food Oasis card on the projects page</summary>
  
![food-oasis-proj-page](https://github.com/hackforla/website/assets/42459347/4887e67d-dd9e-49c5-ae37-8f6870055cd4)

</details>
