### PR TITLE
Refactored HTML on the about page sponsors card

### DIFF
--- a/_includes/about-page/about-card-sponsors.html
+++ b/_includes/about-page/about-card-sponsors.html
@@ -1,4 +1,4 @@
-<div class='card-primary page-card-lg page-card--about'>
+<div class="card-primary page-card-lg page-card--about">
     <div class="about-us-section-header" data-hash="sponsors"><span class="sec-head-img"><img
                 src="/assets/images/about/section-header-elements/sponsors.svg"
                 alt="Make your donation for Hack for LA Brigade on codeforamerica.org/donate. Choose the amount and select the payment frequency, then enter 'Hack for LA' under 'if your donation is for a Brigade, please select the Brigade Name(Optional)'."></span>Sponsors


### PR DESCRIPTION
Fixes #5288

### What changes did you make?
  - Updated HTML tag to change single quotes around class names to double quotes

### Why did you make the changes (we will use this info to test)?
  - To resolve a linter error: "Value of attribute [class] must be in double quotes"

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes caused by refactoring HTML for class attribute.