### PR TITLE
Update Section2.7.b - making sure devs checkout gh-pages first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -547,9 +547,11 @@ You can also sync your fork directly on GitHub by clicking "Sync Fork" at the ri
 
 #### **2.7.b Working on an issue (2): Create a new branch where you will work on your issue**
 
-The `git checkout` command will create and change to a new branch where you will do the work on your issue.  In git, the checkout command lets you navigate between different branches.  Using the `-b` flag you can create a new branch and immediately switch into it.
+If you have not already done so, run `git checkout gh-pages` to switch the working directory to the `gh-pages` branch and then update `gh-pages` with upstream changes as described above in Section 2.7.a. 
 
-For example,if we creating a new issue branch off [Update ‘Give’ image credit link and information - #2093](https://github.com/hackforla/website/issues/2093):
+Using the `-b` flag you can also use the `git checkout` command to create a new branch and immediately switch into it.  
+
+For example, if you create a new issue branch for [Update ‘Give’ image credit link and information - #2093](https://github.com/hackforla/website/issues/2093):
 
 ```bash
 git checkout -b update-give-link-2093
@@ -564,6 +566,8 @@ git checkout -b update-give-link-2093
 **Note:** The format should look like the scheme above where the words are a brief description of the issue that will make sense at a glance to someone unfamiliar with the issue.
 
 **Note:** No law of physics will break if you don't adhere to this scheme, but laws of git will break if you add spaces.
+
+We urge developers to be cautious using `git add`. In general it is not advisable to use `git add -all` or `git add .`. Rather, run `git status`, examine the output carefully, and then add only those files specifically related to the current issue. This will ensure that no extraneous files are included in the subsequent commit.  
 
 When you've finished working on your issue, follow the steps below to prepare your changes to push to your repository.
 


### PR DESCRIPTION
Fixes #5698

### What changes did you make?
  - Updated the `CONTRIBUTING.md` file

### Why did you make the changes (we will use this info to test)?
  - We need to ensure that the developer has checked out the `gh-pages` branch prior to proceeding to create the issue branch, and that after making files changes, the developers uses caution when using `git add` to prevent inclusion of unwanted files in the subsequent commit.

For Reviewers: Do not review changes locally, rather, review changes at: https://github.com/jphamtv/website/blob/update-contributing-guidelines-5698/CONTRIBUTING.md

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Updated CONTRIBUTING.md file. No visual changes to the website.
