### PR TITLE
Updated code behind Events page

### DIFF
--- a/assets/js/utility/api-events.js
+++ b/assets/js/utility/api-events.js
@@ -147,7 +147,7 @@ function convertTime12to24(time12h) {
  * Function that represent the individual object extracted from the api
  */
 function display_object(item) {
-  if (item && item.project) { 
+  if (item?.project?.name !== "Hack4LA" && item?.project?.name !== "test") { 
     const rv_object = {
       meetingName: item.name,
       name: item.project.name,


### PR DESCRIPTION
Fixes #6082 

### What changes did you make?
  - The change has been made in the event page to no longer display Hack4LA and test events.
 

### Why did you make the changes (we will use this info to test)?
  - The changes were made because those events do not represent regular project meetings.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot-2024-01-23-at-145605](https://github.com/hackforla/website/assets/25173636/c49627cb-53f2-493c-bef5-8b5b6e67a7ec)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot-2024-01-23-at-145504](https://github.com/hackforla/website/assets/25173636/6b3656dc-c963-40f7-8b79-81d9abf234d7)

</details>
