### PR TITLE
updated the slack img.

### DIFF
--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -4,12 +4,14 @@
   max-width: 508px;
   margin-top: 31px;
 
-  .self-invite-img {
-    /*Note "margin-top: 15px" is needed to keep this img aligned with neighboring text*/
-    margin-top: 15px;
+  svg.icon {
+    path {
+      fill: #fa114f;
+    }
+    margin-top: -10px;
     margin-right: 27px;
-    width: 24px;
-    height: 24px;
+    width: 80px;
+    height: 80px;
   }
 
   .alert--communities {

--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -15,7 +15,7 @@ permalink: /communities-of-practice
             If you'd like to join one of the Communities of Practice that has a regular meeting time, join their Slack channel and look for the meeting details, usually pinned or in the description. Otherwise, see the "How to get started" sections below.
         </p>
             <div class="header-self-invite--communities">
-                <img class="self-invite-img" src="/assets/images/communities-of-practice/slack-self-invite.svg" alt="slack icon" />
+                {% include svg/icon-slack.svg %} 
                 <p class="alert--communities">To join the Slack channels below, you first need to be a member of our Hack for LA Slack Community. If you have not joined yet, please follow the steps in <a href="/getting-started" target="_blank">Getting Started</a>.
             </p></div>
     </div>


### PR DESCRIPTION
Fixes #5827

### What changes did you make?
 modify the Communities of Practice page, replacing the current image with the inline SVG

### Why did you make the changes (we will use this info to test)?
 storing only a single Slack icon SVG file in the codebase and matching the appearance of the current image.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="1511" alt="Screenshot 2023-11-17 at 4 42 10 PM" src="https://github.com/hackforla/website/assets/97300861/603e1365-dfc5-4357-a93e-2d70f5eb8ac2">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1510" alt="Screenshot 2023-11-17 at 4 55 12 PM" src="https://github.com/hackforla/website/assets/97300861/88b415dc-4834-441e-839c-9850834270f4">



</details>
