### PR TITLE
include meetingName on Project Meetings page

### DIFF
--- a/assets/js/utility/api-events.js
+++ b/assets/js/utility/api-events.js
@@ -42,7 +42,8 @@ function insertEventSchedule(eventData, page) {
 				  if (page === "events") {
 					  eventHtml = `<li>${event.start} - ${event.end} </li><li><a href="${event.hflaWebsiteUrl}">${event.name}</a> ${event.meetingName}</li>`;
 				  } else {
-					  eventHtml = `<li>${event.start} - ${event.end} <a href="${event.hflaWebsiteUrl}">${event.name}</a> ${event.dsc}</li>`;
+            if(event.dsc != "") event.meetingName += ", ";
+					  eventHtml = `<li>${event.start} - ${event.end} <a href="${event.hflaWebsiteUrl}">${event.name}</a> ${event.meetingName} ${event.dsc}</li>`;
 				  }
 				  placeToInsert.insertAdjacentHTML("beforeend", eventHtml);}
       });


### PR DESCRIPTION
Fixes #5345 

### What changes did you make?
  - Inserted meetingName on the Project Meetings page
  - Included logic to add a comma after meetingName when dsc is not an empty string

### Why did you make the changes (we will use this info to test)?
  - To provide additional information about project meetings

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Before Changes](https://github.com/hackforla/website/assets/104318817/d3f343e7-7326-4b68-95d5-fdec5f03ebec)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![After Changes](https://github.com/hackforla/website/assets/104318817/f44dbf1b-c215-48a8-91a3-d65ce2d42bb6)

</details>
