### PR TITLE
Add Heejung Hong to CoP Engineering on HfLA website

### DIFF
--- a/_data/internal/communities/engineering.yml
+++ b/_data/internal/communities/engineering.yml
@@ -31,6 +31,12 @@ leadership:
       slack: https://hackforla.slack.com/team/U01J93AQKSS
       github: https://github.com/chelseybeck
     picture: https://avatars.githubusercontent.com/chelseybeck
+  - name: Heejung Hong
+    role: Co-lead
+    links:
+      slack: https://hackforla.slack.com/team/U064M7X48SY
+      github: https://github.com/heejung-hong
+    picture: https://avatars.githubusercontent.com/heejung-hong
 
 links:
   - name: Slack


### PR DESCRIPTION
Fixes #6189 

### What changes did you make?
* Added Heejung Hong's details to _data/internal/communities/engineering.yml as specified in issue

### Why did you make the changes (we will use this info to test)?
* To keep list of Engineering CoP leadership team on HfLA website up to date

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/106627338/b6c853f5-59fd-4580-8e1a-c4d0a2172626)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](https://github.com/hackforla/website/assets/106627338/392ded5e-8c1d-4b35-84ae-313bc50cc515)

</details>
