### PR TITLE
Replace CfA name and address in privacy policy page

### DIFF
--- a/_data/internal/privacy-policy.yml
+++ b/_data/internal/privacy-policy.yml
@@ -91,7 +91,7 @@ privacy-policy: |
 
   If you have any questions, comments, concerns, or complaints related to our websites, please contact us by email at [privacy@hackforla.org](privacy@hackforla.org), or by mail at:
 
-  Code for America\
+  Civic Tech Structure, Inc.\
   Ref: Hack for LA, HackforLA.org\
-  155 9th Street\
-  San Francisco, CA 94103
+  13428 Maxella Ave, Unit 821\
+  Marina Del Rey, CA 90292


### PR DESCRIPTION
Fixes #5429 

### What changes did you make?
  - At the bottom of the privacy policy page https://www.hackforla.org/privacy-policy 
  - Removed the mentioned CfA from the Privacy Policy and added a new name and address.
  - In the file: _data/internal/privacy-policy.yml replaced:
  - Code for America\
    Ref: Hack for LA, HackforLA.org\
    155 9th Street\
    San Francisco, CA 94103
  - With:
  - Civic Tech Structure, Inc.\
    Ref: Hack for LA, HackforLA.org\
    13428 Maxella Ave, Unit 821\
    Marina Del Rey, CA 90292

### Why did you make the changes (we will use this info to test)?
  - The name and address have been changed.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->



<details>
<summary>Visuals before changes are applied</summary>

![before](https://github.com/hackforla/website/assets/135071951/22902f02-f6e9-4692-b1eb-058c980ee7c1)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after](https://github.com/hackforla/website/assets/135071951/5922362b-c2c0-41e7-9e03-e5033ff4ff03)

</details>
