### PR TITLE
Removed Michael and added Ryan & Anna to 311 data team on UI

### DIFF
--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -6,7 +6,7 @@ image: /assets/images/projects/311_data.png
 alt: '311 Data'
 image-hero: /assets/images/projects/311data-beta.png
 leadership:
-  - name: Saju Venugopal
+  - name: Sanju Venugopal
     github-handle: sanjumv
     role: Product Manager
     links:

--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -6,12 +6,6 @@ image: /assets/images/projects/311_data.png
 alt: '311 Data'
 image-hero: /assets/images/projects/311data-beta.png
 leadership:
-  - name: Michael Criste
-    role: Product Manager
-    links:
-      slack: 'https://hackforla.slack.com/team/U048U430FQV'
-      github: 'https://github.com/mc759'
-    picture: https://avatars.githubusercontent.com/mc759
   - name: Saju Venugopal
     github-handle: sanjumv
     role: Product Manager
@@ -26,6 +20,20 @@ leadership:
       slack: https://hackforla.slack.com/team/U05MQ8CB2S1
       github: https://github.com/CottonChristopher
     picture: https://avatars.githubusercontent.com/CottonChristopher
+  - name: Ryan Chase
+    github-handle: ryanfchase
+    role: Project Manager, Developer
+    links:
+      slack: https://hackforla.slack.com/team/U052L9R6ETD
+      github: https://github.com/ryanfchase
+    picture: https://avatars.githubusercontent.com/ryanfchase
+  - name: Anna Kim
+    github-handle: annaseulgi
+    role: UX Design Lead, Product Manager
+    links:
+      slack: https://hackforla.slack.com/team/U05JKGV3F4N
+      github: https://github.com/annaseulgi
+    picture: https://avatars.githubusercontent.com/annaseulgi
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/311-data'


### PR DESCRIPTION
Fixes #5860 

### What changes did you make?
  - Removed Michael Criste from the 311 Data UI page.
  - Added Ryan Chase to the 311 Data UI page.
  - Added Anna Kim to the 311 Data UI page.

### Why did you make the changes (we will use this info to test)?
  - To keep 311 Data UI Page up to date with new leadership.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_I
![311 Data Project Page UI before working on issue](https://github.com/hackforla/website/assets/93952027/cb34bcce-ee05-4cbf-b240-7b72e87a9ef5)
mage_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your
![311 Data Project Page UI After working on issue](https://github.com/hackforla/website/assets/93952027/bc5754ee-69c2-4b8f-a76a-8cc08f4ce630)
_Image_Link_Here_After_Attaching_Files)

</details>
