### PR TITLE
Refactored img tag on Join page

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -21,7 +21,7 @@ permalink: /join
         Los Angeles chapter.
       </p>
     </div>
-    <img class="header-hero-image" src="/assets/images/join-us/banner-icon.svg" alt="" />
+    <img class="header-hero-image" src="/assets/images/join-us/banner-icon.svg" alt="">
   </div>
 
   <div class="content-section join-us-card-container">


### PR DESCRIPTION
Fixes #5147 

### What changes did you make?
  - Removed ending slash in img tag for banner-icon.svg on the Join Us page.

### Why did you make the changes (we will use this info to test)?
  - To make codebase consistent with how Hack for LA uses img HTML tags.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Refactored img tag. No visual changes to the website.
