### PR TITLE
Implemented SRI check on the external babel links

### DIFF
--- a/_layouts/default-markdown.html
+++ b/_layouts/default-markdown.html
@@ -12,7 +12,9 @@
         {{ content | markdownify }}
     </main>
     {%- include footer.html -%}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.js"
+      integrity="sha384-5eDs4qg7Mm6lRIqLmB5k7P/GV+iEWdlzONR7lOdXJ/hquF3S4n4Z2u0rbhx8OYXs" crossorigin="anonymous">
+    </script>
     <script src="{{ '/assets/js/api-actionnetwork.js' | absolute_url }}"></script>
   </div>
 </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,9 @@
       {{ content }}
     </main>
     {%- include footer.html -%}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.js"
+     integrity="sha384-5eDs4qg7Mm6lRIqLmB5k7P/GV+iEWdlzONR7lOdXJ/hquF3S4n4Z2u0rbhx8OYXs" crossorigin="anonymous">
+   </script>
     <script src="{{ '/assets/js/api-actionnetwork.js' | absolute_url }}"></script>
   </div>
 </body>


### PR DESCRIPTION
Fixes #6120 

### What changes did you make?
  - The script tag in the `default-markdown.html` and `default.html` files was updated with integrity and crossorigin attributes.

### Why did you make the changes (we will use this info to test)?
  - The changes were made to address CodeQL alerts 36 and 37, which will enhance the script integrity and mitigate potential vulnerabilities.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1440" alt="Screenshot 2024-01-24 at 18 23 30" src="https://github.com/hackforla/website/assets/25173636/97ff4434-678f-4ba6-8c1b-c46e1173dd87">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1440" alt="Screenshot 2024-01-24 at 18 17 05" src="https://github.com/hackforla/website/assets/25173636/c33d2ffc-b15a-4dc6-8fa9-17651de891b2">
<img width="1440" alt="Screenshot 2024-01-24 at 18 17 57" src="https://github.com/hackforla/website/assets/25173636/8793f96f-5361-4c7c-9c30-491838100453">
<img width="1440" alt="Screenshot 2024-01-24 at 18 18 25" src="https://github.com/hackforla/website/assets/25173636/b68142d1-a1de-4e9e-9eaa-61fa0976b4af">
<img width="1440" alt="Screenshot 2024-01-24 at 18 18 46" src="https://github.com/hackforla/website/assets/25173636/8a84fc37-9b6c-4d2c-ad29-e4beb710a22b">


</details>
