### PR TITLE
Replace slack-self-invite.svg with icon-slack.svg on CoP page

### DIFF
--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -4,12 +4,15 @@
   max-width: 508px;
   margin-top: 31px;
 
-  .self-invite-img {
-    /*Note "margin-top: 15px" is needed to keep this img aligned with neighboring text*/
+  svg.icon {
+    path {
+      fill: #fa114f;
+    }
     margin-top: 15px;
     margin-right: 27px;
     width: 24px;
     height: 24px;
+    min-width: 24px;
   }
 
   .alert--communities {

--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -4,15 +4,14 @@
   max-width: 508px;
   margin-top: 31px;
 
-  svg.icon {
-    path {
-      fill: #fa114f;
-    }
-    margin-top: 15px;
-    margin-right: 27px;
-    width: 24px;
-    height: 24px;
-    min-width: 24px;
+  .self-invite-img {
+    color: #fa114f;
+    margin-top: 14px;
+    margin-right: 26px;
+    margin-left: -1px;
+    width: 26px;
+    height: 26px;
+    min-width: 26px;
   }
 
   .alert--communities {

--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -15,7 +15,7 @@ permalink: /communities-of-practice
             If you'd like to join one of the Communities of Practice that has a regular meeting time, join their Slack channel and look for the meeting details, usually pinned or in the description. Otherwise, see the "How to get started" sections below.
         </p>
             <div class="header-self-invite--communities">
-                <img class="self-invite-img" src="/assets/images/communities-of-practice/slack-self-invite.svg" alt="slack icon" />
+                {% include svg/icon-slack.svg %}
                 <p class="alert--communities">To join the Slack channels below, you first need to be a member of our Hack for LA Slack Community. If you have not joined yet, please follow the steps in <a href="/getting-started" target="_blank">Getting Started</a>.
             </p></div>
     </div>

--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -15,7 +15,9 @@ permalink: /communities-of-practice
             If you'd like to join one of the Communities of Practice that has a regular meeting time, join their Slack channel and look for the meeting details, usually pinned or in the description. Otherwise, see the "How to get started" sections below.
         </p>
             <div class="header-self-invite--communities">
-                {% include svg/icon-slack.svg %}
+                <svg version="1.1" class="self-invite-img" viewBox="0 0 90 90" xmlns="http://www.w3.org/2000/svg" width="100%">
+                    {% include svg/icon-slack.svg %}
+                </svg>
                 <p class="alert--communities">To join the Slack channels below, you first need to be a member of our Hack for LA Slack Community. If you have not joined yet, please follow the steps in <a href="/getting-started" target="_blank">Getting Started</a>.
             </p></div>
     </div>


### PR DESCRIPTION
Fixes #5827

### What changes did you make?
  - Replaced img tag for the Slack icon underneath the Communities of Practice header with a liquid image element referencing _includes/svg/icon-slack.svg
  - Modified CSS to maintain current appearance of page

### Why did you make the changes (we will use this info to test)?
  - To make sure that only a single slack icon svg is used in the codebase
  - Make it easier to render the svg in various colors throughout the website

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-01-21 at 23-05-11 Communities of Practice by Hack for LA](https://github.com/hackforla/website/assets/15069166/a19b9f59-db50-4296-b55c-129bafca1a4f)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-01-21 at 23-18-41 Communities of Practice by Hack for LA](https://github.com/hackforla/website/assets/15069166/67774761-ef10-4bea-9210-41fd85ea3eb8)

</details>
