### PR TITLE
Refectoring github actions by moving function to a new file 

### DIFF
--- a/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
@@ -1,6 +1,6 @@
 var fs = require("fs")
 
-// Constant variables
+const formatComment= require("../../utils/format-comment")
 const LABELS_OBJ = {
   'Complexity: Missing': 'Complexity',
   'role missing': 'Role',
@@ -67,21 +67,6 @@ function makeComment(labels) {
   }
   return formatComment(labelsCommentObject)
 }
-
-/**
- * Formats the comment to be posted based on an object input
- * @param {String} replacementString - the string to replace the placeholder in the md file
- * @param {String} placeholderString - the placeholder to be replaced in the md file
- * @param {String} filePathToFormat - the path of the md file to be formatted
- * @param {String} textToFormat - the text to be formatted. If null, use the md file provided in the path. If provided, format that text
- * @returns {String} - returns a formatted comment to be posted on github
- */
- function formatComment({ replacementString, placeholderString, filePathToFormat, textToFormat }) {
-  const text = textToFormat === null ? fs.readFileSync(filePathToFormat).toString('utf-8') : textToFormat
-  const commentToPost = text.replace(placeholderString, replacementString)
-  return commentToPost
-}
-
 /**
  * Posts a comment on github
  * @param {Number} issueNum - the issue number where the comment should be posted

--- a/github-actions/utils/format-comment.js
+++ b/github-actions/utils/format-comment.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+/**
+ * Formats the comment to be posted based on an object input
+ * @param {String} replacementString - the string to replace the placeholder in the md file
+ * @param {String} placeholderString - the placeholder to be replaced in the md file
+ * @param {String} filePathToFormat - the path of the md file to be formatted
+ * @param {String} textToFormat - the text to be formatted. If null, use the md file provided in the path. If provided, format that text
+ * @returns {String} - returns a formatted comment to be posted on github
+ */
+function formatComment({ replacementString, placeholderString, filePathToFormat, textToFormat }) {
+    const text = textToFormat === null ? fs.readFileSync(filePathToFormat).toString('utf-8') : textToFormat
+    const commentToPost = text.replace(placeholderString, replacementString)
+    return commentToPost
+  }
+
+module.exports = formatComment;


### PR DESCRIPTION
Fixes #5831 

### What changes did you make?
  - In the github-actions\trigger-issue\add-missing-labels-to-issues\post-labels-comment.js  I removed the formatComment function along with the parameters  that belong to that function
  - created a new file called called format-comment.js in the utils folder that holds the formatComment function
  - exported the formatComment function then imported the function into github-actions\trigger-issue\add-missing-labels-to-issues\post-labels-comment.js on line 3

### Why did you make the changes (we will use this info to test)?
  - This code refactor  were made to reduce space of the file where the function was  initially located 


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes 
