### PR TITLE
Update SSH key setup instructions for Windows users. Addresses #6187

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -769,7 +769,7 @@ pbcopy < ~/.ssh/id_ed25519.pub
 
 ##### **ii. Setting up SSH Keys for Windows**
 
-1. You have to set up SSH keys in order to contribute to github remotely. First check if you have any keys set up already.
+1. You have to set up SSH keys in order to contribute to github remotely. First check if you have any keys set up already. Open Git Bash and run:
 
 ```bash
 ls -al ~/.ssh


### PR DESCRIPTION
Fixes #6187 

### What changes did you make?
  - Replaced:
```
1. You have to set up SSH keys in order to contribute to github remotely. First check if you have any keys set up already.
```

  - With: 
``` 
1. You have to set up SSH keys in order to contribute to github remotely. First check if you have any keys set up already. Open Git Bash and run:
```

### Why did you make the changes (we will use this info to test)?
  - Clarify the process of checking existing SSH keys on Windows by specifying the use of Git Bash. This ensures new contributors can accurately verify their SSH key setup before contributing, reducing setup confusion and potential errors.
  - For Reviewers: Do not review changes locally, rather, review changes at:
 `https://github.com/[REPLACE WITH GITHUB HANDLE]/website/blob/[REPLACE WITH NAME OF ISSUE BRANCH]/CONTRIBUTING.md`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/76270077/4ddb92ae-80d4-4805-9adc-5d616f30d4ac)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/76270077/7de1eff6-d879-4cb6-9e05-c0a6f420942d)

</details>
