### PR TITLE
Refactored CSS so icon-slack.svg can use various colors

### DIFF
--- a/_sass/elements/_icons.scss
+++ b/_sass/elements/_icons.scss
@@ -1,9 +1,5 @@
-.svg-sprites {
-  display: none;
-}
-
 .svg-sprites,
-.icon {
+.icon:not(div.resource-img *) {
   path {
     fill: currentColor;
   }

--- a/_sass/elements/_icons.scss
+++ b/_sass/elements/_icons.scss
@@ -1,3 +1,7 @@
+.svg-sprites {
+  display: none;
+}
+
 .svg-sprites,
 .icon:not(div.resource-img *) {
   path {


### PR DESCRIPTION
Fixes #5819

### What changes did you make?
  - added ":not(div.resource-img *" to .icon {}

### Why did you make the changes (we will use this info to test)?
  - This will allow the icon-slack.svg icons to be displayed in resource cards with their original colors

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
