### PR TITLE
removes sam sengupta from lucky parking profile

### DIFF
--- a/_projects/lucky-parking.md
+++ b/_projects/lucky-parking.md
@@ -67,12 +67,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U0270QURQCD'
       github: 'https://github.com/eugenecha'
     picture: https://avatars.githubusercontent.com/eugenecha
-  - name: Sam Sengupta
-    role: UX/UI Designer
-    links:
-      slack:
-      github:
-    picture: https://avatars.githubusercontent.com/u/41702879
   - name: Seymour Liao
     role: Data Scientist
     links:


### PR DESCRIPTION
Fixes #5802

### What changes did you make?
  - Removed Sam Sengupta from Lucky Parking profile page

### Why did you make the changes (we will use this info to test)?
  - To update Lucky Parking contributors profile page

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1465" alt="Screenshot 2023-11-14 at 12 58 07 PM" src="https://github.com/hackforla/website/assets/119828225/2219fb3c-794b-423e-94b0-2cf6e97535c4">

</details>

<details>
<summary>Visuals after changes are applied</summary>

<img width="1466" alt="Screenshot 2023-11-14 at 1 00 47 PM" src="https://github.com/hackforla/website/assets/119828225/450d9ca2-e46f-47d1-b385-36f9c5c5f3dc">
  
</details>
