### PR TITLE
"Code for America" has been removed from sponsors#

### DIFF
--- a/_includes/about-page/about-card-sponsors.html
+++ b/_includes/about-page/about-card-sponsors.html
@@ -12,9 +12,6 @@
             </a>
             {% endfor %}
             {% endcomment %}
-            <a href="https://www.codeforamerica.org" target="_blank" alt="Code for America">
-                <img src="/assets/images/sponsors/code-for-america.svg" title="Code for America">
-            </a>
             <a href="https://laincubator.org" target="_blank" alt="LA Incubator">
                 <img src="/assets/images/sponsors/laci.svg" title="Los Angeles Cleantech Incubator">
             </a>


### PR DESCRIPTION
Fixes #5511

### What changes did you make?
  I removed mention of Code for America from the list of sponsors, which appears on the "About Us" page

### Why did you make the changes (we will use this info to test)?
  i fixed the issue #5511  as there were written to remove mention of CFA


