### PR TITLE
 removed the line mentioning CFA from civic tech index page

### DIFF
--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -127,7 +127,7 @@ technologies:
 location:
   # - Downtown LA
   - Remote
-partner: Code for America, Yale OpenLab and many more.
+
 tools:
   - Google docs
   - Figma


### PR DESCRIPTION
Fixes #5426

### What changes did you make?
  -removed the line: partner: Code for America, Yale OpenLab and many more.
  -confirmed using docker that the "Partner" list has been removed from the Civic Tech Index Project page, and the rest of the page is unchanged.
  

### Why did you make the changes (we will use this info to test)?
  -the issue required to remove mention of cfA from the list of partners on the Civic Tech Index project page.
  



<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/69686216/dc80bdb6-3832-47c6-8336-11fd1567b963)



</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/69686216/949f11e7-bed8-4a54-ab27-1db4eeae3adb)



</details>
