### PR TITLE
Updated Project Profile #5459: Removed Johnny Wu

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -72,12 +72,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U04U531MS5P
       github: https://github.com/kwangric
     picture: https://avatars.githubusercontent.com/kwangric
-  - name: Johnny Wu
-    role: Merge Team
-    links:
-      slack: 'https://hackforla.slack.com/team/U043KH4FQ1M'
-      github: 'https://github.com/Skydodle'
-    picture: https://avatars.githubusercontent.com/Skydodle
   - name: Adrian Ang
     role: Merge Team
     links:


### PR DESCRIPTION
Fixes #5459 

### What changes did you make?
  - Removed Johnny Wu from [Hackforla.org Website project page](https://www.hackforla.org/projects/website)

### Why did you make the changes (we will use this info to test)?
  - The Hackforla.org Website project page needs to be updated so that the project information is up to date.
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not scree
<details>
<summary>Visuals before changes are applied</summary>

<img width="1512" alt="Screenshot 2023-09-14 at 3 32 18 PM" src="https://github.com/hackforla/website/assets/105751313/fbe45946-076d-4934-99f8-12eecb1b4517">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1512" alt="Screenshot 2023-09-14 at 3 22 20 PM" src="https://github.com/hackforla/website/assets/105751313/caeb2efa-f6e5-4102-abf7-5bd783227fe1">


</details>
