### PR TITLE
Updated header text on Join Us page donation card

### DIFF
--- a/_includes/join-donate-card.html
+++ b/_includes/join-donate-card.html
@@ -20,7 +20,7 @@
     {% include /donation/in-kind.html %}
   </div>
   <div class="join-us-donation">
-    <h3 class="title6 page-card--large-icon-header-secondary">Make a donation to Hack for LA</h3>
+    <h3 class="title6 page-card--large-icon-header-secondary">Make a donation</h3>
     {% include /donation/donate-gif-text.html %}
   </div>
 </div>


### PR DESCRIPTION
Fixes #5448 

### What changes did you make?
  -  Replaced the following text on join-us-donation card:  

> <h3 class="title6 page-card--large-icon-header-secondary">Make a donation to Hack for LA</h3>
 
With:

> <h3 class="title6 page-card--large-icon-header-secondary">Make a donation</h3>

 
### Why did you make the changes (we will use this info to test)?
  - To conform with the issue #5403, which aims to remove any mention of CfA (Code for America) from various webpages.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image]
<img width="1084" alt="Screenshot 2023-09-19 at 08 53 56" src="https://github.com/hackforla/website/assets/99047099/979a134b-855f-4eeb-b13d-5e4d1ee16a61">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image]
<img width="1066" alt="Screenshot 2023-09-19 at 08 55 22" src="https://github.com/hackforla/website/assets/99047099/725b0cd5-2eb0-4841-a133-01c6fae5621a">

</details>
