### PR TITLE
added  instructions for installation and use of the cspell npm packag…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,9 +312,9 @@ You must use VS Code as your local text editor to install the VS Code extension 
 The recommended installation method is to install Code Spell Checker directly from the VS Code text editor, and those instructions can be found [here](https://code.visualstudio.com/learn/get-started/extensions).
 The extension can also be installed via the VS Code Marketplace website [here](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). 
 
-For developers who do not use VSCode, use the corresponding npm package, cspell, and those instructions can be found [here](https://www.npmjs.com/package/cspell).
+For developers who do not use VS Code, use the corresponding npm package, cspell, and those instructions can be found [here](https://www.npmjs.com/package/cspell).
 
-<strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/messages/hfla-site/) if you have trouble installing the VSCode extension or the cspell npm package on your system.</em></strong>
+<strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/messages/hfla-site/) if you have trouble installing the VS Code extension or the cspell npm package on your system.</em></strong>
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 ***

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,7 +313,8 @@ The recommended installation method is to install Code Spell Checker directly fr
 The extension can also be installed via the VS Code Marketplace website [here](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). 
 
 For developers who do not use VSCode, use the corresponding npm package, cspell, and those instructions can be found [here](https://www.npmjs.com/package/cspell).
-<strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/messages/hfla-site/) if you have trouble installing docker on your system</em></strong>
+
+<strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/messages/hfla-site/) if you have trouble installing the VSCode extension or the cspell npm package on your system.</em></strong>
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 ***

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ The following is a set of guidelines for contributing to the website repository,
     - [**1.6 Dev setup (6): Build and serve the website locally**](#16-dev-setup-6-build-and-serve-the-website-locally)
       - [**1.6.a Starting Docker**](#16a-starting-docker)
       - [**1.6.b Stopping Docker**](#16b-stopping-docker)
+    - [**1.7 Dev setup (7): Install local codebase spell checker**](#17-Install-local-codebase-spell-checker)
   - [**Part 2: How the Website team works with GitHub issues**](#part-2-how-the-website-team-works-with-github-issues)
     - [**2.1 Hack for LA Contributor expectations**](#21-hack-for-la-contributor-expectations)
     - [**2.2 How Hack for LA organizes issues**](#22-how-hack-for-la-organizes-issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ The following is a set of guidelines for contributing to the website repository,
     - [**1.6 Dev setup (6): Build and serve the website locally**](#16-dev-setup-6-build-and-serve-the-website-locally)
       - [**1.6.a Starting Docker**](#16a-starting-docker)
       - [**1.6.b Stopping Docker**](#16b-stopping-docker)
-    - [**1.7 Dev setup (7): Install local codebase spell checker**](#17-Install-local-codebase-spell-checker)
+    - [**1.7 Dev setup (7): Install local codebase spell checker**](#17-dev-setup-7-install-local-codebase-spell-checker)
   - [**Part 2: How the Website team works with GitHub issues**](#part-2-how-the-website-team-works-with-github-issues)
     - [**2.1 Hack for LA Contributor expectations**](#21-hack-for-la-contributor-expectations)
     - [**2.2 How Hack for LA organizes issues**](#22-how-hack-for-la-organizes-issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,6 +304,19 @@ docker-compose up
 
 ***
 
+### **1.7 Dev setup (7): Install local codebase spell checker**
+
+You must use VS Code as your local text editor to install the VS Code extension for spell checking your codebase, Code Spell Checker.
+
+The recommended installation method is to install Code Spell Checker directly from the VS Code text editor, and those instructions can be found [here](https://code.visualstudio.com/learn/get-started/extensions).
+The extension can also be installed via the VS Code Marketplace website [here](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). 
+
+For developers who do not use VSCode, use the corresponding npm package, cspell, and those instructions can be found [here](https://www.npmjs.com/package/cspell).
+<strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/messages/hfla-site/) if you have trouble installing docker on your system</em></strong>
+
+<sub>[Back to Table of Contents](#table-of-contents)</sub>
+***
+
 ## **Part 2: How the Website team works with GitHub issues**
 
 ### **2.1 Hack for LA Contributor expectations**


### PR DESCRIPTION

Fixes #5652

### What changes did you make?
  - In CONTRIBUTING.md, section 1.7, added instructions for local codebase spell checking for users who do not use VSCode.

### Why did you make the changes (we will use this info to test)?
  - To provide guidance for use of the  npm package, cspell for developers who do not use VSCode.
  
### For Reviewers:
- Do not review changes locally, rather, review changes at https://github.com/robertnjenga/website/blob/workstation-spell-check-5652/CONTRIBUTING.md

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- No visual changes


