### PR TITLE
Updated project profile and removed 2 people

### DIFF
--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -34,24 +34,12 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U0245UJP868'
       github: 'https://github.com/Aparna1Gopal'
     picture: https://avatars.githubusercontent.com/Aparna1Gopal
-  - name: Deepa Mohan
-    role: UX Designer 
-    links:
-      slack: 'https://hackforla.slack.com/team/U033H9HT0P2'
-      github: 'https://github.com/deepamohan22'
-    picture: https://avatars.githubusercontent.com/deepamohan22
   - name: Tony Delgado
     role: Developer
     links:
       slack: 'https://hackforla.slack.com/team/U05422GPUQ2'
       github: 'https://github.com/TonyDelgadoWillis'
     picture: https://avatars.githubusercontent.com/TonyDelgadoWillis
-  - name: Jason Yung
-    role: Project Manager
-    links:
-      slack: 'https://hackforla.slack.com/team/U059W9P96C8'
-      github: 'https://github.com/merlinsmagic'
-    picture: https://avatars.githubusercontent.com/merlinsmagic
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/access-the-data/'


### PR DESCRIPTION
Fixes #5315 

### What changes did you make?
  - Removed Deepa Mohan and Jason Yung from [Access the data](https://github.com/hackforla/website/blob/gh-pages/_projects/access-the-data.md)

### Why did you make the changes (we will use this info to test)?
  - We need the information that we present for each of our projects to be up to date and reflect recent personnel changes.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/20477610/70eb73cd-7f18-4dae-a2a5-54520a44edcd)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/20477610/16138f62-08d8-40e9-af09-7eae3fd6e4bc)

</details>
