### PR TITLE
Refactor div to resolve linter error –– about-card-partners.html

### DIFF
--- a/_includes/about-page/about-card-partners.html
+++ b/_includes/about-page/about-card-partners.html
@@ -1,4 +1,4 @@
-<div class='card-primary page-card-lg page-card--about'>
+<div class="card-primary page-card-lg page-card--about">
     <div class="about-us-section-header" data-hash="partners"><span class="sec-head-img"><img
                 src="/assets/images/about/section-header-elements/partners.svg" alt=""></span>Partners</div>
     <div class="about-us-section-content">


### PR DESCRIPTION
Fixes #5287

### What changes did you make?
  - Refactored the outer-most div to include double quotes instead of single quotes

### Why did you make the changes (we will use this info to test)?
  -Resolves the linter error "Value of attribute [class] must be in double quotes"

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- No visual changes were made
