### PR TITLE
Please review but don't merge yet: Update PR Instruction GHA to add instruction for previewing CONTRIBUTING.md

### DIFF
--- a/.github/workflows/wr-pr-instructions.yml
+++ b/.github/workflows/wr-pr-instructions.yml
@@ -41,7 +41,7 @@ jobs:
             // Retrieve pull request and issue number from downloaded artifact
             const fs = require('fs')
             const artifact = fs.readFileSync('artifact.txt')
-            const artifactJSON = decodeURI(JSON.parse(artifact))
+            const artifactJSON = JSON.parse(artifact)
             return artifactJSON
       
       - uses: actions/checkout@v3

--- a/.github/workflows/wr-pr-instructions.yml
+++ b/.github/workflows/wr-pr-instructions.yml
@@ -41,7 +41,7 @@ jobs:
             // Retrieve pull request and issue number from downloaded artifact
             const fs = require('fs')
             const artifact = fs.readFileSync('artifact.txt')
-            const artifactJSON = JSON.parse(artifact);
+            const artifactJSON = decodeURI(JSON.parse(artifact))
             return artifactJSON
       
       - uses: actions/checkout@v3

--- a/github-actions/pr-instructions/create-instruction.js
+++ b/github-actions/pr-instructions/create-instruction.js
@@ -7,7 +7,7 @@ const fs = require('fs');
  * Uses information from the pull request to create commandline instructions.
  * @param {Object} g - github object
  * @param {Object} c - context object
