### PR TITLE
Added code of conduct link to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
       <div class="header-links">
         <a href="/donate/" class="btn btn-primary-on-dark btn-md-narrow btn--donate-footer btn--default" title="Go to Donate Page">Donate</a>
         <div class="footer-links">
-          <div class="credits-page"><a href="/credits">Credits</a>&nbsp;|&nbsp;<a href="/sitemap">Site Map</a>&nbsp;|&nbsp;<a href="/privacy-policy">Privacy Policy</a>&nbsp;|&nbsp;<a href="/join">Join Us</a></div>
+          <div class="credits-page"><a href="/credits">Credits</a>&nbsp;|&nbsp;<a href="/sitemap">Site Map</a>&nbsp;|&nbsp;<a href="/privacy-policy">Privacy Policy</a>&nbsp;|&nbsp;<a href="/code-of-conduct">Code of Conduct</a>&nbsp;|&nbsp;<a href="/join">Join Us</a></div>
           <ul class="inline-list header-list">
             {% for item in site.data.navigation.social %} {% if item.footer %}
             <li>

--- a/redirections/conduct.md
+++ b/redirections/conduct.md
@@ -3,5 +3,5 @@
 layout: redirect
 title: Code of Conduct
 permalink: /conduct/
-redirect_to: https://github.com/hackforla/codeofconduct
+redirect_to: https://www.hackforla.org/code-of-conduct
 ---


### PR DESCRIPTION
Fixes #4251

### What changes did you make?
  - changed the value of redirect_to in /redirections/conduct.md to https://www.hackforla.org/code-of-conduct
  - added Code of Conduct link to footer in /_includes/footer.html in between the Privacy Policy and Join Us links

### Why did you make the changes (we will use this info to test)?
  - to allow the user to access the hfla code of conduct page from the website's footer

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](
https://github.com/hackforla/website/assets/121644228/ab81fdaf-0f15-47bc-9b58-1b439be8a8af
)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](
https://github.com/hackforla/website/assets/121644228/34c3d62e-c675-48f4-b385-81d50bd8a619
)

![image](
https://github.com/hackforla/website/assets/121644228/b8663443-f014-4afa-9abb-9ff7fd62f047
)

</details>
