### PR TITLE
updates cspell.json casing

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -5,8 +5,8 @@
   "words": [
       "Westside",
       "Cleantech",
-      "collabathon",
-      "Undebate",
+      "Collabathon",
+      "Undebate"
   ],
   "ignorePaths": [
       "node_modules",


### PR DESCRIPTION
Fixes #5684

### What changes did you make?
  - Removed a comma after undebate in the cspell.json
  - Used a capital letter for collabathon in the cspell.json

### Why did you make the changes (we will use this info to test)?
  - To update the casing for collabathon to ensure there are no spelling errors in VSC after adding extension Spell Checker

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
 - No changes required