### PR TITLE
Added 'test/' to ignorePaths array in cspell.json

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
   ],
   "ignorePaths": [
       "node_modules",
-      ".github"
+      ".github",
+      "test/"
   ]
 }


### PR DESCRIPTION
Fixes #5848 

### What changes did you make?
  - Added 'test/' to ignorePaths array in cspell.json

### Why did you make the changes (we will use this info to test)?
  - To ignore files in the 'test/' path for spell checking.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
