### PR TITLE
Prevent Page Scrolling Behind Filter Overlay on Mobile View

### DIFF
--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -240,6 +240,9 @@ a.clear-filter-tags {
     padding: 32px 16px;
     // flex-direction: column;
   }
+  .scroll-lock {
+    overflow: hidden;
+  }
   .filter-toolbar {
     background-color: $color-pink;
     padding: 0;

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -257,10 +257,13 @@ function showNoneEventHandler(e) {
 // shows filters popup on moble
 function showFiltersEventHandler(e) {
     document.querySelector(".filter-toolbar").classList.add("show-filters")
+    // prevent page scrolling behind filter overlay
+    document.getElementsByTagName("html")[0].classList.add("scroll-lock")
 }
 // hides filters popup on moble
 function hideFiltersEventHandler(e) {
     document.querySelector(".filter-toolbar").classList.remove("show-filters")
+    document.getElementsByTagName("html")[0].classList.remove("scroll-lock")
 }
 // cancel button on mobile filters
 function cancelMobileFiltersEventHandler(e) {

--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -482,12 +482,15 @@ function showFiltersEventHandler(e) {
     filterToolbar.classList.add("show-filters")
     // Prevents corners of mobile filter toggle from having white corners
     filterToolbar.childNodes[1].classList.remove("filtersDiv-background")
+    // prevent page scrolling behind filter overlay
+    document.getElementsByTagName("html")[0].classList.add("scroll-lock")
 }
 // hides filters popup on mobile
 function hideFiltersEventHandler(e) {
     let filterToolbar = document.querySelector(".filter-toolbar")
     filterToolbar.classList.remove("show-filters")
     filterToolbar.childNodes[1].classList.add("filtersDiv-background")
+    document.getElementsByTagName("html")[0].classList.remove("scroll-lock")
 }
 
 //event handler for keyboard users to click spans when focused


### PR DESCRIPTION
Fixes #5730

### What changes did you make?
  - Created scroll-lock class in "_dropdown_filters.scss" to hide overflow content
  - Added scroll-lock toggle on html in "current-projects.js" & "toolkit.js"

### Why did you make the changes (we will use this info to test)?
  - Enhance UX on mobile view when filtering projects & toolkit pages

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

![275727298-5dcf8256-d159-483a-8ee3-28fb671e38a0](https://github.com/hackforla/website/assets/105189603/8cddbdbf-9451-4177-a33c-19225f70465b)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![Nov-11-2023 01-14-07](https://github.com/hackforla/website/assets/105189603/ff58e80f-9a24-433e-aa13-1a57312bf520)

</details>