- * @returns {string} string containing commandline instructions, URI encoded since the backtick character is not allowed in *  artifact
+ * @returns {string} string containing commandline instructions, URI encoded since the backtick character causes a problem in *  the artifact
  */
 function main({ g, c }) {
     github = g;

--- a/github-actions/pr-instructions/create-instruction.js
+++ b/github-actions/pr-instructions/create-instruction.js
@@ -1,30 +1,56 @@
 // Global variables
 var github;
 var context;
+const fs = require('fs');
 
 /**
  * Uses information from the pull request to create commandline instructions.
  * @param {Object} g - github object
  * @param {Object} c - context object
- * @returns {string} string containing commandline instructions
+ * @returns {string} string containing commandline instructions, URI encoded since the backtick character is not allowed in *  artifact
  */
 function main({ g, c }) {
     github = g;
     context = c;
-    return createInstruction();
+    return encodeURI(compositeInstruction());   
 }
 
-function createInstruction() {
+function formatPullComment(instruction) {
+    const path = './github-actions/pr-instructions/pr-instructions-template.md'
+    const text = fs.readFileSync(path).toString('utf-8');
+    const completedInstructions = text.replace('${commandlineInstructions}', instruction);
+    return completedInstructions;
+}
+
+function formatContribComment(instruction){
+	const path = './github-actions/pr-instructions/pr-instructions-contrib-template.md'
+    const text = fs.readFileSync(path).toString('utf-8');
+    const completedInstructions = text.replace('${previewContribInstructions}', instruction);
+    return completedInstructions;
+}
+
+function createPullInstruction(){
     const nameOfCollaborator = context.payload.pull_request.head.repo.owner.login;
     const nameOfFromBranch = context.payload.pull_request.head.ref;
     const nameOfIntoBranch = context.payload.pull_request.base.ref;
     const cloneURL = context.payload.pull_request.head.repo.clone_url;
-
-    const instructionString =
+    const pullInstructionString =
 `git checkout -b ${nameOfCollaborator}-${nameOfFromBranch} ${nameOfIntoBranch}
 git pull ${cloneURL} ${nameOfFromBranch}`
+    return pullInstructionString;
+}
 
-    return instructionString
+function createContribInstruction(){
+	const nameOfCollaborator = context.payload.pull_request.head.repo.owner.login;
+    const nameOfFromBranch = context.payload.pull_request.head.ref;
+	const previewContribURL = `https://github.com/${nameOfCollaborator}/website/blob/${nameOfFromBranch}/CONTRIBUTING.md`
+	return previewContribURL;
+}
+
+function compositeInstruction() {
+	const completedPullInstruction = formatPullComment(createPullInstruction());
+	const completedContribInstruction = formatContribComment(createContribInstruction());
+	return completedPullInstruction + completedContribInstruction;
 }
 
 module.exports = main

--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -16,16 +16,9 @@ async function main({ g, c }, { issueNum, instruction }) {
     github = g;
     context = c;
 
-    const instructions = formatComment(instruction)
-    postComment(issueNum, instructions);
+    postComment(issueNum, decodeURI(instruction));
 }
 
-function formatComment(instruction) {
-    const path = './github-actions/pr-instructions/pr-instructions-template.md'
-    const text = fs.readFileSync(path).toString('utf-8');
-    const completedInstuctions = text.replace('${commandlineInstructions}', instruction)
-    return completedInstuctions
-}
 
 async function postComment(issueNum, instructions) {
     try {

--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -15,7 +15,7 @@ var context;
 async function main({ g, c }, { issueNum, instruction }) {
     github = g;
     context = c;
-    postComment(issueNum, instruction);
+    postComment(issueNum, decodeURI(instruction));
 }
 
 

--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -6,7 +6,8 @@ var github;
 var context;
 
 /**
- * Formats the commandline instructions into a template, then posts it to the pull request.
+ * Use decodeURI() to decode the instruction prior to posting to PR
+ * (URI Encoding was applied in create-instruction.js to handle the backtick character)
  * @param {Object} g - github object  
  * @param {Object} c - context object 
  * @param {Number} issueNum - the number of the issue where the post will be made 

--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -15,8 +15,7 @@ var context;
 async function main({ g, c }, { issueNum, instruction }) {
     github = g;
     context = c;
-	const decodedInstruction = decodeURI(instruction);
-    postComment(issueNum, decodedInstruction);
+    postComment(issueNum, instruction);
 }
 
 

--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -15,8 +15,8 @@ var context;
 async function main({ g, c }, { issueNum, instruction }) {
     github = g;
     context = c;
-
-    postComment(issueNum, decodeURI(instruction));
+	const decodedInstruction = decodeURI(instruction);
+    postComment(issueNum, decodedInstruction);
 }
 
 

--- a/github-actions/pr-instructions/pr-instructions-contrib-template.md
+++ b/github-actions/pr-instructions/pr-instructions-contrib-template.md
@@ -1,0 +1,9 @@
+<!-- Note: Commandline instructions are added into where the placeholder string first appears --->
+
+-------------------
+
+Note that CONTRIBUTING.md cannot previewed locally; rather it should be previewed at this URL:
+
+```
+${previewContribInstructions}  
+```

--- a/github-actions/pr-instructions/pr-instructions-contrib-template.md
+++ b/github-actions/pr-instructions/pr-instructions-contrib-template.md
@@ -1,6 +1,6 @@
 <!-- Note: Commandline instructions are added into where the placeholder string first appears --->
 
--------------------
+------------------
 
 Note that CONTRIBUTING.md cannot previewed locally; rather it should be previewed at this URL:
 


### PR DESCRIPTION
Fixes #5165

### What changes did you make?
  - Added a PR instruction for previewing CONTRIBUTING.md, with new instruction (based on a new .md template) that provides the reviewer with a preview URL based on the contributor's issue branch
  - Moved instruction formatting from `post-comment.js` to `create-instruction.js` and added URI Encoding 

### Why did you make the changes (we will use this info to test)?
  - The existing PR instruction is not accurate for previewing CONTRIBUTING.md, because CONTRIBUTING.md cannot be previewed locally
  - The JS reformatting was done so that regardless of how many instructions we provide in the PR (each with its own template), only a single composite instruction will be stored in the artifact, and in create-instruction.js, we have access to the PR context so that in the future, we could include or exclude instructions based on the files that were changed.  
  - URI Encoding was added because the backtick character caused a problem when stored in the artifact.  

### Note to reviewers:
- The PR instruction displayed in this PR is not diplayed properly because one of the updated scripts (post-comment.js) is running from gh-pages instead of running from the issue branch.   This is because post-comment.js runs as part of the "WR Add Pull Request Instruction" workflow which is triggered on "workflow_run" and uses Ref of the latest commit on the default branch,, as opposed to "Add Pull Request Instruction", which runs using the Ref of the issue branch.  Please see the pr instructions in https://github.com/roslynwythe/website/pull/40 where I set the default branch of my repository to the issue branch and therefore all the required scripts run in the proper context.  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
no visual changes