### PR TITLE
Removed Code for America from About Us Intro

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -10,9 +10,10 @@ permalink: /about/
         <p>We bring together civic-minded volunteers to build digital products,
             programs and services with community partners and local government to address issues in our LA region.
         </p>
-        <p class="sub-p">
-            Hack for LA is a project of <a class="header-link--about" href="https://www.codeforamerica.org/" target="_blank">Code for America</a> and its official Los Angeles chapter.
-        </p>
+              <p class="sub-p">
+                  Hack for LA is a project of <a class="header-link--about" href="https://www.civictechstructure.org/"
+                      target="_blank">Civic Tech Structure</a>.
+              </p>
     </div>
     <img class="header-hero-image"src="/assets/images/about/about-us-header.svg" alt="" />
 </div>

--- a/pages/about.html
+++ b/pages/about.html
@@ -10,10 +10,9 @@ permalink: /about/
         <p>We bring together civic-minded volunteers to build digital products,
             programs and services with community partners and local government to address issues in our LA region.
         </p>
-              <p class="sub-p">
-                  Hack for LA is a project of <a class="header-link--about" href="https://www.civictechstructure.org/"
-                      target="_blank">Civic Tech Structure</a>.
-              </p>
+        <p class="sub-p">
+            Hack for LA is a project of <a class="header-link--about" href="https://www.civictechstructure.org/" target="_blank">Civic Tech Structure</a>.
+        </p>
     </div>
     <img class="header-hero-image"src="/assets/images/about/about-us-header.svg" alt="" />
 </div>


### PR DESCRIPTION
Fixes #5959 

### What changes did you make?
  - Removed Code for America from About Us Intro

### Why did you make the changes (we will use this info to test)?
  - We need to replace the reference to 'Code for America' with 'Civic Tech Structure.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1440" alt="Screenshot 2024-01-05 at 15 41 02" src="https://github.com/hackforla/website/assets/25173636/d4e372a0-70ae-4824-bce4-f744992c54a6">


</details>

<details>
<summary>Visuals after changes are applied</summary>

  <img width="1440" alt="Screenshot 2024-01-05 at 15 38 59" src="https://github.com/hackforla/website/assets/25173636/91ee96ea-0b80-4b73-b1bc-94766ed36abd">


</details>
 
</details>
