### PR TITLE
Added Sydney Walcoff to the expunge-assist.md File

### DIFF
--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -40,6 +40,13 @@ leadership:
       slack: https://hackforla.slack.com/team/U05RZAETCQ4
       github: https://github.com/CBx3000
     picture: https://avatars.githubusercontent.com/CBx3000
+  - name: Sydney Walcoff
+    github-handle: sydneywalcoff
+    role: Development, Team Lead
+    links:
+      slack: https://hackforla.slack.com/team/U02P0A49XL4
+      github: https://github.com/sydneywalcoff
+    picture: https://avatars.githubusercontent.com/sydneywalcoff
 links:
     - name: GitHub
       url: 'https://github.com/hackforla/record-clearance/'

--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -54,7 +54,7 @@ links:
       url: https://expungeassist.org/
     - name: Readme
       url: 'https://github.com/hackforla/record-clearance/blob/master/README.md'
-    - name: Slack``
+    - name: Slack
       url: 'https://hackforla.slack.com/messages/CN8NXTPK5'
 looking:
   - category: Marketing

--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -46,7 +46,7 @@ links:
       url: https://expungeassist.org/
     - name: Readme
       url: 'https://github.com/hackforla/record-clearance/blob/master/README.md'
-    - name: Slack
+    - name: Slack``
       url: 'https://hackforla.slack.com/messages/CN8NXTPK5'
 looking:
   - category: Marketing


### PR DESCRIPTION
Fixes #5760 

### What changes did you make?
  - Found the leadership variable and added the Sydney Walcoff text as a new entry for Expunge Assist project (_projects/expunge-assist.md)

### Why did you make the changes (we will use this info to test)?
  - We need to keep project information up to date so that visitors to the website can find accurate information.
  - Not sure how else to answer this personally besides *cue Patrick Star voice* "Because you told me to!" 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<details>
<summary>Visuals before changes are applied</summary>
<img width="956" alt="issue 5760 before changes" src="https://github.com/hackforla/website/assets/119633800/d789fb6b-06ad-46c0-bbfe-d722ac0cdf1e">
</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="954" alt="issue 5760 after changes" src="https://github.com/hackforla/website/assets/119633800/c238614a-fc46-4b31-935c-88219856517b">
</details>
