### PR TITLE
Fix bug with display of Tools data on Homepage and Projects page

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -661,14 +661,14 @@ function projectCardComponent(project){
                         `:""
                         }
 
-                ${project.tools ?
-                `
-                <div class="project-tools">
-                <strong>Tools: </strong>
-                ${ project.tools }
-                </div>
-                `:""
-                }
+                        ${project.tools ?
+                        `
+                        <div class="project-tools">
+                        <strong>Tools: </strong>
+                        ${project.tools.map(tool => `<p class='project-card-field-inline'> ${ tool }</p>`).join(", ")}
+                        </div>
+                        `: ""
+                        }
 
                         ${project.looking ? "" : ""
                         // `


### PR DESCRIPTION
Fixes #5321

### What changes did you make?
  - Fixed indentation of the project-tools div to match the others in the section
  - Refactored the ${project.tools} code to place a comma and space between each tool, similar to the project languages and project technologies
  - Confirmed with Docker that the Tools data renders as expected on both pages, and didn't notice any unexpected changes

### Why did you make the changes (we will use this info to test)?
  - So that the website better demonstrates professionalism and attention to detail to our visitors

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before](https://github.com/hackforla/website/assets/21321101/dfce8c8f-a42f-439e-8e25-12f4e0b13043)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after](https://github.com/hackforla/website/assets/21321101/07c9f49c-1766-4992-9d4e-47f1a8010330)


</details>
