### PR TITLE
Update Image Tag in About Page

### DIFF
--- a/_includes/about-page/about-card-donations.html
+++ b/_includes/about-page/about-card-donations.html
@@ -1,6 +1,6 @@
 <div class="card-primary page-card-lg page-card--about">
-    <div class="about-us-section-header" data-hash="donations"><span class="sec-head-img"><img src="/assets/images/about/section-header-elements/donations.svg" alt="" /></span>Make a Donation</div>
-    <div class="about-us-section-content">  
+    <div class="about-us-section-header" data-hash="donations"><span class="sec-head-img"><img src="/assets/images/about/section-header-elements/donations.svg" alt=""></span>Make a Donation</div>
+    <div class="about-us-section-content">
         {% include donation/donate-gif-text.html %}
-    </div>  
+    </div>
 </div>


### PR DESCRIPTION
Fixes #5189 

### What changes did you make?
  - The change involves using a self-closing img tag without a trailing slash.

### Why did you make the changes (we will use this info to test)?
  - I implemented this alteration to enhance the uniformity of the codebase.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
I removed the ending slash from the image tag, but there were no visual changes as a result.