### PR TITLE
Refactor Slack image icon with svg icon in communities of practice page

### DIFF
--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -142,8 +142,8 @@
   }
   
   #slack-icon{
-    width: 22px;
-    height: 22px;
+    width: 24px;
+    height: 24px;
   }
 
   #github-icon{
@@ -159,6 +159,7 @@
   }
   .cop-btn{
     width: 232px;
+    padding: 0 30px;
   }
 }
 
@@ -169,6 +170,7 @@
 
   .cop-btn{
       width: 203px;
+      padding: 0 15px;
   }
 
   .link-buttons a:nth-child(2){

--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -141,9 +141,10 @@
     margin-right: 5px;
   }
   
-  #slack-icon{
+  #Layer_1{ 
     width: 24px;
     height: 24px;
+    margin-right: 5px;
   }
 
   #github-icon{

--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -71,9 +71,7 @@ permalink: /communities-of-practice
                 {% if community[1].links[0].url %}
                     {% assign url_links = true %}
                     <a href="{{ community[1].links[0].url }}" class="btn btn-primary btn-md btn--default cop-btn" target="_blank" title="{{community[1].name}} Slack channel">
-                        <svg class="button-icon" id="slack-icon" alt="slack icon" viewBox="0 0 100 100">
-                            {% include svg/icon-slack.svg %}
-                        </svg>
+                        {% include svg/icon-slack.svg %}
                         Join Slack Channel
                     </a>
                 {% endif %}

--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -71,7 +71,9 @@ permalink: /communities-of-practice
                 {% if community[1].links[0].url %}
                     {% assign url_links = true %}
                     <a href="{{ community[1].links[0].url }}" class="btn btn-primary btn-md btn--default cop-btn" target="_blank" title="{{community[1].name}} Slack channel">
-                        <img class="button-icon" id="slack-icon" src="/assets/images/communities-of-practice/slack-join-meeting-channel.svg" alt="slack icon" />
+                        <svg class="button-icon" id="slack-icon" alt="slack icon" viewBox="0 0 100 100">
+                            {% include svg/icon-slack.svg %}
+                        </svg>
                         Join Slack Channel
                     </a>
                 {% endif %}


### PR DESCRIPTION
Fixes #5829

### What changes did you make?
  - Replaced img tag for the "Join Slack Channel" button icon with a liquid image element referencing _includes/svg/icon-slack.svg
  - Modified CSS to maintain current appearance of page

### Why did you make the changes (we will use this info to test)?
  - To make sure that only a single slack icon svg is used in the codebase
  - Make it easier to render the svg in various colors throughout the website

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="947" alt="communities-of-practice-before" src="https://github.com/hackforla/website/assets/15069166/8e0f61f1-b867-4c7a-806f-145a0bcb61d2">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="947" alt="communities-of-practice-after" src="https://github.com/hackforla/website/assets/15069166/bc94e1f3-69f9-45c9-85ca-3384ea28501e">

</details>
