### PR TITLE
Update Language Merging to Support Projects with Multiple Additional Repositories

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -197,7 +197,7 @@ layout: default
         src="/assets/js/project.js"
         type="module"
         projectId="{{ page.identification }}"
-        additionalRepoIdNums="{{ page.additional-repo-ids }}"
+        additionalRepoIdNums="{{ page.additional-repo-ids | join: ',' }}"
         imageHero="{{ page.image-hero }}"
         projectTitle="{{ page.title }}">
 </script>

--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -1,7 +1,8 @@
 ---
 # 'identification' is the 9 digit ID for your repo in the GitHub API.
 identification: '241519642'
-additional-repo-ids: '275296439'
+additional-repo-ids:
+  - 275296439
 title: Civic Tech Index
 description: Our goal of the project is to create a comprehensive, searchable index of all civic tech open source software projects around the world. We have created the framework and an interest list. We are currently working on building out the website and other marketing tools that demonstrate the power of the index.
 image: /assets/images/projects/civic-tech-index.png

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -90,7 +90,7 @@ document.addEventListener("DOMContentLoaded",function(){
  * Retrieves project data from jekyll _projects collection using liquid and transforms it into a javascript object
  * The function returns a javascript array of objects representing all the projects under the _projects directory
 */
-function retrieveProjectDataFromCollection(){
+function retrieveProjectDataFromCollection() {
     // { "project": {"id":"/projects/311-data","relative_path":"_projects/311-data.md","excerpt"
     {% assign projects = site.data.external.github-data %}
     {% assign visible_projects = site.projects | where: "visible", "true" %}
@@ -98,73 +98,94 @@ function retrieveProjectDataFromCollection(){
     // const scriptTag = document.getElementById("projectScript");
     // const projectId = scriptTag.getAttribute("projectId");
     // Search for correct project
-    let projectLanguagesArr = [];
-    projects.forEach(project=> {
-        if(project.languages){
+    let projectLanguagesArray = [];
+    projects.forEach(project => {
+        if (project.languages) {
             const projectLanguages = {
                 id: project.id,
                 languages: project.languages
             };
-            projectLanguagesArr.push(projectLanguages);
+            projectLanguagesArray.push(projectLanguages);
         }
-    })
+    });
 
-    let projectData = [{%- for project in visible_projects -%}
+    // Construct project data objects for visible projects, 
+    // including dynamic properties like additional repositories.
+    let projectData = [
+        {%- for project in visible_projects -%}
             {
                 "project": {
-                            'id': "{{project.id | default: 0}}",
-                            'identification': {{project.identification | default: 0}},
-                            'additionalRepoIds': {{project.additional-repo-ids | default: 0}},
-                            "status": "{{ project.status }}"
-                            {%- if project.image -%},
-                            "image": '{{ project.image }}'
-                            {%- endif -%}
-                            {%- if project.alt -%},
-                            "alt": `{{ project.alt }}`
-                            {%- endif -%}
-                            {%- if project.title -%},
-                            "title": `{{ project.title }}`
-                            {%- endif -%}
-                            {%- if project.description -%},
-                            "description": `{{ project.description }}`
-                            {%- endif -%}
-                            {%- if project.partner -%},
-                            "partner": `{{ project.partner }}`
-                            {%- endif -%}
-                            {%- if project.tools -%},
-                            "tools": {{ project.tools | jsonify }}
-                            {%- endif -%}
-                            {%- if project.looking -%},
-                            "looking": {{ project.looking | jsonify }}
-                            {%- endif -%}
-                            {%- if project.links -%},
-                            "links": {{ project.links | jsonify }}
-                            {%- endif -%}
-                            {%- if project.technologies -%},
-                            "technologies": {{ project.technologies | jsonify }}
-                            {%- endif -%}
-                            {%- if project.program-area -%},
-                            "programAreas": {{ project.program-area | jsonify }}
-                            {%- endif -%}
-                            {%- if project.languages -%},
-                            "languages": {{ project.languages }}
-                            {%- endif -%}
-                            }
-            }{%- unless forloop.last -%}, {% endunless %}
-    {%- endfor -%}]
-    projectData.forEach((data,i) => {
+                    "id": `{{project.id | default: 0}}`,
+                    "identification": {{ project.identification | default: 0 }},
+                    {%- if project.additional-repo-ids -%}
+                    "additionalRepoIds": [{{ project.additional-repo-ids | join: ',' }}],
+                    {% endif %}
+                    "status": `{{ project.status }}`,
+                    {%- if project.image -%}
+                    "image": `{{ project.image }}`,
+                    {%- endif -%}
+                    {%- if project.alt -%}
+                    "alt": `{{ project.alt }}`,
+                    {%- endif -%}
+                    {%- if project.title -%}
+                    "title": `{{ project.title }}`,
+                    {%- endif -%}
+                    {%- if project.description -%}
+                    "description": `{{ project.description }}`,
+                    {%- endif -%}
+                    {%- if project.partner -%}
+                    "partner": `{{ project.partner }}`,
+                    {%- endif -%}
+                    {%- if project.tools -%}
+                    "tools": {{ project.tools | jsonify }},
+                    {%- endif -%}
+                    {%- if project.looking -%}
+                    "looking": {{ project.looking | jsonify }},
+                    {%- endif -%}
+                    {%- if project.links -%}
+                    "links": {{ project.links | jsonify }},
+                    {%- endif -%}
+                    {%- if project.technologies -%}
+                    "technologies": {{ project.technologies | jsonify }},
+                    {%- endif -%}
+                    {%- if project.program-area -%}
+                    "programAreas": {{ project.program-area | jsonify }},
+                    {%- endif -%}
+                    {%- if project.languages -%}
+                    "languages": {{ project.languages }}
+                    {%- endif -%}
+                }
+            }
+            {%- unless forloop.last -%},{% endunless %}
+        {%- endfor -%}
+    ];
+
+    projectData.forEach((data, i) => {
         const { project } = data;
-        const matchingProject = projectLanguagesArr.find(x=> x.id === project.identification);
-        if(matchingProject) {
+        const matchingProject = projectLanguagesArray.find(repo => repo.id === project.identification);
+
+        if (matchingProject) {
             project.languages = matchingProject.languages;
-            if(project.additionalRepoIds != 0){
-                const additionalMatchingProject = projectLanguagesArr.find(x=> x.id === project.additionalRepoIds);
-                const langArr = [...matchingProject.languages, ...additionalMatchingProject.languages];
-                let set = new Set(langArr);
-                project.languages = Array.from(set);
+            
+            // Merge languages from additional GitHub repositories to ensure  
+            // a comprehensive list of languages used on a single project.
+            if (project.additionalRepoIds) {
+                const additionalRepoIdNums = project.additionalRepoIds;
+                let languagesArray = [...project.languages];
+
+                additionalRepoIdNums.forEach(repoId => {
+                    const additionalRepo = projectLanguagesArray.find(repo => repo.id === repoId);
+                    if (additionalRepo && additionalRepo.languages) {
+                        languagesArray = [...languagesArray, ...additionalRepo.languages];                
+                    }
+                });
+
+                let uniqueLanguages = new Set(languagesArray);
+                project.languages = Array.from(uniqueLanguages);
             }
         }
-    })
+    });
+
     return projectData;
 }
 

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -26,16 +26,22 @@ function findProjectById(identification){
     }
 } 
 
-// Merge the language sections if there's a second repo
-if (scriptTag.getAttribute("additionalRepoIdNums")){
-    const additionalRepoIdNums = scriptTag.getAttribute("additionalRepoIdNums");    
-    const firstLangs = project.languages;
-    const additionalLangs = findProjectById(additionalRepoIdNums).languages;
-
-    let languagesArr = [...firstLangs, ...additionalLangs];
-    let set = new Set(languagesArr);
-    project.languages = Array.from(set);
+// Merge language lists from multiple GitHub repositories associated with a single project
+if (scriptTag.getAttribute('additionalRepoIdNums')) {
+    const additionalRepoIdNums = scriptTag.getAttribute('additionalRepoIdNums').split(',');    
+    let languagesArray = [...project.languages];
+    
+    additionalRepoIdNums.forEach(repoId => {
+        const additionalRepo = findProjectById(repoId);
+        if (additionalRepo && additionalRepo.languages) {
+            languagesArray = [...languagesArray, ...additionalRepo.languages];
+        }
+    });
+ 
+    let uniqueLanguages = new Set(languagesArray);
+    project.languages = Array.from(uniqueLanguages);
 }
+
 /*
   Assign hero background image
 */


### PR DESCRIPTION
Fixes #5160

### What changes did you make?

- _projects/civic-tech-index.md:
  - Updated `additional-repo-ids` format to enable support for multiple additional repositories.
&nbsp;
- _layouts/project.html:
  - Applied  Liquid's `join` filter to convert multiple additional repository IDs from a project's Markdown file into a comma-separated string.
&nbsp;
- assets/js/projects.js:
  - Modified JavaScript logic to enhance the merging of languages from multiple repos associated with a project.
&nbsp;
- assets/js/current-projects.js:
  - Updated JavaScript logic in the `retrieveProjectDataFromCollection` function to merge languages from multiple repos associated with a project more efficiently.
  - Refined code formatting within this function for better readability, maintainability, and consistency.

### Why did you make the changes (we will use this info to test)?
  - These changes upgrade the existing language display feature to accommodate projects with more than two additional repository IDs in the Markdown file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes to the website.