### PR TITLE
Fix SDG background bug

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -110,7 +110,8 @@ layout: default
                 <p><strong>Impact</strong></p>
                 <p>{{ page.impact }}</p>
             </div>
-            <div class='sdg-description-card'>
+            {%- assign background_color = page.sdg-color-variable |  replace_first: "$", "background-" -%}
+            <div class='sdg-description-card {{ background_color }}'>
                 <h2 class='sdg-card-title title7'>Sustainable Development Goal</h2>
                 <div class='sdg-description-wrapper'>
                     <img class='sdg-img' src='{{ page.sdg-image-src }}'>

--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -75,4 +75,5 @@ impact: Neighborhood Councils are able to use visualizations to demonstrate and 
 sdg: '<strong>16.8:</strong> Broaden and strengthen the awareness and participation of City and local communities, especially those traditionally underserved and marginalized, in the institutions of local and global governance.'
 sdg-image-src: /assets/images/sdg/sdg16.svg
 sdg-image-alt: '16: peace, justice and strong institutions'
+sdg-color-variable: $color-sdg16
 ---

--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -105,4 +105,5 @@ visible: true
 sdg: '<strong>16.8:</strong> Broaden and strengthen the awareness and participation of City and local communities, especially those traditionally underserved and marginalized, in the institutions of local and global governance.'
 sdg-image-src: /assets/images/sdg/sdg16.svg
 sdg-image-alt: '16: peace, justice and strong institutions'
+sdg-color-variable: $color-sdg16
 ---

--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -70,4 +70,5 @@ impact: Our platform will make important local conversations much more represent
 sdg: '<strong>16.8:</strong> Broaden and strengthen the awareness and participation of City and local communities, especially those traditionally underserved and marginalized, in the institutions of local and global governance.'
 sdg-image-src: /assets/images/sdg/sdg16.svg
 sdg-image-alt: '16: peace, justice and strong institutions'
+sdg-color-variable: $color-sdg16
 ---

--- a/_projects/lucky-parking.md
+++ b/_projects/lucky-parking.md
@@ -150,4 +150,5 @@ impact: Our project seeks to educate and inform city leaders and the community a
 sdg: '<strong>11.2:</strong> By 2030, provide access to safe, affordable, accessible and sustainable transport systems for all, improving road safety, notably by expanding public transport, with special attention to the needs of those in vulnerable situations, women, children, persons with disabilities and older persons.'
 sdg-image-src: /assets/images/sdg/sdg11.svg
 sdg-image-alt: '11: sustainable cities and communities'
+sdg-color-variable: $color-sdg11
 ---

--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -78,4 +78,5 @@ impact: <i>We are currently drafting the Impact statement for this project.</i>
 sdg: '<strong>16.8:</strong> Broaden and strengthen the awareness and participation of City and local communities, especially those traditionally underserved and marginalized, in the institutions of local and global governance.'
 sdg-image-src: /assets/images/sdg/sdg16.svg
 sdg-image-alt: '16: peace, justice and strong institutions'
+sdg-color-variable: $color-sdg16
 ---

--- a/_sass/components/_project-page.scss
+++ b/_sass/components/_project-page.scss
@@ -239,7 +239,6 @@
   flex-direction: column;
   flex-wrap: wrap;
   margin-right: auto;
-  background: #02548B;
   text-align: center;
   border-radius: 10px 10px 11px 11px;
   height: fit-content;


### PR DESCRIPTION
Fixes #4187 

### What changes did you make?
  - Update sdg-color-variable for 311-data, access the data, engage, and community survey projects
  - Remove old background color variable from _project_page.scss

### Why did you make the changes (we will use this info to test)?
  - consistency between background and element color (wasn't matching before)
  - Note: no visual change in access the data


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
lucky parking
<img width="1436" alt="lucky-parking-desktop-before" src="https://github.com/hackforla/website/assets/93944737/baa3636a-b2bc-4fbe-8040-8e85c1811a84">

<img width="501" alt="lucky-parking-mobile-before" src="https://github.com/hackforla/website/assets/93944737/5e71d610-b403-440c-abef-331c19a627f9">

311-data
<img width="1086" alt="311-data-desktop-before" src="https://github.com/hackforla/website/assets/93944737/a623ed72-77c3-4506-99ee-7b2fe1d1437c">
<img width="584" alt="311-data-mobile-before" src="https://github.com/hackforla/website/assets/93944737/8a8e2aa3-1db0-454a-9153-beccce61d142">
engage
<img width="1375" alt="engage-desktop-before" src="https://github.com/hackforla/website/assets/93944737/f11907df-7dd8-4c61-afa0-a96e8bd4d74a">
<img width="679" alt="engage-mobile-before" src="https://github.com/hackforla/website/assets/93944737/55f06280-a8aa-443d-9df0-dce697497915">
open-community
<img width="1374" alt="open-community-desktop-before" src="https://github.com/hackforla/website/assets/93944737/eefc20df-77d5-4198-a91a-fe7272f372a8">
<img width="679" alt="open-community-mobile-before" src="https://github.com/hackforla/website/assets/93944737/de886675-0ed0-421e-84bd-147718f9f3d0">


</details>

<details>
<summary>Visuals after changes are applied(mobile views same)</summary>
  lucky parking
<img width="1433" alt="lucky-parking-desktop-after" src="https://github.com/hackforla/website/assets/93944737/d7b55867-29b4-4e47-8dbe-1fd393e209b5">
<img width="491" alt="lucky-parking-mobile-after" src="https://github.com/hackforla/website/assets/93944737/d96f3070-e71d-4f27-8e22-94841a309490">

311-data
<img width="1084" alt="311-data-desktop-after" src="https://github.com/hackforla/website/assets/93944737/97cb98b6-be73-4401-96e8-535fb3b24577">
<img width="586" alt="311-data-mobile-after" src="https://github.com/hackforla/website/assets/93944737/6a16c192-27e4-498c-a664-5bdd0d784bf0">
engage desktop
<img width="1376" alt="engage-desktop-after" src="https://github.com/hackforla/website/assets/93944737/d4e6aa82-6129-42b7-a6d8-41c86b370c70">
<img width="683" alt="engage-mobile-after" src="https://github.com/hackforla/website/assets/93944737/b4c58475-d02b-4d94-99c0-c39781a4e0e2">
open community
<img width="1371" alt="open-community-desktop-after" src="https://github.com/hackforla/website/assets/93944737/7074cc25-0b4c-4f9e-b253-44ab7e63eb7a">
<img width="676" alt="open-community-mobile-after" src="https://github.com/hackforla/website/assets/93944737/c62374f3-e79b-4086-9ade-91f61495cfdb">



</details>
