### PR TITLE
Remove Josiah Odosu from project leadership section

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -12,12 +12,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/UE1UG1YFP'
       github: 'https://github.com/ExperimentsInHonesty'
     picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
-  - name: Josiah Odosu
-    role: Product Team
-    links:
-      slack: https://hackforla.slack.com/team/U052L9U44LB
-      github: https://github.com/Josiah-O
-    picture: https://avatars.githubusercontent.com/Josiah-O    
   - name: Anjola Jaiyeola
     role: Product Team
     links:


### PR DESCRIPTION
Fixes #6165 

### What changes did you make?
- Updated the website's project leadership section by removing Josiah Odosu's details.

### Why did you make the changes (we will use this info to test)?
- This change keeps the site's information accurate and up-to-date.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->


<details>
<summary>Visuals before changes are applied</summary>

<img width="1728" alt="image" src="https://github.com/hackforla/website/assets/76270077/1edbf6d0-b0f2-4d51-976e-85d468d82037">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1728" alt="image" src="https://github.com/hackforla/website/assets/76270077/14e729e7-18ce-4ac5-8c45-b4a03157af02">

</details>
