### PR TITLE
Added a new Project Profile to  the Expunge Assist team 

### DIFF
--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -38,6 +38,15 @@ leadership:
       slack: https://hackforla.slack.com/team/U025XR6MY6S
       github: https://github.com/SamHyler
     picture: https://avatars.githubusercontent.com/SamHyler
+  - name: Curtis Barber
+    github-handle: CBx3000
+    role: Product Manager, Content
+    links:
+      slack: https://hackforla.slack.com/team/U05RZAETCQ4
+      github: https://github.com/CBx3000
+    picture: https://avatars.githubusercontent.com/CBx3000
+  
+ 
 links:
     - name: GitHub
       url: 'https://github.com/hackforla/record-clearance/'

--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -45,8 +45,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U05RZAETCQ4
       github: https://github.com/CBx3000
     picture: https://avatars.githubusercontent.com/CBx3000
-  
- 
 links:
     - name: GitHub
       url: 'https://github.com/hackforla/record-clearance/'


### PR DESCRIPTION
Fixes #5759  

### What changes did you make?
  -  In  the _projects/expunge-assist.md file from line 41-47 I added a new profile to the leadership Variable 


### Why did you make the changes (we will use this info to test)?
  -  Expunge Assist needed an update to their project team on the Hack For LA website  
  
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->

<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>




![Screen Shot 2023-10-27 at 1 25 19 PM](https://github.com/hackforla/website/assets/107657521/f857b4c9-0e90-4a07-8d14-6d35201fba9d)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screen Shot 2023-10-27 at 1 37 18 PM](https://github.com/hackforla/website/assets/107657521/2f5d4242-1b2c-42d4-8c24-d947890d0ffd)


</details>


