### PR TITLE
Removed reference to CFA in Privacy Policy Intro

### DIFF
--- a/pages/privacy-policy.html
+++ b/pages/privacy-policy.html
@@ -12,7 +12,7 @@ permalink: /privacy-policy
       We respect your privacy, and recognize that we must maintain and use your information responsibly.
     </p>
     <p class="sub-p paragraph2 paragraph--privacy-policy">
-      HackforLA.org is an informational website managed by Hack for LA which is a project of Code for America Labs, Inc. ("Code for America", "we", "us", "our").
+      HackforLA.org is an informational website managed by Civic Tech Structure, Inc.
       This Privacy Policy describes how we collect, use, and protect your personal information on this website.
       By submitting your personal information on our websites, you agree to the terms in this Privacy Policy.
       If you do not agree with these terms, please do not use our websites.


### PR DESCRIPTION
Fixes #5958 

### What changes did you make?
  - Replaced CFA reference in privacy policy intro with reference to Civic Tech Structure, Inc.
  
### Why did you make the changes (we will use this info to test)?
  - HfLA is no longer part of CfA.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/34320199/f6582444-a18b-4360-83c5-878d3396d6ef)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/34320199/d1bb6d88-7a73-4890-be44-7cedb749a658)

</details>
