### PR TITLE
changed complexity label  missing to prework

### DIFF
--- a/.github/ISSUE_TEMPLATE/pre-work-template---ux.md
+++ b/.github/ISSUE_TEMPLATE/pre-work-template---ux.md
@@ -2,8 +2,7 @@
 name: Pre-work Template - UX
 about: New Research team members should start by making this issue
 title: 'Pre-work Checklist: Researcher: [replace brackets with your name]'
-labels: 'Complexity: Missing, Feature: Onboarding/Contributing.md, prework, role:
-  user research, size: 1pt'
+labels: ['Complexity: Prework, Feature: Onboarding/Contributing.md, prework, role: user research, size: 1pt']
 assignees: ''
 
 ---


### PR DESCRIPTION
Fixes #5336 

### What changes did you make?
  - Made changes to the pre-work-UX template Complexity: Missing to Complexity: Prework
  
### Why did you make the changes (we will use this info to test)?
  - Edited the Pre-work--UX Issue Template so that team members start with the correct labels during issue-making.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="1506" alt="before" src="https://github.com/hackforla/website/assets/129820906/7996d9bd-1dd5-4c42-9c76-1c4112e050df">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  

<img width="1506" alt="after" src="https://github.com/hackforla/website/assets/129820906/31fd466a-63a9-4b0b-ba47-df305375b64e">



</details>
