### PR TITLE
Add GitHub handle 100automations kim audrey 5508

### DIFF
--- a/_projects/100-automations.md
+++ b/_projects/100-automations.md
@@ -31,6 +31,7 @@ leadership:
       github: 'https://github.com/mdothman'
     picture: 'https://avatars.githubusercontent.com/mdothman'
   - name: Audrey Kim
+    github-handle: 
     role: UX Writer
     links:
       slack: 'https://hackforla.slack.com/team/U01H0CXBTUM'


### PR DESCRIPTION
Fixes #5508

### What changes did you make?
  - In 100 Automations project page, added new variable `github-handle` below `-name: Audrey Kim`, w/o assignment, nested like other variables assoc. w/Kim eg `role`.

### Why did you make the changes (we will use this info to test)?
  - To hold the github handle for this member o/100 Automations leadership team
  - To prepare for the eventual replacement of the `github` and `picture` variables
  - In re: issue [5508](https://github.com/hackforla/website/issues/5508)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Added variable without assignment; no visual changes to the website.
