### PR TITLE
Refactor img tag –– About Us Sponsors Card

### DIFF
--- a/_includes/about-page/about-card-sponsors.html
+++ b/_includes/about-page/about-card-sponsors.html
@@ -1,7 +1,7 @@
 <div class='card-primary page-card-lg page-card--about'>
     <div class="about-us-section-header" data-hash="sponsors"><span class="sec-head-img"><img
                 src="/assets/images/about/section-header-elements/sponsors.svg"
-                alt="Make your donation for Hack for LA Brigade on codeforamerica.org/donate. Choose the amount and select the payment frequency, then enter 'Hack for LA' under 'if your donation is for a Brigade, please select the Brigade Name(Optional)'." /></span>Sponsors
+                alt="Make your donation for Hack for LA Brigade on codeforamerica.org/donate. Choose the amount and select the payment frequency, then enter 'Hack for LA' under 'if your donation is for a Brigade, please select the Brigade Name(Optional)'."></span>Sponsors
     </div>
     <div class="about-us-section-content">
         <div class="flex-container-row flex-container-row--partners">


### PR DESCRIPTION
Fixes #5201 

### What changes did you make?
  - Removed the ending slash in the img HTML tag for the about-card-sponsors header icon

### Why did you make the changes (we will use this info to test)?
  - The tag was updated to create consistency among HTML tags in the rest of the codebase 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
No visual changes were made!
</details>

<details>
<summary>Visuals after changes are applied</summary>
</details>
