### PR TITLE
Updating Home Unite Us tools section

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -138,9 +138,9 @@ tools:
   - Zoom
   - GitHub
   - Google Drive
-  - Docs
-  - Sheets
-  - Slides
+  - Google Docs
+  - Google Sheets
+  - Google Slides
 partner: Safe Place for Youth (SPY), Point Source Youth (PSY)
 visible: true
 program-area:


### PR DESCRIPTION
Fixes #6019 

### What changes did you make?
  - Updated tools section on home-unite-us page. 

### Why did you make the changes (we will use this info to test)?
  - Tools on the "Home Unite Us" project page were missing the word "Google"


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" 
width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-01-05 at 12 06 50 AM](https://github.com/hackforla/website/assets/46732901/50c196b7-7a6b-4d16-afb6-9c47b11b5558)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-01-05 at 12 05 15 AM](https://github.com/hackforla/website/assets/46732901/f9eda65f-8ead-44d7-8317-aceeefc1229d)


</details>
