### PR TITLE
Removes CFA from about page

### DIFF
--- a/_includes/about-page/about-card-sponsors.html
+++ b/_includes/about-page/about-card-sponsors.html
@@ -12,9 +12,6 @@
             </a>
             {% endfor %}
             {% endcomment %}
-            <a href="https://www.codeforamerica.org" target="_blank" alt="Code for America">
-                <img src="/assets/images/sponsors/code-for-america.svg" title="Code for America">
-            </a>
             <a href="https://laincubator.org" target="_blank" alt="LA Incubator">
                 <img src="/assets/images/sponsors/laci.svg" title="Los Angeles Cleantech Incubator">
             </a>


### PR DESCRIPTION
Fixes #5511

### What changes did you make?
  - Removed mention of Code for America from About page

### Why did you make the changes (we will use this info to test)?
  - Code for America is no longer a sponsor

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before](https://github.com/hackforla/website/assets/52722401/b8c8a5ed-8c0c-4a5c-8950-e372647bd60c)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after](https://github.com/hackforla/website/assets/52722401/3ac14f48-2632-4f7e-9ca0-bb937c7f80c3)

</details>
