### PR TITLE
Adjusting padding in drop down menu for filters

### DIFF
--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -290,7 +290,7 @@ a.clear-filter-tags {
 
   .filter-toolbar.show-filters ul.filter-list {
     display: flex;
-    padding: 0 12px 35px 0;
+    padding: 0 12px 65px 0;
   }
   .filter-toolbar.show-filters .mobile-filter-buttons {
     display: flex;

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -290,7 +290,7 @@ a.clear-filter-tags {
 
   .filter-toolbar.show-filters ul.filter-list {
     display: flex;
-    padding: 0 12px 65px 0;
+    padding: 0 12px 65px 12px;
   }
   .filter-toolbar.show-filters .mobile-filter-buttons {
     display: flex;

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -290,7 +290,7 @@ a.clear-filter-tags {
 
   .filter-toolbar.show-filters ul.filter-list {
     display: flex;
-    padding: 0 12px;
+    padding: 0 12px 35px 0;
   }
   .filter-toolbar.show-filters .mobile-filter-buttons {
     display: flex;


### PR DESCRIPTION
Fixes #5333 

### What changes did you make?
  - Adjusted padding values in _dropdown_filters.scss  to make sure filter items are not covered by buttons on the bottom when in smartphone/tablet views

### Why did you make the changes (we will use this info to test)?
  - Per requested in the issue #5333
  - When filter drop down menus is fully expanded certain selections are covered by buttons on the bottom.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="392" alt="截圖 2023-11-28 下午6 14 29" src="https://github.com/hackforla/website/assets/109251936/416b6015-9a4e-4dc1-90c7-57128a614b8f">

</details>

<details>
<summary>Visuals after changes are applied</summary>

<img width="392" alt="截圖 2023-11-28 下午6 14 48" src="https://github.com/hackforla/website/assets/109251936/834017f7-6899-44f5-846e-4b54184405a1">

</details>
