### PR TITLE
Replace Code for America link with Hack for LA link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ url: https://www.hackforla.org
 #    2. Collection — Will have its own page, URLs, and possibly an index page. [https://gist.github.com/akibrhast/31c7bb723d80e9efe3d28f619ef0798d]
 collections:
 # The redirection collection exist to allow us to type urls `hackforla.org/github` or hackforla.org/donate 
-# which then redirects to `github.com/hackforla/website` and `https://www.codeforamerica.org/donate` respecitively
+# which then redirects to `github.com/hackforla/website` and `https://www.hackforla/donate` respectively
   redirections:
     output: true
   projects:


### PR DESCRIPTION
Fixes #5965

### What changes did you make?
  -  replaced Code for America link with the Hack for LA link inside the `_config.yml` file
  -  corrected the spelling of the word `respectively`

### Why did you make the changes (we will use this info to test)?
  - to avoid confusion with other orgs

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Links inside the `_config.yml` comments were changed. No visual changes to the website.