### PR TITLE
adds blank github handle to Muhi-Dean

### DIFF
--- a/_projects/100-automations.md
+++ b/_projects/100-automations.md
@@ -27,6 +27,7 @@ leadership:
       github: 'https://github.com/Olivia-Chiong'
     picture: 'https://avatars.githubusercontent.com/Olivia-Chiong'
   - name: Muhi-Dean Othman
+    github-handle:
     role: Full-Stack Developer
     links:
       slack: 'https://hackforla.slack.com/team/U01F5K8DDPW'


### PR DESCRIPTION
Fixes #5507

### What changes did you make?
  - added github-handle: to Muhi-Dean's profile

### Why did you make the changes (we will use this info to test)?
  - to update Muhi-Dean's profile

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="1462" alt="Screenshot 2023-12-26 at 12 05 30 PM" src="https://github.com/hackforla/website/assets/119828225/cf677f4b-145c-48ce-9784-e2f7ef56df15">
<img width="629" alt="Screenshot 2023-12-26 at 12 06 07 PM" src="https://github.com/hackforla/website/assets/119828225/df5ab445-dea0-4afd-8b4d-9124379d51da">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1465" alt="Screenshot 2023-12-26 at 12 08 37 PM" src="https://github.com/hackforla/website/assets/119828225/90dbc561-5a79-4c86-a71c-6f7b75cdbbc5">
<img width="635" alt="Screenshot 2023-12-26 at 12 08 56 PM" src="https://github.com/hackforla/website/assets/119828225/cb69fcb4-ec42-4390-800e-b795529b0860">

</details>
