### PR TITLE
Refactor GHA pr instructions, add instruction for previewing CONTRIBUTING.md

### DIFF
--- a/.github/workflows/wr-pr-instructions.yml
+++ b/.github/workflows/wr-pr-instructions.yml
@@ -41,7 +41,7 @@ jobs:
             // Retrieve pull request and issue number from downloaded artifact
             const fs = require('fs')
             const artifact = fs.readFileSync('artifact.txt')
-            const artifactJSON = decodeURI(JSON.parse(artifact))
+            const artifactJSON = JSON.parse(artifact)
             return artifactJSON
       
       - uses: actions/checkout@v3

--- a/.github/workflows/wr-pr-instructions.yml
+++ b/.github/workflows/wr-pr-instructions.yml
@@ -41,7 +41,7 @@ jobs:
             // Retrieve pull request and issue number from downloaded artifact
             const fs = require('fs')
             const artifact = fs.readFileSync('artifact.txt')
-            const artifactJSON = JSON.parse(artifact);
+            const artifactJSON = decodeURI(JSON.parse(artifact))
             return artifactJSON
       
       - uses: actions/checkout@v3

--- a/github-actions/pr-instructions/create-instruction.js
+++ b/github-actions/pr-instructions/create-instruction.js
@@ -1,30 +1,56 @@
 // Global variables
 var github;
 var context;
+const fs = require('fs');
 
 /**
  * Uses information from the pull request to create commandline instructions.
  * @param {Object} g - github object
  * @param {Object} c - context object
- * @returns {string} string containing commandline instructions
+ * @returns {string} string containing commandline instructions, URI encoded since the backtick character is not allowed in *  artifact
  */
 function main({ g, c }) {
     github = g;
     context = c;
-    return createInstruction();
+    return encodeURI(compositeInstruction());   
 }
 
-function createInstruction() {
+function formatPullComment(instruction) {
+    const path = './github-actions/pr-instructions/pr-instructions-template.md'
+    const text = fs.readFileSync(path).toString('utf-8');
+    const completedInstructions = text.replace('${commandlineInstructions}', instruction);
+    return completedInstructions;
+}
+
+function formatContribComment(instruction){
+	const path = './github-actions/pr-instructions/pr-instructions-contrib-template.md'
+    const text = fs.readFileSync(path).toString('utf-8');
+    const completedInstructions = text.replace('${previewContribInstructions}', instruction);
+    return completedInstructions;
+}
+
+function createPullInstruction(){
     const nameOfCollaborator = context.payload.pull_request.head.repo.owner.login;
     const nameOfFromBranch = context.payload.pull_request.head.ref;
     const nameOfIntoBranch = context.payload.pull_request.base.ref;
     const cloneURL = context.payload.pull_request.head.repo.clone_url;
-
-    const instructionString =
+    const pullInstructionString =
 `git checkout -b ${nameOfCollaborator}-${nameOfFromBranch} ${nameOfIntoBranch}
 git pull ${cloneURL} ${nameOfFromBranch}`
+    return pullInstructionString;
+}
 
-    return instructionString
+function createContribInstruction(){
+	const nameOfCollaborator = context.payload.pull_request.head.repo.owner.login;
+    const nameOfFromBranch = context.payload.pull_request.head.ref;
+	const previewContribURL = `https://github.com/${nameOfCollaborator}/website/blob/${nameOfFromBranch}/CONTRIBUTING.md`
+	return previewContribURL;
+}
+
+function compositeInstruction() {
+	const completedPullInstruction = formatPullComment(createPullInstruction());
+	const completedContribInstruction = formatContribComment(createContribInstruction());
+	return completedPullInstruction + completedContribInstruction;
 }
 
 module.exports = main

--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -16,16 +16,9 @@ async function main({ g, c }, { issueNum, instruction }) {
     github = g;
     context = c;
 
-    const instructions = formatComment(instruction)
-    postComment(issueNum, instructions);
+    postComment(issueNum, decodeURI(instruction));
 }
 
-function formatComment(instruction) {
-    const path = './github-actions/pr-instructions/pr-instructions-template.md'
-    const text = fs.readFileSync(path).toString('utf-8');
-    const completedInstuctions = text.replace('${commandlineInstructions}', instruction)
-    return completedInstuctions
-}
 
 async function postComment(issueNum, instructions) {
     try {

--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -15,7 +15,7 @@ var context;
 async function main({ g, c }, { issueNum, instruction }) {
     github = g;
     context = c;
-    postComment(issueNum, instruction);
+    postComment(issueNum, decodeURI(instruction));
 }
 
 

--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -15,8 +15,7 @@ var context;
 async function main({ g, c }, { issueNum, instruction }) {
     github = g;
     context = c;
-	const decodedInstruction = decodeURI(instruction);
-    postComment(issueNum, decodedInstruction);
+    postComment(issueNum, instruction);
 }
 
 

--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -15,8 +15,8 @@ var context;
 async function main({ g, c }, { issueNum, instruction }) {
     github = g;
     context = c;
-
-    postComment(issueNum, decodeURI(instruction));
+	const decodedInstruction = decodeURI(instruction);
+    postComment(issueNum, decodedInstruction);
 }
 
 

--- a/github-actions/pr-instructions/pr-instructions-contrib-template.md
+++ b/github-actions/pr-instructions/pr-instructions-contrib-template.md
@@ -1,0 +1,9 @@
+<!-- Note: Commandline instructions are added into where the placeholder string first appears --->
+
+-------------------
+
+Note that CONTRIBUTING.md cannot previewed locally; rather it should be previewed at this URL:
+
+```
+${previewContribInstructions}  
+```


### PR DESCRIPTION
Fixes #5165 

### What changes did you make?
  - refactored logic for preparing pr instructions
  - add instruction for previewing changes to CONTRIBUTING.md
 

### Why did you make the changes (we will use this info to test)?
  - Preparing for introducing logic to include various pr instructions based on the files changed in the PR
  - The existing pr instructions were not accurate for CONTRIBUTING.md because CONTRIBUTING.md cannot be previewed locally.  
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

no visual changes