### PR TITLE
Remove mention of cf a about.html 5408

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -6,8 +6,7 @@
     </h2>
     <p>
       We bring together civic-minded volunteers to build digital products, programs and services with community partners and local 
-      government to address issues in our LA region. Hack for LA is a project of <a href="https://www.codeforamerica.org" rel="noopener" target="_blank">Code for America</a> and is it's 
-      official Los Angeles chapter. 
+      government to address issues in our LA regio. Hack for LA is a project of <a href="https://www.civictechstructure.org/" rel="noopener" target="_blank">Civic Tech Structure, Inc.</a>
     </p>
   </div>
 </section>

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -6,7 +6,7 @@
     </h2>
     <p>
       We bring together civic-minded volunteers to build digital products, programs and services with community partners and local 
-      government to address issues in our LA regio. Hack for LA is a project of <a href="https://www.civictechstructure.org/" rel="noopener" target="_blank">Civic Tech Structure, Inc.</a>
+      government to address issues in our LA region. Hack for LA is a project of <a href="https://www.civictechstructure.org/" rel="noopener" target="_blank">Civic Tech Structure, Inc.</a>
     </p>
   </div>
 </section>

--- a/_projects/brigade-organizers-playbook.md
+++ b/_projects/brigade-organizers-playbook.md
@@ -1,7 +1,7 @@
 ---
 identification: '277577906'
 title: Brigade Organizers Playbook
-description: Each of the 80+ Code for America Brigades is an experiment which generates valuable learnings and new effective processes and practices. However, Brigades and other civic tech volunteer organizations need not start from scratch. This project aims to improve existing structures and create new ones that make it easier to share replicable processes and practices so that organizers and members can iterate on each others work, improving outcomes for the whole network.
+description: Civic tech volunteer organizations often start building from scratch, which uses up valuable resources (time, labor and momentum).  This project aims to improve existing structures and create new ones that make it easier to share replicable processes and practices so that organizers and members can iterate on each other's work, improving outcomes for the civic tech ecosystem.
 image: /assets/images/projects/brigade-organizers-playbook.png
 alt: 'Brigade Organizers Playbook'
 image-hero: /assets/images/projects/brigade-organizers-playbook-hero.png
@@ -101,7 +101,7 @@ technologies:
 location:
   - Remote
 
-partner: Code for America (CfA), CfA National Advisory Council, Code for Boston, Code for Charlottesville
+partner: CfA National Advisory Council, Code for Boston, Code for Charlottesville 
 visible: true
 status: Active
 ---


### PR DESCRIPTION
Fixes #5408

### What changes did you make?
  - removes mention of cfa in about.html
  - replaced the text in `_includes/about.html`  with given text
  - noticed and corrected the misspell of word  `region ` in the issue.

### Why did you make the changes (we will use this info to test)?
  - To keep the website data up-to-date.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/97607439/7c18ec26-ddf4-4433-8192-5645534961d7)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/97607439/7c34fda6-811c-45a1-8d68-228498af6b4c)

</details>
