### PR TITLE
Remove "good second issue" from designer prework template

### DIFF
--- a/.github/ISSUE_TEMPLATE/pre-work-template---design.md
+++ b/.github/ISSUE_TEMPLATE/pre-work-template---design.md
@@ -52,8 +52,7 @@ As a new designer on the HfLA website UX team, fill in the following fields as y
 - [ ] Please work on only one issue at a time and wait until your pull request is merged before picking up another issue.
 - [ ] Read and understand how we progress through issues. Then, you can check this off.
 Progress through issues with increasing complexity in the following order:
-  - Good first issue (one per person)
-  - Good second issue (one per person)
+  - Good first issue (two per person)
   - Small (one per person, with some exceptions, see below)
   - Medium (you can work on more than one medium issue, but only one at a time)
   - Large (you can work on more than one large issue, but only one at a time)


### PR DESCRIPTION
Fixes #5477 

### What changes did you make?
  - Removed mention of "good second issue."
  - Changed the number of "good first issues" from one to two per person.

### Why did you make the changes (we will use this info to test)?
  - To remove mention of "good second issues" from the designer prework template.

### For Reviewers
- Use this URL to check the updated issue template: https://github.com/allison-truhlar/website/issues/new?assignees=&labels=Feature%3A+Onboarding%2FContributing.md%2Cprework%2Crole%3A+design%2Csize%3A+1pt%2CComplexity%3A+Missing&projects=&template=pre-work-template---design.md&title=Pre-work+Checklist%3A+Designer%3A+%5Breplace+brackets+with+your+name%5D

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->
Updates were to a Github issue template. No visual changes to website.