### PR TITLE
Re Issue 5753: Removed Jamie Siu from Expunge Assist project page leadership section

### DIFF
--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -13,12 +13,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U02DFJ72V8Q'
       github: 'https://github.com/thomasdemoner'
     picture: 'https://avatars.githubusercontent.com/thomasdemoner'
-  - name: Jamie Siu
-    role: Product Manager, Design
-    links:
-      slack: 'https://hackforla.slack.com/team/U036RQHGRRR'
-      github: 'https://github.com/jamiesiu'
-    picture: 'https://avatars.githubusercontent.com/jamiesiu'
   - name: Sheron Virani
     role: Product Manager, Research
     links:

--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -20,12 +20,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U02DFJ72V8Q'
       github: 'https://github.com/thomasdemoner'
     picture: 'https://avatars.githubusercontent.com/thomasdemoner'
-  - name: Jamie Siu
-    role: Product Manager, Design
-    links:
-      slack: 'https://hackforla.slack.com/team/U036RQHGRRR'
-      github: 'https://github.com/jamiesiu'
-    picture: 'https://avatars.githubusercontent.com/jamiesiu'
   - name: James Shin
     role: Product Manager, Design
     links:


### PR DESCRIPTION
Fixes #5753 

### What changes did you make?
  -    Removed following code from _projects/expunge-assist.md

```
- name: Jamie Siu
    role: Product Manager, Design
    links:
      slack: 'https://hackforla.slack.com/team/U036RQHGRRR'
      github: 'https://github.com/jamiesiu'
    picture: 'https://avatars.githubusercontent.com/jamiesiu'
```

### Why did you make the changes (we will use this info to test)?
  - To remove Jamie Siu from Expunge Assist project page
  - To keep project info up to date and accurate

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot (15)](https://github.com/hackforla/website/assets/67331818/0cc795f5-971f-4329-9e1a-f8da97402175)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot (16)](https://github.com/hackforla/website/assets/67331818/30a4ca46-6f8e-4ed7-8e4c-06b6745b349d)

</details>
