### PR TITLE
Fixes #5882 Adds github-handle variable beneath Tony Delgado name variable in _projects/access-the-data.md

### DIFF
--- a/_projects/access-the-data.md
+++ b/_projects/access-the-data.md
@@ -41,6 +41,7 @@ leadership:
       github: 'https://github.com/Aparna1Gopal'
     picture: https://avatars.githubusercontent.com/Aparna1Gopal
   - name: Tony Delgado
+    github-handle: 
     role: Developer
     links:
       slack: 'https://hackforla.slack.com/team/U05422GPUQ2'


### PR DESCRIPTION
… now empty github-handle variable.

Fixes #5882

### What changes did you make?
  - Added github-handle variable beneath Tony Delgado name variable in _projects/access-the-data.md.

### Why did you make the changes (we will use this info to test)?
  - The github handle variable will eventually replace the github and picture variables, making the code drier and reducing redundancy.  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/Pfulcher26/images/raw/main/5882-tony-delgado.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/Pfulcher26/images/raw/main/5882-tony-delgado.png)

</details>
