### PR TITLE
removed 1Password from tools

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -117,7 +117,6 @@ tools:
   - Google Drive
   - Zoom
   - Google Analytics
-  - 1Password
 location:
   # - Santa Monica
   # - Downtown LA


### PR DESCRIPTION
Fixes #5680

### What changes did you make?
  - Removed "1Password" from the Tools section in _projects/website.md

### Why did you make the changes (we will use this info to test)?
  - To remove "1Password" from Tools section on [hackforla.org/projects](https://www.hackforla.org/projects/)
  - To remove "1Password" from Tools section on [hackforla.org/projects/website](https://www.hackforla.org/projects/website)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![1pass-before](https://github.com/hackforla/website/assets/113205241/ea7d7ad5-362b-4cdf-be36-7de8fded3de2)
![1pass-before-pt2](https://github.com/hackforla/website/assets/113205241/e1556af9-e1cf-41a7-9689-7b3447a947d7)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  

![1pass-after](https://github.com/hackforla/website/assets/113205241/067c27cc-5740-4db1-a02b-366113e830be)
![1pass-after-pt2](https://github.com/hackforla/website/assets/113205241/d6cff536-a8bd-4aaf-8a3f-d1496c4fd424)

</details>
