### PR TITLE
Added Anita Morales to Expunge Assist Project on the UI

### DIFF
--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -38,6 +38,13 @@ leadership:
       slack: https://hackforla.slack.com/team/U025XR6MY6S
       github: https://github.com/SamHyler
     picture: https://avatars.githubusercontent.com/SamHyler
+  - name: Anita Morales
+    github-handle: anitadesigns
+    role: UX Design, Team Co-lead
+    links:
+      slack: https://hackforla.slack.com/team/U03F43PFR3K
+      github: https://github.com/anitadesigns
+    picture: https://avatars.githubusercontent.com/anitadesigns
 links:
     - name: GitHub
       url: 'https://github.com/hackforla/record-clearance/'


### PR DESCRIPTION
Fixes #5761 

### What changes did you make?
  - I added Anita Morales's profile information such as their name, GitHub handle, role, social links, and picture to the project team section of Expunge Assist.

### Why did you make the changes (we will use this info to test)?
  - We need to keep project information up to date so that visitors to the website can find accurate information.
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Before Adding Anita Morales Expunge Assist Team UI](https://github.com/hackforla/website/assets/93952027/c1582d49-9c92-40f8-a49a-cf08f6f12d30)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![After Adding Anita Morales Expunge Assist UI](https://github.com/hackforla/website/assets/93952027/f807efe3-3801-478f-b8d4-cff1d365e96c)


</details>
