### PR TITLE
removes 1password from tech work experience

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -113,7 +113,6 @@ tools:
   - Zoom
   - Calendly
   - LinkedIn
-  - 1Password
   - GitHub Wiki
   - Google Sheets
   - Google Docs


### PR DESCRIPTION
Fixes #5681

### What changes did you make?
  - Removed 1Password from the tools section of tech-work-experience

### Why did you make the changes (we will use this info to test)?
  - To update the tools section of the Project Check Page and Tech Work Experience Project Page 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="1470" alt="before1" src="https://github.com/hackforla/website/assets/119828225/3a0b8c2e-9944-408b-96cc-71ae7a29ab7d">

<img width="1468" alt="before2" src="https://github.com/hackforla/website/assets/119828225/2b43c371-f459-441d-955e-3a42dd6d239a">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1464" alt="after1" src="https://github.com/hackforla/website/assets/119828225/c4fb14b0-f6e7-4c68-b4ed-78bcba1de1aa">

</details>
