### PR TITLE
refactor pr instruction logic, add instruction for viewing changes to CONTRIBUTING.md

### DIFF
--- a/github-actions/pr-instructions/create-instruction.js
+++ b/github-actions/pr-instructions/create-instruction.js
@@ -1,30 +1,56 @@
 // Global variables
 var github;
 var context;
+const fs = require('fs');
 
 /**
  * Uses information from the pull request to create commandline instructions.
  * @param {Object} g - github object
  * @param {Object} c - context object
- * @returns {string} string containing commandline instructions
+ * @returns {string} string containing commandline instructions, URI encoded since the backtick character is not allowed in *  artifact
  */
 function main({ g, c }) {
     github = g;
     context = c;
-    return createInstruction();
+    return encodeURI(compositeInstruction());   
 }
 
-function createInstruction() {
+function formatPullComment(instruction) {
+    const path = './github-actions/pr-instructions/pr-instructions-template.md'
+    const text = fs.readFileSync(path).toString('utf-8');
+    const completedInstructions = text.replace('${commandlineInstructions}', instruction);
+    return completedInstructions;
+}
+
+function formatContribComment(instruction){
+	const path = './github-actions/pr-instructions/pr-instructions-contrib-template.md'
+    const text = fs.readFileSync(path).toString('utf-8');
+    const completedInstructions = text.replace('${previewContribInstructions}', instruction);
+    return completedInstructions;
+}
+
+function createPullInstruction(){
     const nameOfCollaborator = context.payload.pull_request.head.repo.owner.login;
     const nameOfFromBranch = context.payload.pull_request.head.ref;
     const nameOfIntoBranch = context.payload.pull_request.base.ref;
     const cloneURL = context.payload.pull_request.head.repo.clone_url;
-
-    const instructionString =
+    const pullInstructionString =
 `git checkout -b ${nameOfCollaborator}-${nameOfFromBranch} ${nameOfIntoBranch}
 git pull ${cloneURL} ${nameOfFromBranch}`
+    return pullInstructionString;
+}
 
-    return instructionString
+function createContribInstruction(){
+	const nameOfCollaborator = context.payload.pull_request.head.repo.owner.login;
+    const nameOfFromBranch = context.payload.pull_request.head.ref;
+	const previewContribURL = `https://github.com/${nameOfCollaborator}/website/blob/${nameOfFromBranch}/CONTRIBUTING.md`
+	return previewContribURL;
+}
+
+function compositeInstruction() {
+	const completedPullInstruction = formatPullComment(createPullInstruction());
+	const completedContribInstruction = formatContribComment(createContribInstruction());
+	return completedPullInstruction + completedContribInstruction;
 }
 
 module.exports = main

--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -16,16 +16,9 @@ async function main({ g, c }, { issueNum, instruction }) {
     github = g;
     context = c;
 
-    const instructions = formatComment(instruction)
-    postComment(issueNum, instructions);
+    postComment(issueNum, decodeURI(instruction));
 }
 
-function formatComment(instruction) {
-    const path = './github-actions/pr-instructions/pr-instructions-template.md'
-    const text = fs.readFileSync(path).toString('utf-8');
-    const completedInstuctions = text.replace('${commandlineInstructions}', instruction)
-    return completedInstuctions
-}
 
 async function postComment(issueNum, instructions) {
     try {

--- a/github-actions/pr-instructions/pr-instructions-contrib-template.md
+++ b/github-actions/pr-instructions/pr-instructions-contrib-template.md
@@ -1,0 +1,9 @@
+<!-- Note: Commandline instructions are added into where the placeholder string first appears --->
+
+-------------------
+
+Note that CONTRIBUTING.md cannot previewed locally; rather it should be previewed at this URL:
+
+```
+${previewContribInstructions}  
+```


### PR DESCRIPTION
Fixes #5165

### What changes did you make?
  - All logic to generate, format (with template) and combine instructions is now in create-instruction.js.  The combined instruction is then URI encoded prior to artifact upload.   
  - Instruction (and template) added for review of changes to CONTRIBUTING.md


### Why did you make the changes (we will use this info to test)?
  - The existing PR instructions were not appropriate for reviewing change to CONTRIBUTING.md, because CONTRIBUTING.md must be previewed within a GitHub repository.  
  - We are preparing for the next step which will be to include (or exclude) specific portions of the pr instructions based on the files contained within the PR.  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No Visual Changes to the website