### PR TITLE
Removed AJPrice, added Chelsey Beck to COP-Engg

### DIFF
--- a/_data/internal/communities/engineering.yml
+++ b/_data/internal/communities/engineering.yml
@@ -19,12 +19,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U04N8H0V72R
       github: https://github.com/MicahBear
     picture: https://avatars.githubusercontent.com/MicahBear
-  - name: AJ Price
-    role: Co-Lead
-    links:
-      slack: https://hackforla.slack.com/team/U02UZ5BK8UB
-      github: https://github.com/mxajprice
-    picture: https://avatars.githubusercontent.com/mxajprice
   - name: Alejandro Gomez
     role: Co-Lead
     links:
@@ -37,7 +31,12 @@ leadership:
       slack: https://hackforla.slack.com/team/U04PFCPK6EP
       github: https://github.com/hkatzdev
     picture: https://avatars.githubusercontent.com/hkatzdev
-  
+  - name: Chelsey Beck
+    role: Co-Lead
+    links:
+      slack: https://hackforla.slack.com/team/U01J93AQKSS
+      github: https://github.com/chelseybeck
+    picture: https://avatars.githubusercontent.com/chelseybeck
 
 links:
   - name: Slack


### PR DESCRIPTION
Fixes #5404 

### What changes did you make?
  - Removed entry for AJ Price in Community of Practice- Engineering
  - Added entry for Chelsey Beck in Community of Practice- Engineering


### Why did you make the changes (we will use this info to test)?
  - Updating leadership info for in Community of Practice- Engineering


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)


<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2023-09-22 132613](https://github.com/hackforla/website/assets/40799239/cec8f611-1522-4704-9f5d-9e56858c2255)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![Screenshot 2023-09-22 132624](https://github.com/hackforla/website/assets/40799239/5d0a3321-6dd1-4d58-bf7d-f8b8eca1c4f6)

</details>
