### PR TITLE
fix Code Spell Checker configuration file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -395,7 +395,7 @@ We recommend you visit the `Prioritized Backlog` column in the filtered Project 
 
 #### **2.3.b Available issues for returning members (front end)**
 
-* `Prioritized Backlog` column in the [filtered Project Board - **complexity: Good second issues** label](https://github.com/hackforla/website/projects/7?card_filter_query=label%3A%22role%3A+front+end%22+label%3A%22complexity%3A+good+second+issue%22)
+
 * `Prioritized Backlog` column in the [filtered Project Board - **complexity: Small** label](https://github.com/hackforla/website/projects/7?card_filter_query=label%3A%22complexity%3A+small%22+label%3A%22role%3A+front+end%22)
 * `Prioritized Backlog` column in the [filtered Project Board - **complexity: Medium** label](https://github.com/hackforla/website/projects/7?card_filter_query=label%3A%22role%3A+front+end%22+label%3A%22complexity%3A+medium%22)
 * `Prioritized Backlog` column in the [filtered Project Board - **complexity: Large** label](https://github.com/hackforla/website/projects/7?card_filter_query=label%3A%22role%3A+front+end%22+label%3A%22complexity%3A+large%22)

--- a/cspell.json
+++ b/cspell.json
@@ -3,7 +3,8 @@
   "language": "en",
   // words - list of words to be always considered correct
   "words": [
-      "collabathon"
+      "collabathon",
+      "Westside"
   ],
   "ignorePaths": [
       "node_modules",


### PR DESCRIPTION
Fixes #5618 

### What changes did you make?
  - Add "Westside" to list of words in Code Spell Checker configuration file

### Why did you make the changes (we will use this info to test)?
  - So that no Code Spell Checker errors/messages are displayed.

### Screenshots of Proposed Changes of The Website (if any, please do not screenshot code changes)
- No visual changes to the website.
