### PR TITLE
added new variable `github-handle` to Eric Cho in 311-data.md

### DIFF
--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -7,6 +7,7 @@ alt: '311 Data'
 image-hero: /assets/images/projects/311data-beta.png
 leadership:
   - name: Eric Cho
+    github-handle: 
     role: Product Manager
     links:
       slack: 'https://hackforla.slack.com/team/U02E95SPK4N'


### PR DESCRIPTION
Fixes #5713

### What changes did you make?
  - added variable `github-handle` to Eric Cho and checked with Docker at localhost:4000/

### Why did you make the changes (we will use this info to test)?
  - The issue aimed to replace variables `github` and `picture` with new variable `github-handle`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before](https://github.com/hackforla/website/assets/118224034/b5b7ab53-b5cd-4c42-a815-daaa725d6ce2)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after](https://github.com/hackforla/website/assets/118224034/4016164f-b9e5-4f43-bda5-309b6f23ada9)

</details>
