### PR TITLE
updated img tag

### DIFF
--- a/_includes/press.html
+++ b/_includes/press.html
@@ -5,7 +5,7 @@
     <blockquote class="quote">
       <p>{{ item.quote }}</p>
       <cite class="type-h4">{{ item.source }}</cite>
-      <img class="quote-tmb" src="{{ item.img_url | absolute_url }}" alt="{{ item.source }}" />
+      <img class="quote-tmb" src="{{ item.img_url | absolute_url }}" alt="{{ item.source }}">
     </blockquote>
     {% endfor %}
     <h2 class="title2">Press</h2>


### PR DESCRIPTION
Fixes #5439

### What changes did you make?
  - Removed forward slash at the end of img tag within _includes/press.html file
  - no other changes made

### Why did you make the changes (we will use this info to test)?
  - To keep the code structure consistent

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

</details>

<details>
<summary>Visuals after changes are applied</summary>
  

</details>
