### PR TITLE
Remove good second issue from CONTRIBUTING section 2.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,7 +352,6 @@ We currently have issues with the following **role** labels:
 And the following **complexity** labels:
 
 * `good first issue` 
-* `complexity: good second issue`
 * `complexity: Small`
 * `complexity: Medium`
 * `complexity: Large`


### PR DESCRIPTION
Fixes #5590

### What changes did you make?
  - Deleted ``* `complexity: good second issue` `` within section 2.2 of CONTRIBUTING.md

### Why did you make the changes (we will use this info to test)?
  - Because we are no longer creating issues with the label `Complexity: good second issue'.

For Reviewers: Do not review locally, rather review changes at https://github.com/romainyvernes/hackforlawebsite/blob/remove-good-second-issue-5590/CONTRIBUTING.md

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - No visual changes on website.