### PR TITLE
Updated Pre-work Instructions for Google Calendar Invites

### DIFF
--- a/.github/ISSUE_TEMPLATE/pre-work-template--dev.md
+++ b/.github/ISSUE_TEMPLATE/pre-work-template--dev.md
@@ -22,12 +22,7 @@ As a new developer on the HfLA website team, fill in the following fields as you
 
 - [ ] Add yourself to the #hfla-site and #hfla-site-pr Slack channels
   - [ ] To find contact information for the merge team members and technical leads, please take a look at our [Meet the Team wiki page](https://github.com/hackforla/website/wiki/Meet-the-Team)
-<<<<<<< HEAD
-- [ ] Also, confirm with a merge team member or a technical lead that they have added you to the Google Calendar invites for our Zoom meetings
 - [ ] Add yourself to the [team roster](https://docs.google.com/spreadsheets/d/11u71eT-rZTKvVP8Yj_1rKxf2V45GCaFz4AXA7tS_asM/edit#gid=0)
-=======
-- [ ] (Once added to the Drive) Add yourself to the [team roster](https://docs.google.com/spreadsheets/d/11u71eT-rZTKvVP8Yj_1rKxf2V45GCaFz4AXA7tS_asM/edit#gid=0)
->>>>>>> c78e6e3d (removed line regarding prework instructions for calendar invites)
 - [ ] After you have finished adding yourself to the roster, let a merge team member or a technical lead know you have added yourself to the roster and would like to be added to the `website-write` and `website` teams on GitHub
 - [ ] Once added to the website-write team:
   - [ ] Self Assign this issue (gear in right side panel)

--- a/.github/ISSUE_TEMPLATE/pre-work-template--dev.md
+++ b/.github/ISSUE_TEMPLATE/pre-work-template--dev.md
@@ -22,8 +22,12 @@ As a new developer on the HfLA website team, fill in the following fields as you
 
 - [ ] Add yourself to the #hfla-site and #hfla-site-pr Slack channels
   - [ ] To find contact information for the merge team members and technical leads, please take a look at our [Meet the Team wiki page](https://github.com/hackforla/website/wiki/Meet-the-Team)
+<<<<<<< HEAD
 - [ ] Also, confirm with a merge team member or a technical lead that they have added you to the Google Calendar invites for our Zoom meetings
 - [ ] Add yourself to the [team roster](https://docs.google.com/spreadsheets/d/11u71eT-rZTKvVP8Yj_1rKxf2V45GCaFz4AXA7tS_asM/edit#gid=0)
+=======
+- [ ] (Once added to the Drive) Add yourself to the [team roster](https://docs.google.com/spreadsheets/d/11u71eT-rZTKvVP8Yj_1rKxf2V45GCaFz4AXA7tS_asM/edit#gid=0)
+>>>>>>> c78e6e3d (removed line regarding prework instructions for calendar invites)
 - [ ] After you have finished adding yourself to the roster, let a merge team member or a technical lead know you have added yourself to the roster and would like to be added to the `website-write` and `website` teams on GitHub
 - [ ] Once added to the website-write team:
   - [ ] Self Assign this issue (gear in right side panel)


### PR DESCRIPTION
Fixes #5629

### What changes did you make?
  -  Removed the instructions provided in the pre-work checklist regarding Google calendar invites

### Why did you make the changes (we will use this info to test)?
  -   In order to avoid confusion

### For Reviewers
- Use this URL to check the updated issue template: [URL to updated issue template](https://github.com/agutiernc/website/issues/new?assignees=&labels=Feature%3A+Onboarding%2FContributing.md%2Cprework%2Csize%3A+1pt%2Crole+missing%2CComplexity%3A+Prework&projects=&template=pre-work-template--dev.md&title=Pre-work+Checklist%3A+Developer%3A+%5Breplace+brackets+with+your+name%5D) 

### Screenshots of Proposed Changes Of The Website
<details>
<summary>Visuals before changes are applied</summary>

![before_screenshot](https://github.com/hackforla/website/assets/42459347/d420f987-20b6-4998-9ab8-e99c494391aa)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after-screenshot](https://github.com/hackforla/website/assets/42459347/eefeadb9-ae23-4459-95ea-67746cf990a9)

</details>

