### PR TITLE
Updated technologies on the Access the Data project profile

### DIFF
--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -85,7 +85,7 @@ technologies:
   #- other etc.
   - CKAN
   - Docker
-  - Amazon Web Services (AWS)
+  - AWS
   - PostgreSQL
 location:
   #- Downtown LA


### PR DESCRIPTION
Fixes #5151 

### What changes did you make?
  - On the Access The Data markdown page, in the technologies section, I replaced Amazon Web Services (AWS) with AWS.

### Why did you make the changes (we will use this info to test)?
  - To make the information presented across projects on the Hack for LA website consistent. Previously, the project filter on the homepage and project page included options for both "AWS" and "Amazon Web Services (AWS)". Access the Data was the only project using "Amazon Web Services (AWS)", so changing this to "AWS" will group this project with other projects also using "AWS."

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![filter-before](https://github.com/hackforla/website/assets/114596142/44c69882-2fa2-4ea5-870e-032252a0a6cf)

![project-card-before](https://github.com/hackforla/website/assets/114596142/cb56ef46-0cb4-49b6-8d04-303ad0b127d6)

![project-page-before](https://github.com/hackforla/website/assets/114596142/522e0691-e7ca-4b07-9604-24b1d064780c)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![filter-after](https://github.com/hackforla/website/assets/114596142/9befa2f1-f39c-46a6-85d2-fba8e24777e0)

![project-card-after](https://github.com/hackforla/website/assets/114596142/ffcbe7a9-1819-4ae7-ac79-48a5fc44fa05)

![project-page-after](https://github.com/hackforla/website/assets/114596142/23dbd0ca-5162-41e9-93df-473f08186a71)

</details>
