### PR TITLE
Delete slash on img tag - #5031

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -70,7 +70,7 @@ permalink: /join
     <a class="anchor" id="partner"></a>
     <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
       <h2 class="title4 page-card--large-icon-header">Partner with Us</h2>
-      <img class="join-us-card-img" src="/assets/images/join-us/partner-with-us-icon.svg" alt="" />
+      <img class="join-us-card-img" src="/assets/images/join-us/partner-with-us-icon.svg" alt="">
       <div class="join-us-card-body page-card--large-icon-body">
         <p>
           The more you tell us about yourself, the better we can match you with


### PR DESCRIPTION
Fixes #5031

### What changes did you make?
  - Delete the ending slash on the img tag in the join-us.html

### Why did you make the changes (we will use this info to test)?
  - Made the changes in order to make the code more consistent syntactically 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![originalJoinUs](https://github.com/hackforla/website/assets/104947296/83a0551e-5fba-42af-81c4-1df496a62037)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![changesAfterFix](https://github.com/hackforla/website/assets/104947296/b7ac5c5b-16d1-43b5-bd2b-f21a54388743)

</details>
