### PR TITLE
Remove CfA sponsor #5409

### DIFF
--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -3,9 +3,6 @@
     <div class="section-body-full">
       <h2 class="title2">Sponsors</h2>
         <div class="flex-container-row flex-container-row--partners">
-            <!-- <a href="https://www.codeforamerica.org" target="_blank" alt="Code for America">
-                <img src="/assets/images/sponsors/code-for-america.svg" title="Code for America">
-            </a> -->
             <a href="https://laincubator.org" target="_blank" alt="LA Incubator">
                 <img src="/assets/images/sponsors/laci.svg" title="Los Angeles Cleantech Incubator">
             </a>

--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -3,9 +3,9 @@
     <div class="section-body-full">
       <h2 class="title2">Sponsors</h2>
         <div class="flex-container-row flex-container-row--partners">
-            <a href="https://www.codeforamerica.org" target="_blank" alt="Code for America">
+            <!-- <a href="https://www.codeforamerica.org" target="_blank" alt="Code for America">
                 <img src="/assets/images/sponsors/code-for-america.svg" title="Code for America">
-            </a>
+            </a> -->
             <a href="https://laincubator.org" target="_blank" alt="LA Incubator">
                 <img src="/assets/images/sponsors/laci.svg" title="Los Angeles Cleantech Incubator">
             </a>


### PR DESCRIPTION
Fixes #5409 

### What changes did you make?
  - Removed lines mentioning Code for America sponsorship from `_includes/sponsors.html`

### Why did you make the changes (we will use this info to test)?
  - To reflect that CfA is no longer a sponsor of Hack for LA

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1470" alt="Screenshot 2023-09-13 at 2 19 57 PM" src="https://github.com/hackforla/website/assets/106345703/91a478ed-ca44-4c71-b779-8f50865d06e6">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1470" alt="Screenshot 2023-09-13 at 2 20 11 PM" src="https://github.com/hackforla/website/assets/106345703/c0e227c2-896b-43a5-b094-61edecf2f194">


</details>
