### PR TITLE
Removed Google Drive access

### DIFF
--- a/.github/ISSUE_TEMPLATE/pre-work-template--dev.md
+++ b/.github/ISSUE_TEMPLATE/pre-work-template--dev.md
@@ -21,8 +21,6 @@ As a new developer on the HfLA website team, fill in the following fields as you
 ### Action Items
 
 - [ ] Add yourself to the #hfla-site and #hfla-site-pr Slack channels
-- [ ] Share your GitHub handle and Gmail address in the hfla-site-onboarding slack channel so you can be added to the Google Drive (alternative to go to meeting and direct message a merge team member at the [meeting](https://github.com/hackforla/website/wiki/Meetings-and-Agendas
-))
   - [ ] To find contact information for the merge team members and technical leads, please take a look at our [Meet the Team wiki page](https://github.com/hackforla/website/wiki/Meet-the-Team)
 - [ ] Also, confirm with a merge team member or a technical lead that they have added you to the Google Calendar invites for our Zoom meetings
 - [ ] (Once added to the Drive) Add yourself to the [team roster](https://docs.google.com/spreadsheets/d/11u71eT-rZTKvVP8Yj_1rKxf2V45GCaFz4AXA7tS_asM/edit#gid=0)


### PR DESCRIPTION
Fixes #5628

### What changes did you make?
  - Removed the following line from the Developer Pre-work Template:
  ```
  - [ ] Share your GitHub handle and Gmail address in the hfla-site-onboarding slack channel so you can be added to the Google Drive (alternative to go to meeting and direct message a merge team member at the [meeting](https://github.com/hackforla/website/wiki/Meetings-and-Agendas
))
```

### Why did you make the changes (we will use this info to test)?
  - The instructions in the pre-work checklist issue for new developers to obtain Google Drive access were updated in order to avoid confusion.

### For Reviewers
- Use this URL to check the updated issue template: [https://github.com/DorianDeptuch/website/issues/new?assignees=&labels=Feature%3A+Onboarding%2FContributing.md%2Cprework%2Csize%3A+1pt%2Crole+missing%2CComplexity%3A+Prework&projects=&template=pre-work-template--dev.md&title=Pre-work+Checklist%3A+Developer%3A+%5Breplace+brackets+with+your+name%5D](https://github.com/DorianDeptuch/website/issues/new?assignees=&labels=Feature%3A+Onboarding%2FContributing.md%2Cprework%2Csize%3A+1pt%2Crole+missing%2CComplexity%3A+Prework&projects=&template=pre-work-template--dev.md&title=Pre-work+Checklist%3A+Developer%3A+%5Breplace+brackets+with+your+name%5D)