### PR TITLE
Removed ending slash in img tag

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -70,7 +70,7 @@ permalink: /join
     <a class="anchor" id="partner"></a>
     <div class="page-card card-primary page-card-lg page-card--join page-card--large-icon-container">
       <h2 class="title4 page-card--large-icon-header">Partner with Us</h2>
-      <img class="join-us-card-img" src="/assets/images/join-us/partner-with-us-icon.svg" alt="" />
+      <img class="join-us-card-img" src="/assets/images/join-us/partner-with-us-icon.svg" alt="">
       <div class="join-us-card-body page-card--large-icon-body">
         <p>
           The more you tell us about yourself, the better we can match you with


### PR DESCRIPTION
Fixes #5150 
### What changes did you make?
  - Changed the img HTML tag ending with a slash (<img.../>) to an img tag without an ending slash (<img...>) in the Partner With Us section of the Join Us page

### Why did you make the changes (we will use this info to test)?
  - So that the codebase is consistent with how we use img HTML tags

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes to site