### PR TITLE
Update LA TDM Calculator removed Moji Momoh

### DIFF
--- a/_projects/tdm-calculator.md
+++ b/_projects/tdm-calculator.md
@@ -30,12 +30,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U045EHW8NDA'
       github: 'https://github.com/Noushie'
     picture: https://avatars.githubusercontent.com/Noushie
-  - name: Moji Momoh
-    role: Product Manager
-    links:
-      slack: 'https://hackforla.slack.com/team/D04HDM7DM18'
-      github: 'https://github.com/mojimoh'
-    picture: https://avatars.githubusercontent.com/mojimoh
   - name: Jane He
     role: Lead, UX Research
     links:


### PR DESCRIPTION
Fixes #5393 

### What changes did you make?
  - Removed Moji Momoh from tdm-calculator.md, leadership variable


### Why did you make the changes (we will use this info to test)?
  - Per simple and clear instructions provided by issue #5393 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![mmomohbefore](https://github.com/hackforla/website/assets/76914884/32ae944e-843d-4ea4-b92c-fcb4d24c763c)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![mmomohafter](https://github.com/hackforla/website/assets/76914884/06284394-68ad-40ac-825d-18875b85f273)

</details>
