### PR TITLE
added a new entry for Nga Do in the civic tech jobs page

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -90,6 +90,12 @@ leadership:
       slack: https://hackforla.slack.com/team/U02M686LYET
       github: https://github.com/Blulady
     picture: https://avatars.githubusercontent.com/Blulady
+  - name: Nga Do
+    role: UX Researcher
+    links:
+      slack: https://hackforla.slack.com/team/U05JS3BS9FD
+      github: https://github.com/ngadoq
+    picture: https://avatars.githubusercontent.com/ngadoq 
 links: 
   - name: GitHub
     url: https://github.com/hackforla/civictechjobs


### PR DESCRIPTION
Fixes #5388 

### What changes did you make?
  - Added a new entry for Nga Do profile below Sarah Sanger profile in the civic-tech-jobs page

### Why did you make the changes (we will use this info to test)?
  - To keep the Civic Tech Jobs webpage up to date

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img src="https://i.ibb.co/5rbjsZb/before-updating-profile-civic-tech-jobs.png" alt="before-updating-profile-civic-tech-jobs" border="0"/></a>

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img src="https://i.ibb.co/0Y4jWPN/after-updating-profile-civic-tech-jobs.png" alt="after-updating-profile-civic-tech-jobs" border="0"/></a>

</details>
