### PR TITLE
Add size missing label gha 6022

### DIFF
--- a/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
@@ -1,6 +1,6 @@
 // Constant variables
 const REQUIRED_LABELS = ['Complexity', 'role', 'Feature']
-const LABEL_MISSING = ['Complexity: Missing', 'role missing', 'Feature Missing']
+const LABEL_MISSING = ['Complexity: Missing', 'role missing', 'Feature Missing', 'size: missing']
 const COMPLEXITY_EXCEPTIONS = ['good first issue']
 
 // SPECIAL_CASE is for issue created by reference with issue title "Hack for LA website bot" (from "Review Inactive Team Members")

--- a/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
@@ -1,5 +1,5 @@
 // Constant variables
-const REQUIRED_LABELS = ['Complexity', 'role', 'Feature']
+const REQUIRED_LABELS = ['Complexity', 'role', 'Feature', 'size']
 const LABEL_MISSING = ['Complexity: Missing', 'role missing', 'Feature Missing', 'size: missing']
 const COMPLEXITY_EXCEPTIONS = ['good first issue']
 

--- a/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
@@ -6,7 +6,8 @@ const formatComment = require('../../utils/format-comment')
 const LABELS_OBJ = {
   'Complexity: Missing': 'Complexity',
   'role missing': 'Role',
-  'Feature Missing': 'Feature'
+  'Feature Missing': 'Feature',
+  'size: missing': 'Size'
 }
 
 // Global variables


### PR DESCRIPTION
Fixes #6022

### What changes did you make?
  - Added "size" check to GHA's 

### Why did you make the changes (we will use this info to test)?
  - GHA does not check whether a newly created issue has a size label. We need to update this GHA so that the size: missing label is added to issues created without a size label.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals after changes are applied</summary>

![label_added](https://github.com/hackforla/website/assets/52722401/bee72d2e-8662-4893-b995-733006c347de)

</details>

Link to [test issue](https://github.com/djbradleyii/website/issues/3)
[Action log](https://github.com/djbradleyii/website/actions/runs/7466047911/job/20316540362#logs): It shows that it errors, but I can't understand why, but if you look at the "Check Labels" you will see the information needed.