### PR TITLE
Update Partner Text Under BallotNav Project

### DIFF
--- a/_projects/ballot-nav.md
+++ b/_projects/ballot-nav.md
@@ -62,7 +62,7 @@ looking:
     skill: Translators (Spanish especially)
 location:
   - Remote
-partner: Code for America, Other Brigades
+partner: Code for San Jose, Code for Atlanta, Open Oakland
 visible: true
 status: Active
 program-area:


### PR DESCRIPTION
Fixes #5410

### What changes did you make?
  - Within _projects/ballot-nav.md, removed line "partner: Code for America, Other Brigades"
  - Replaced line with "partner: Code for San Jose, Code for Atlanta, Open Oakland"

### Why did you make the changes (we will use this info to test)?
  - We need to remove mention of CfA from the list of partners on the Ballot Nav project

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="395" alt="Screenshot 2023-09-14 at 5 53 27 PM" src="https://github.com/hackforla/website/assets/75091266/a9dd4036-5954-4cb8-8c76-8a2faa4b93a5">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="398" alt="Screenshot 2023-09-14 at 6 14 33 PM" src="https://github.com/hackforla/website/assets/75091266/eb324421-3304-4968-86ad-1d54e1cc9698">

</details>
