### PR TITLE
modified redirections/cop.md-changed redirect to https://www.hackforl…

### DIFF
--- a/redirections/cop.md
+++ b/redirections/cop.md
@@ -1,7 +1,8 @@
 ---
-# https://www.hackforla.org/cop redirects to -> https://github.com/hackforla/communities-of-practice/blob/main/README.md
+# https://www.hackforla.org/cop redirects to https://www.hackforla.org/communities-of-practice
+
 layout: redirect
 title: cop
 permalink: /cop/
-redirect_to: https://github.com/hackforla/communities-of-practice/blob/main/README.md
+redirect_to: /communities-of-practice/
 ---


### PR DESCRIPTION
…a.org/communities-of-practice

Fixes #5329

### What changes did you make?
  - Changed https://www.hackforla.org/cop redirects to -> https://github.com/hackforla/communities-of-practice/blob/main/README.md to https://www.hackforla.org/cop redirects to https://www.hackforla.org/communities-of-practice
  - Changed redirect_to: https://github.com/hackforla/communities-of-practice/blob/main/README.md to redirect_to: /communities-of-practice/

### Why did you make the changes (we will use this info to test)?
  - To redirect to the Communities of Practice (CoP) page so that it redirects to the expected page on the website.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![cop-1](https://github.com/hackforla/website/assets/49097867/9121ae7c-e4d5-43d8-bc86-dcd2fa18ee40)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![cop-2](https://github.com/hackforla/website/assets/49097867/867317f7-38f0-4598-9cff-9b93c0adbefa)

</details>
