### PR TITLE
Add ignoreWords array to cspell.jon

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -10,6 +10,9 @@
       "Collabathon",
       "Undebate"
   ],
+  "ignoreWords": [
+      "Harish"
+  ],
   "ignorePaths": [
       "node_modules",
       ".github",


### PR DESCRIPTION
Fixes #5676 

### What changes did you make?
* Added ignoreWords array containing "Harish" to cspell.json as specified in issue

### Why did you make the changes (we will use this info to test)?
* To stop Code Spell Checker (VS Code extension) from marking "Harish" as an "unknown word" within the IDE.
* To easily add other names, words, etc. in the future experiencing similar problems to ignoreWords array

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Below are screenshots showing the change in the IDE (not the code I that changed).

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/106627338/ebc2db8a-49cd-4ba8-bd84-490bda23b26d)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](https://github.com/hackforla/website/assets/106627338/fd665815-69f1-4977-9b58-a3fb130d6ff8)

</details>
