### PR TITLE
Updated wins app script to add spacing and line breaks to wins json feed

### DIFF
--- a/google-apps-scripts/wins-form-responses/Code.js
+++ b/google-apps-scripts/wins-form-responses/Code.js
@@ -65,7 +65,7 @@ function main() {
   */
 
   // Create an array of objects (key-value pair) for _wins-data.json
-  const cleanedAndFormattedKeyValueData = JSON.stringify(sortedKeyValueData);
+  const cleanedAndFormattedKeyValueData = JSON.stringify(sortedKeyValueData, null, 5);
   const encodedKeyValueData = Utilities.base64Encode(`${cleanedAndFormattedKeyValueData}`, Utilities.Charset.UTF_8);
 
     // Retrieves latest sha of the _wins data file, which is needed for edits later
@@ -89,7 +89,7 @@ function main() {
   */
 
   // Create an array of data for wins-data.json
-  const cleanedAndFormattedArrayData = JSON.stringify(filteredRows, null, 5);
+  const cleanedAndFormattedArrayData = JSON.stringify(filteredRows);
   // const encodedArrayData = Utilities.base64Encode(`${cleanedAndFormattedArrayData}`);
   const encodedArrayData = Utilities.base64Encode(cleanedAndFormattedArrayData, Utilities.Charset.UTF_8); 
 

--- a/google-apps-scripts/wins-form-responses/Code.js
+++ b/google-apps-scripts/wins-form-responses/Code.js
@@ -89,7 +89,7 @@ function main() {
   */
 
   // Create an array of data for wins-data.json
-  const cleanedAndFormattedArrayData = JSON.stringify(filteredRows);
+  const cleanedAndFormattedArrayData = JSON.stringify(filteredRows, null, 5);
   // const encodedArrayData = Utilities.base64Encode(`${cleanedAndFormattedArrayData}`);
   const encodedArrayData = Utilities.base64Encode(cleanedAndFormattedArrayData, Utilities.Charset.UTF_8); 
 


### PR DESCRIPTION
…etween items and line breaks inbetwen arrays

Fixes #4035 

### What changes did you make?
  - Added a spacer parameter to JSON.stringify() on line 68


### Why did you make the changes (we will use this info to test)?
  - Adds line breaks in between arrays and indentation for array elements in the _wins-data.json.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
There were no visual changes to the website
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>JSON before changes are applied</summary>

![image](
https://github.com/hackforla/website/assets/121644228/3d25c501-9373-46f0-895e-a516312cf0ff
)

</details>

<details>
<summary>JSON after changes are applied</summary>
  
![image](
https://github.com/hackforla/website/assets/121644228/b4223dba-f50f-4236-9eaf-c25f3186a837

)

</details>

Link to "Update wins-data.json via Google Apps Script" PR: https://github.com/Jung-GunSong/website/pull/5

