### PR TITLE
Removed Code for America alt text on sponsor icon in the about page

### DIFF
--- a/_includes/about-page/about-card-sponsors.html
+++ b/_includes/about-page/about-card-sponsors.html
@@ -1,7 +1,7 @@
 <div class="card-primary page-card-lg page-card--about">
     <div class="about-us-section-header" data-hash="sponsors"><span class="sec-head-img"><img
                 src="/assets/images/about/section-header-elements/sponsors.svg"
-                alt="Make your donation for Hack for LA Brigade on codeforamerica.org/donate. Choose the amount and select the payment frequency, then enter 'Hack for LA' under 'if your donation is for a Brigade, please select the Brigade Name(Optional)'."></span>Sponsors
+                alt=""></span>Sponsors
     </div>
     <div class="about-us-section-content">
         <div class="flex-container-row flex-container-row--partners">


### PR DESCRIPTION
Fixes #5963 

### What changes did you make?
  - Removed the alt text in the sponsor icon tag

### Why did you make the changes (we will use this info to test)?
  - To keep the about page up to date. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
Removed alt attribute to empty string. No visual changes to website. 
