### PR TITLE
remove hkatz & added zaranylucas from engineering cop

### DIFF
--- a/_data/internal/communities/engineering.yml
+++ b/_data/internal/communities/engineering.yml
@@ -25,12 +25,12 @@ leadership:
       slack: https://hackforla.slack.com/team/U04HFRQ5Y12
       github: https://github.com/agosmou
     picture: https://avatars.githubusercontent.com/agosmou
-  - name: Harrison Katz
+  - name: Zeke Arany-Lucas
     role: Co-Lead
     links:
-      slack: https://hackforla.slack.com/team/U04PFCPK6EP
-      github: https://github.com/hkatzdev
-    picture: https://avatars.githubusercontent.com/hkatzdev
+      slack: https://hackforla.slack.com/team/U062KFUJFU5
+      github: https://github.com/ZekeAranyLucas
+    picture: https://avatars.githubusercontent.com/ZekeAranyLucas
   - name: Chelsey Beck
     role: Co-Lead
     links:


### PR DESCRIPTION
Fixes #5876 

### What changes did you make?
  - in _data/internal/communities/engineering.yml, removed Harrison Katz block from leadership section and added Zeke Arany-Lucas block

### Why did you make the changes (we will use this info to test)?
  - in re issue 5876
  - to keep project information up-to-date and accurate

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)
![Screenshot (17)](https://github.com/hackforla/website/assets/67331818/3150944a-ac71-49cf-9754-8bb9cb02803c)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)
![Screenshot (18)](https://github.com/hackforla/website/assets/67331818/180fec57-769f-4174-8a9e-bb28a252a437)

</details>
