### PR TITLE
Update Communities of Practice: Engineering - removed Alejandro Gomez #6074

### DIFF
--- a/_data/internal/communities/engineering.yml
+++ b/_data/internal/communities/engineering.yml
@@ -19,12 +19,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U04N8H0V72R
       github: https://github.com/MicahBear
     picture: https://avatars.githubusercontent.com/MicahBear
-  - name: Alejandro Gomez
-    role: Co-Lead
-    links:
-      slack: https://hackforla.slack.com/team/U04HFRQ5Y12
-      github: https://github.com/agosmou
-    picture: https://avatars.githubusercontent.com/agosmou
   - name: Zeke Arany-Lucas
     role: Co-Lead
     links:

--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -45,7 +45,7 @@ permalink: /communities-of-practice
                 <div class='leader-list--communities'>
                 {% for leader in community[1].leadership %}
                 <div class='leader-card--communities'>
-                    <a href='{{ leader.links.github }}' target='_blank' title='GitHub Profile'><img class='leader-img--communities' src='{{ leader.picture }}'/></a>
+                    <a href='{{ leader.links.github }}' target='_blank' title='GitHub Profile'><img class='leader-img--communities' src='{{ leader.picture }}' rel="noopener noreferrer"/></a>
                     <div class='leader-description'>
                         <p class='leader-description-field'><strong>Name: </strong>
                         {% if page.status == "Completed" and item.links.linkedin %}


### PR DESCRIPTION
Update Communities of Practice: Engineering - removed Alejandro Gomez

Fixes #6074 

### What changes did you make?
Removed following from _data/internal/communities/engineering.yml 
  - name: Alejandro Gomez
    role: Co-Lead
    links:
      slack: https://hackforla.slack.com/team/U04HFRQ5Y12
      github: https://github.com/agosmou
    picture: https://avatars.githubusercontent.com/agosmou

### Why did you make the changes (we will use this info to test)?
Excited for open source contribution

