### PR TITLE
updated cspell.json file with false positive term 'Cleantech'

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -3,6 +3,7 @@
   "language": "en",
   // words - list of words to be always considered correct
   "words": [
+      "Cleantech",
       "collabathon"
   ],
   "ignorePaths": [


### PR DESCRIPTION
Fixes #5675 

### What changes did you make?
 Updated cspell.json file with false positive term 'Cleantech'

### Why did you make the changes (we will use this info to test)?
  'Cleantech' was needed to be added to the words for the Code Spell Checker

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

Adding 'Cleantech' to a JSON file. No visual changes to the website. 
  
