### PR TITLE
Project Slack links: Civic Tech Jobs

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -100,7 +100,7 @@ links:
   - name: GitHub
     url: https://github.com/hackforla/civictechjobs
   - name: Slack
-    url: https://hackforla.slack.com/messages/C02509WHFQQ
+    url: https://hackforla.slack.com/archives/C02509WHFQQ
   - name: Overview
     url: ../assets/pdfs/Civic-Tech-Jobs-One-Sheet.pdf
 looking: 


### PR DESCRIPTION
Fixes #5716
### What changes did you make?
  - Changed url: https://hackforla.slack.com/messages/C02509WHFQQ to url: https://hackforla.slack.com/archives/C02509WHFQQ under links in the Civic Tech Jobs project

### Why did you make the changes (we will use this info to test)?
  - So that there is continuity between project Slack links.

