### PR TITLE
Delete slash on img tag

### DIFF
--- a/_includes/about-page/about-card-sustainability.html
+++ b/_includes/about-page/about-card-sustainability.html
@@ -51,7 +51,7 @@
                     <img src="/assets/images/sdg/sdg8.svg" alt="8 Decent Work and Economic Growth" />
                     <img src="/assets/images/sdg/sdg11.svg" alt="11 Sustainable Cities and Communities" />
                     <img src="/assets/images/sdg/sdg13.svg" alt="13 Climate Action">
-                    <img src="/assets/images/sdg/sdg16.svg" alt="16 Peace, Justice and Strong Institutions" />
+                    <img src="/assets/images/sdg/sdg16.svg" alt="16 Peace, Justice and Strong Institutions">
                     <img src="/assets/images/sdg/sdg17.svg" alt="17 Partnerships For The Goals" />
                     <div class="grid-center"><img src="/assets/images/sdg/sdg-la.svg" alt="" /><br />
                     </div>


### PR DESCRIPTION
Fixes #5173

### What changes did you make?
  - Delete ending img tag slash 

### Why did you make the changes (we will use this info to test)?
  - Made the changes in order to make the codebase consistent with using the '/' in img tags 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

***No need for photos since there were no visual changes***
