### PR TITLE
add github-handle to member Tan Zhou

### DIFF
--- a/_projects/civic-opportunity-project.md
+++ b/_projects/civic-opportunity-project.md
@@ -13,6 +13,7 @@ leadership:
       github: 'https://github.com/rfambro2'
     picture: https://avatars.githubusercontent.com/rfambro2
   - name: Tan Zhou
+    github-handle: 
     role: UX Research Lead
     links:
       slack: 'https://hackforla.slack.com/team/UPMSC27G8'


### PR DESCRIPTION
Fixes #6192

### What changes did you make?
  - add GitHub-handle variable for member Tan Zhou
  - made chage in civic-opportunity-project.md
  -

### Why did you make the changes (we will use this info to test)?
  -  creating a single variable github-handle to hold the GitHub handle for each member of the leadership team.
  -  Eventually, github-handle will replace the GitHub and picture variables, reducing redundancy in the project file.
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->



No visual changes to the website.