### PR TITLE
Removed Ability to Highlight Filter Drop-down Arrows

### DIFF
--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -156,6 +156,7 @@ border-radius: 2.5px;
   right: 5%;
   font-size: 24px;
   position: absolute;
+  user-select: none;
 }
 .show-none .labelArrow {
   transform: rotate(-45deg);


### PR DESCRIPTION
Fixes #5282

### What changes did you make?
  - Added ```user-select: none;``` to ```labelArrow``` class in ```_dropdown_filters.scss```

### Why did you make the changes (we will use this info to test)?
  - To prevent users from accidentally highlighting the arrows if they click it in rapid successions on the home, projects, and toolkit pages


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2023-09-18 at 11 55 45 AM](https://github.com/hackforla/website/assets/126220790/82a76c6a-8fe0-4bbe-9784-86834b3ad4c6)

![Screenshot 2023-09-18 at 11 57 25 AM](https://github.com/hackforla/website/assets/126220790/f4f6326e-286d-4d5c-a039-8333771655e9)



</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2023-09-18 at 11 56 06 AM](https://github.com/hackforla/website/assets/126220790/e5ba571e-527c-418c-bdae-eab207096391)

![Screenshot 2023-09-18 at 11 56 56 AM](https://github.com/hackforla/website/assets/126220790/dca00bf4-50e6-45b2-809e-2ead62ef54a9)

</details>
