### PR TITLE
Change Clickable Area from Arrow to Filter Section Heading

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -49,9 +49,12 @@ document.addEventListener("DOMContentLoaded",function(){
         document.querySelectorAll("li.view-all").forEach(viewAll => {
             viewAll.addEventListener("click", viewAllEventHandler)
         })
-
-        document.querySelectorAll(".labelArrow").forEach(arrow => {
-            arrow.addEventListener("click", showNoneEventHandler)
+        
+        // Event listener for arrows to collapse categories
+        document.querySelectorAll(".filter-item").forEach(filterItem => {
+            filterItem.addEventListener("click", () => {
+                filterItem.querySelector('a').classList.toggle("show-none")
+            })
         })
 
         document.querySelectorAll(".show-filters-button").forEach(button => {
@@ -249,10 +252,6 @@ function tabFocusedKeyDownHandler(e) {
 	if ((event.key === "Enter" || event.key === "Spacebar" || event.key === " ") && document.activeElement.getAttribute("aria-label")) {
         document.activeElement.click()
     }
-}
-//hides all filters in a category (unless in mobile view, then this shows all, because mobile default is show none)
-function showNoneEventHandler(e) {
-    e.target.parentNode.classList.toggle("show-none")
 }
 // shows filters popup on moble
 function showFiltersEventHandler(e) {

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -51,9 +51,9 @@ document.addEventListener("DOMContentLoaded",function(){
         })
         
         // Event listener for arrows to collapse categories
-        document.querySelectorAll(".filter-item").forEach(filterItem => {
-            filterItem.addEventListener("click", () => {
-                filterItem.querySelector('a').classList.toggle("show-none")
+        document.querySelectorAll("li.filter-item a.category-title").forEach(categoryHeading => {
+            categoryHeading.addEventListener("click", () => {
+                categoryHeading.classList.toggle("show-none")
             })
         })
 

--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -181,9 +181,9 @@ function initializeFilters() {
         })
     }
     // Event listener for arrows to collapse categories
-    document.querySelectorAll(".filter-item").forEach(filterItem => {
-        filterItem.addEventListener("click", () => {
-            filterItem.querySelector('a').classList.toggle("show-none")
+    document.querySelectorAll("li.filter-item a.category-title").forEach(categoryHeading => {
+        categoryHeading.addEventListener("click", () => {
+            categoryHeading.classList.toggle("show-none")
         })
     })
 }

--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -181,10 +181,9 @@ function initializeFilters() {
         })
     }
     // Event listener for arrows to collapse categories
-    const labelArrows = document.querySelectorAll(".labelArrow")
-    labelArrows.forEach(label => {
-        label.addEventListener('click', function() {
-            label.parentElement.classList.toggle("show-none")
+    document.querySelectorAll(".filter-item").forEach(filterItem => {
+        filterItem.addEventListener("click", () => {
+            filterItem.querySelector('a').classList.toggle("show-none")
         })
     })
 }


### PR DESCRIPTION
Fixes #5770 

### What changes did you make?
  -  Changed the clickable area for a filter section from the arrow to the filter section heading


### Why did you make the changes (we will use this info to test)?
  - To keep the clickable area consistent without the use of images/svgs.
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image]( 
![Screen Recording 2023-11-15 at 2-2](https://github.com/hackforla/website/assets/129820906/d39e031b-b6ee-4a0b-b89f-019f6bbc57e6)
)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](
![Screen Recording 2023-11-15 at 2](https://github.com/hackforla/website/assets/129820906/740c500e-6252-487b-8463-c21e3a853530)
)

</details>
