### PR TITLE
Refactor HTML to resolve linter error in about-card-executive-letter

### DIFF
--- a/_includes/about-page/about-card-executive-letter.html
+++ b/_includes/about-page/about-card-executive-letter.html
@@ -1,4 +1,4 @@
-<div class='card-primary page-card--about page-card--ed'>
+<div class="card-primary page-card--about page-card--ed">
     <div class="about-us-section-header--ED" data-hash="letter"><span class="sec-head-img-ed">
         <img src="/assets/images/about/section-header-elements/letter.svg" alt="" /></span><span id="letterBR">Letter from the Executive Director</span>
     </div>


### PR DESCRIPTION
Fixes #5317 

### What changes did you make?
  - Replaced single quotes with double quotes in the class attribute of the `div` tag.
  -
  -

### Why did you make the changes (we will use this info to test)?
  - To resolve the linter error stating "Value of attribute [class] must be in double quotes."
  - To ensure consistency and adherence to coding standards within the project.
