### PR TITLE
Removed James Shin from Expunge Assist Team on UI - #5755

### DIFF
--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -20,12 +20,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U02DFJ72V8Q'
       github: 'https://github.com/thomasdemoner'
     picture: 'https://avatars.githubusercontent.com/thomasdemoner'
-  - name: James Shin
-    role: Product Manager, Design
-    links:
-      slack: 'https://hackforla.slack.com/team/U04BS46F67L'
-      github: 'https://github.com/jamesshin27'
-    picture: 'https://avatars.githubusercontent.com/jamesshin27'
   - name: Samantha Hyler
     github-handle: SamHyler
     role:  UX Content, Team Lead


### PR DESCRIPTION
Fixes #5755 

### What changes did you make?
  - Removed James Shin's information from the Expunge Assist current project team section on the UI.

### Why did you make the changes (we will use this info to test)?
  - Needed to remove James Shin from the Expunge Assist team to keep the site up to date.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->
<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)
![Before Removing James Shin UI](https://github.com/hackforla/website/assets/93952027/ec0de100-7004-4659-b7fa-58fc49b66946)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image
![After Removing James Shin UI](https://github.com/hackforla/website/assets/93952027/776f6ed7-639a-4f17-a95d-bb1111d999e9)
_Link_Here_After_Attaching_Files)

</details>
