### PR TITLE
Update Project Profile: Civic Tech Jobs (remove Ava Li)

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -12,12 +12,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U03HUJM7YCX
       github: https://github.com/Salimays
     picture: https://avatars.githubusercontent.com/Salimays
-  - name: Ava Li
-    role: Development Lead
-    links:
-      slack: https://hackforla.slack.com/team/U01B73XGCKV
-      github: https://github.com/Aveline-art
-    picture: https://avatars.githubusercontent.com/Aveline-art
   - name: Noor Grewal
     role: Full Stack Developer
     links:


### PR DESCRIPTION
Fixes #5376 

### What changes did you make?
  - removed Ava Li from `_projects/civic-tech-jobs.md`


### Why did you make the changes (we will use this info to test)?
  - to update the project profiles of Civic Tech Jobs project page.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/97607439/09fe0d88-88ab-45dc-a977-635bc2c9ca0a)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/97607439/20d05d48-a721-4de2-b432-4a6ef06283b6)

</details>
