### PR TITLE
Added "VRMS" to cspell.json so there aren't any false positive spellings

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -3,6 +3,7 @@
   "language": "en",
   // words - list of words to be always considered correct
   "words": [
+      "VRMS",
       "Westside",
       "Cleantech",
       "Collabathon",


### PR DESCRIPTION
Fixes #5687

### What changes did you make?
Updated cspell.json by adding a new element "VRMS" ensuring there aren't any false positives in the word "VRMS" in any codebases.

### Why did you make the changes (we will use this info to test)?
To remove any false positives in any codebase with the word "VRMS"

### removing screenshot option since no visible change in website and only in code
