### PR TITLE
Replaced single quotes with double quotes to avoid linter error

### DIFF
--- a/_includes/about-page/about-card-accomplishments.html
+++ b/_includes/about-page/about-card-accomplishments.html
@@ -1,4 +1,4 @@
-<div class='card-primary page-card-lg page-card--about'>
+<div class="card-primary page-card-lg page-card--about">
     <div class="about-us-section-header" data-hash="accomplishments"><span class="sec-head-img"><img src="/assets/images/about/section-header-elements/accomplishments.svg" alt="" /></span>Accomplishments</div>
     <div class="about-us-section-content">
         <div class="flex-container">


### PR DESCRIPTION
Fixes #5281 

### What changes did you make?
  -Replaced single quotes around class in HTML tag with double quotes


### Why did you make the changes (we will use this info to test)?
  -To avoid a linter error

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Minor formatting issue, no visual changes to website. 