### PR TITLE
Removed Yua Guan from lucky parking page#5808

### DIFF
--- a/_projects/lucky-parking.md
+++ b/_projects/lucky-parking.md
@@ -103,12 +103,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U025M9VRDJR'
       github: 'https://github.com/ymphan'
     picture: https://avatars.githubusercontent.com/ymphan
-  - name: Yao Guan
-    role: Quant UXR
-    links:
-      slack: 'https://hackforla.slack.com/team/U03F35T4PND'
-      github: 'https://github.com/yaoguan'
-    picture: https://avatars.githubusercontent.com/u/41702875
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/lucky-parking'


### PR DESCRIPTION
Fixes #5808

### What changes did you make?
  - Removed Yao Guan from lucky parking page

### Why did you make the changes (we will use this info to test)?
  - User is inactive

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="883" alt="Screenshot 2023-11-08 at 4 46 08 PM" src="https://github.com/hackforla/website/assets/121325991/2abc894f-917b-4086-8716-90d0d6feb79f">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="872" alt="Screenshot 2023-11-08 at 4 47 29 PM" src="https://github.com/hackforla/website/assets/121325991/22783cc9-ca2b-4647-89b5-a1c689bb45bd">


</details>
