### PR TITLE
Add Missing Closing Tags in About Page

### DIFF
--- a/_includes/about-page/about-card-platform.html
+++ b/_includes/about-page/about-card-platform.html
@@ -4,7 +4,7 @@
     </div>
     <div class="about-us-section-content">
         <div class="sub-card">
-            <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/workforce-development.svg" alt=""></span><span class="sub-head-text color-dodgerblue">Workforce Development</div>
+            <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/workforce-development.svg" alt=""></span><span class="sub-head-text color-dodgerblue">Workforce Development</span></div>
             <p class="sub-card-content border-dodgerblue">
                 Enlightened self-interest is a powerful motivator. Our members have access to mentorship,
                 one-on-one help with job searches, and resume coaching. We do project matching to fit skill
@@ -14,7 +14,7 @@
             </p>
             <div class="platform-mid-section">
                 <div class="platform-sec-impact">
-                    <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/impact.svg" alt=""></span><span class="sub-head-text color-lightseagreen">Impact</div>
+                    <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/impact.svg" alt=""></span><span class="sub-head-text color-lightseagreen">Impact</span></div>
                     <p class="sub-card-content border-lightseagreen">
                         We choose and empower projects where there is a demonstrable impact on stakeholders, project partners,
                         our local community, and our members. We don’t seek to be the experts, but instead to learn from them
@@ -49,7 +49,7 @@
                     </p>
                 </div>
                 <div class="platform-sec-agility">
-                    <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/agility.svg" alt=""></span><span class="sub-head-text color-deeppink">Agility</div>
+                    <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/agility.svg" alt=""></span><span class="sub-head-text color-deeppink">Agility</span></div>
                     <p class="sub-card-content border-deeppink">
                         There will be impediments, setbacks and disappointments. We embrace change by empowering our members to
                         meet, talk, experiment and achieve enough common consensus to move internal initiatives forward, without

--- a/_includes/about-page/about-card-platform.html
+++ b/_includes/about-page/about-card-platform.html
@@ -4,7 +4,7 @@
     </div>
     <div class="about-us-section-content">
         <div class="sub-card">
-            <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/workforce-development.svg" alt=""></span><span class="sub-head-text color-dodgerblue">Workforce Development</span></div>
+            <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/workforce-development.svg" alt=""></span><span class="sub-head-text color-dodgerblue">Workforce Development</div>
             <p class="sub-card-content border-dodgerblue">
                 Enlightened self-interest is a powerful motivator. Our members have access to mentorship,
                 one-on-one help with job searches, and resume coaching. We do project matching to fit skill
@@ -14,7 +14,7 @@
             </p>
             <div class="platform-mid-section">
                 <div class="platform-sec-impact">
-                    <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/impact.svg" alt=""></span><span class="sub-head-text color-lightseagreen">Impact</span></div>
+                    <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/impact.svg" alt=""></span><span class="sub-head-text color-lightseagreen">Impact</div>
                     <p class="sub-card-content border-lightseagreen">
                         We choose and empower projects where there is a demonstrable impact on stakeholders, project partners,
                         our local community, and our members. We don’t seek to be the experts, but instead to learn from them


### PR DESCRIPTION

Fixes #5370 

### What changes did you make?
  - Added the missing </span> closing tags in three sections on the About page.

### Why did you make the changes (we will use this info to test)?
  - To remove linter errors caused by span tags that were not paired with closing tags. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screenshot code changes)

Refactoring HTML codes. No visual changes to the website.

