### PR TITLE
updated wiki link for bop - #5972

### DIFF
--- a/_projects/brigade-organizers-playbook.md
+++ b/_projects/brigade-organizers-playbook.md
@@ -44,7 +44,7 @@ links:
   - name: Slack
     url: 'https://hackforla.slack.com/archives/C051M4JU562'
   - name: Wiki
-    url: 'https://github.com/codeforamerica/brigade-playbook/wiki'
+    url: 'https://github.com/hackforla/bop/wiki'
   - name: Effective Practices
     url: 'https://docs.google.com/spreadsheets/d/1N0VSDhYyy5WhX_z18Q0RvLlGO29JGGdMxVsD4X3nFYs/edit#gid=1425278717'
 looking:


### PR DESCRIPTION
Fixes #5972 

### What changes did you make?
 Changed the link of the wiki URL for Brigade Organizers Playbook.

### Why did you make the changes (we will use this info to test)?
Old code had codeforamerica in the link, the new one doesn't.  

No visual changes.