### PR TITLE
Added github-handle variable to Salima Yacoubi

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -13,6 +13,7 @@ leadership:
       github: https://github.com/kcoronel
     picture: https://avatars.githubusercontent.com/kcoronel
   - name: Salima Yacoubi Soussane 
+    github-handle:
     role: Product Manager
     links:
       slack: https://hackforla.slack.com/team/U03HUJM7YCX


### PR DESCRIPTION
Fixes #5715 

### What changes did you make?
  - Added a variable called `github-handle` under Salima Yacoubi's record within the associated file.

### Why did you make the changes (we will use this info to test)?
  - "Eventually `github-handle` will replace the github and picture variables, reducing redundancy in the project file."
  
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No visual changes to the website.