### PR TITLE
Refactor Img Tag in About Page's News Card

### DIFF
--- a/_includes/about-page/about-card-news.html
+++ b/_includes/about-page/about-card-news.html
@@ -5,7 +5,7 @@
             {% for item in site.data.internal.press %}
                 <div class="news-cells">
                     <div class="image-news-container">
-                        <img src="{{item[1].image}}" alt="{{item[1].image_alt}}" />
+                        <img src="{{item[1].image}}" alt="{{item[1].image_alt}}">
                     </div>
                     <p><a href="{{item[1].link_url}}" target="_blank" rel="noopener noreferrer">{{item[1].title}}</a></p>
                 </div>


### PR DESCRIPTION
Fixes #5199

### What changes did you make?
  - Removed ending slash from img HTML tag
  - Removed ending whitespace from img HTML tag

### Why did you make the changes (we will use this info to test)?
  - To ensure that codebase is consistent with how we use img HTML tags

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Removing slash and whitespace from an img HTML tag to ensure consistency. No visual changes to the website.