### PR TITLE
fix misspelling from direclty to directly

### DIFF
--- a/_guide-pages/survey-reporting-dashboard-guide.html
+++ b/_guide-pages/survey-reporting-dashboard-guide.html
@@ -121,7 +121,7 @@ resource-url-depreciated:
     <img class="title-new-columns" src="../assets/images/guides/survey-reporting/dashboard-6.png">
     <h4 class="title-section add-margin-top-to-header">TRANSPOSE ROW DATA</h4>
     <p class="after-paragraph-margin">
-      To create a chart, whether direclty in Google Sheets, or by using a data visualization tool like Google Data Studio, we must have a 1:1 relationship between the data in a particular cell and its dimension (column name). By default, survey questions of the “check all that apply” variety produce data arrays that violate this principle. 
+      To create a chart, whether directly in Google Sheets, or by using a data visualization tool like Google Data Studio, we must have a 1:1 relationship between the data in a particular cell and its dimension (column name). By default, survey questions of the “check all that apply” variety produce data arrays that violate this principle. 
       <br><br>
       We use the TRANSPOSE() function with the SPLIT() and JOIN() functions to achieve this outcome. In our example, we enter the formula =TRANSPOSE((SPLIT(JOIN(“,”, G2:G995), “,”))) in cell H2. 
       <br><br>


### PR DESCRIPTION
Fixes #6233

### What changes did you make?
  - correct misspelling word in _guide-pages/survey-reporting-dashboard-guide.html
  - from "To create a chart, whether direclty in Google Sheets"
  - to "To create a chart, whether directly in Google Sheets"
  

### Why did you make the changes (we will use this info to test)?
  - because the word "directly" was misspelled


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

[image](https://ibb.co/8Xq9mVD)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
[image](https://ibb.co/pw5Bxjk)

</details>
