### PR TITLE
img Tag Refactor - removed ending slash for meetup.svg - #5184

### DIFF
--- a/_includes/events-page/left-col-content.html
+++ b/_includes/events-page/left-col-content.html
@@ -1,5 +1,5 @@
 <h3 class="event-title title4">
-    <img class="vector-img" src="../assets/images/hack-nights/meetup.svg" alt="meetup logo" /> Meetup Events
+    <img class="vector-img" src="../assets/images/hack-nights/meetup.svg" alt="meetup logo"> Meetup Events
 </h3>
 <div class="mobile-dropdown">
 


### PR DESCRIPTION
Fixes #5184 

### What changes did you make?
  - Removed ending slash for img tag of meetup.svg

### Why did you make the changes (we will use this info to test)?
  - Needed a consistent codebase with how we use img HTML tags

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

No visual changes.

</details>

<details>
<summary>Visuals after changes are applied</summary>

No visual changes.

</details>
