### PR TITLE
Fix linting error on about page

### DIFF
--- a/_includes/about-page/about-card-platform.html
+++ b/_includes/about-page/about-card-platform.html
@@ -58,7 +58,7 @@
                     </p>
                 </div>
                 <div class="platform-sec-scalability">
-                    <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/scalability.svg" alt=""></span><span class="sub-head-text color-mediumvioletred">Scalability</div>
+                    <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/scalability.svg" alt=""></span><span class="sub-head-text color-mediumvioletred">Scalability</span></div>
                     <p class="sub-card-content border-mediumvioletred">
                         In order to scale our impact with people and projects, we experiment, iterate and refine, measure and
                         automate.  Using the lowest lift tools possible for the job, and building our own, when scale cannot be


### PR DESCRIPTION
Fixes #5372

### What changes did you make?
  - Added a closing span tag to the Scalability sub-card within the Platform card on the About page

### Why did you make the changes (we will use this info to test)?
  - Caused a linting error

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
 - No visual changes
