### PR TITLE
Update code events page 

### DIFF
--- a/assets/js/utility/api-events.js
+++ b/assets/js/utility/api-events.js
@@ -147,7 +147,7 @@ function convertTime12to24(time12h) {
  * Function that represent the individual object extracted from the api
  */
 function display_object(item) {
-  if (item && item.project.name && (item.project.name !== "Hack4LA" && item.project.name !== "test")) { 
+  if (item?.project?.name !== "Hack4LA" && item?.project?.name !== "test") { 
     const rv_object = {
       meetingName: item.name,
       name: item.project.name,

--- a/assets/js/utility/api-events.js
+++ b/assets/js/utility/api-events.js
@@ -147,7 +147,7 @@ function convertTime12to24(time12h) {
  * Function that represent the individual object extracted from the api
  */
 function display_object(item) {
-  if (item?.project?.name !== "Hack4LA" && item?.project?.name !== "test") { 
+  if (item?.project?.name !== "Hack4LA" && !/^Test\b/i.test(item?.project?.name)) { 
     const rv_object = {
       meetingName: item.name,
       name: item.project.name,

--- a/assets/js/utility/api-events.js
+++ b/assets/js/utility/api-events.js
@@ -147,7 +147,7 @@ function convertTime12to24(time12h) {
  * Function that represent the individual object extracted from the api
  */
 function display_object(item) {
-  if (item && item.project) { 
+  if (item && item.project.name && (item.project.name !== "Hack4LA" && item.project.name !== "test")) { 
     const rv_object = {
       meetingName: item.name,
       name: item.project.name,
@@ -155,7 +155,7 @@ function display_object(item) {
       start: localeTimeIn12Format(item.startTime),
       end: localeTimeIn12Format(item.endTime),
       hflaWebsiteUrl: item.project.hflaWebsiteUrl,
-	  githubUrl: item.project.githubUrl,
+	    githubUrl: item.project.githubUrl,
 	  };
 	  return rv_object;
   }


### PR DESCRIPTION
Fixes #6082 

### What changes did you make?
  - Updated the display_object function's if condition to exclude Hack4LA and test objects.

### Why did you make the changes (we will use this info to test)?
  - To prevent any events with the "Hack4LA" and "test" title from showing up on the events page.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before 1](https://github.com/hackforla/website/assets/74325966/5fc85169-a7f1-4643-b7cd-c016a3f34d0d)


![before 2](https://github.com/hackforla/website/assets/74325966/06eba029-58e9-439d-b645-140fec2c82be)

![before 3](https://github.com/hackforla/website/assets/74325966/c231fd42-7dce-4fc1-b8a5-ef23b45ffd89)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

![after 1](https://github.com/hackforla/website/assets/74325966/d2620e55-fcce-4c82-b7d6-7fbb4b6a8752)
![after 2](https://github.com/hackforla/website/assets/74325966/61d7de2f-9861-47f4-8565-fb294e55a667)

![after 3](https://github.com/hackforla/website/assets/74325966/85cd2cbb-c4e1-42b9-b0c3-f477569f226a)

</details>
