### PR TITLE
make civic tech structure org title consistent

### DIFF
--- a/_includes/donation/donate-gif-text.html
+++ b/_includes/donation/donate-gif-text.html
@@ -1,9 +1,9 @@
 <div class="donation-grid">
   <div class="donation-body">
-    <p>Hack for LA takes donations through Civic Tech Structure.</p>
+    <p>Hack for LA takes donations through Civic Tech Structure, Inc. a non profit 501(c)(3).</p>
     <ol>
       <li>
-        Please follow this link to the Civic Tech Structure Stripe
+        Please follow this link to the Civic Tech Structure, Inc. a non profit 501(c)(3) Stripe
         <a href="https://donate.stripe.com/bIY9Cpcg8dihfIc5kl" target="_blank" rel="noopener noreferrer">donation form.</a>
       </li>
     </ol>

--- a/_includes/events-page/header-container-content.html
+++ b/_includes/events-page/header-container-content.html
@@ -3,8 +3,7 @@
     <div class="header-text-margin--events">
       <h1 class="title1">Events</h1>
       <h2 class="header-desc">
-        Hack for LA was incubated in the Code for America Brigade Network and continues the valuable work under Civic Tech Structure, 
-        Inc. a network of civic-minded technologists who contribute their skills toward using the web as a platform for local government 
+        Hack for LA was incubated in the Code for America Brigade Network and continues the valuable work under Civic Tech Structure, Inc. a non profit 501(c)(3), a network of civic-minded technologists who contribute their skills toward using the web as a platform for local government 
         and community service.
       </h2>
       <!--This is hidden when full screen and shown when mobile and tablet-->

--- a/pages/about.html
+++ b/pages/about.html
@@ -11,7 +11,7 @@ permalink: /about/
             programs and services with community partners and local government to address issues in our LA region.
         </p>
         <p class="sub-p">
-            Hack for LA is a project of <a class="header-link--about" href="https://www.civictechstructure.org/" target="_blank">Civic Tech Structure</a>.
+            Hack for LA is a project of <a class="header-link--about" href="https://www.civictechstructure.org/" target="_blank">Civic Tech Structure, Inc. a non profit 501(c)(3)</a>.
         </p>
     </div>
     <img class="header-hero-image"src="/assets/images/about/about-us-header.svg" alt="" />

--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -17,7 +17,7 @@ permalink: /join
         practices, and code with the larger civic tech community.
       </p>
       <p class="sub-p">
-        Hack for LA is a project of <strong>Civic Tech Structure, Inc.</strong>
+        Hack for LA is a project of <strong>Civic Tech Structure, Inc. a non profit 501(c)(3).</strong>
       </p>
     </div>
     <img class="header-hero-image" src="/assets/images/join-us/banner-icon.svg" alt="">


### PR DESCRIPTION
Fixes #6140

### What changes did you make?
  - change different variations of "Civic Tech Structure" on different pages(Donate, About, Join, Events) to " Civic Tech Structure, Inc. a non profit 501(c)(3)"


### Why did you make the changes (we will use this info to test)?
  - to make the org title to be consistent across all pages.





### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
![AboutBefore](https://github.com/hackforla/website/assets/26665132/18f2abe7-2db5-4efd-baf4-ab80da786e5e)
![DonateBefore](https://github.com/hackforla/website/assets/26665132/d6175c20-d28e-4225-b1fc-8b226e682245)
![EventsBerfore](https://github.com/hackforla/website/assets/26665132/8f6a272c-97b4-4a90-925a-d8c5479e2b27)
![JoinBefore](https://github.com/hackforla/website/assets/26665132/408e4a9c-34bd-41c8-acb4-e408f3a3f69b)
</details>

<details>
<summary>Visuals after changes are applied</summary>
![AboutAfter](https://github.com/hackforla/website/assets/26665132/3355ff6e-b92f-4902-aa14-15aef1584716)
![DonateAfter](https://github.com/hackforla/website/assets/26665132/bce05b23-0ad4-42bb-aa11-5db12cb72f94)
![EventsAfter](https://github.com/hackforla/website/assets/26665132/c365270a-86a1-4723-958c-ab1463b6a133)
![JoinAfter](https://github.com/hackforla/website/assets/26665132/45b67e58-5a9c-412b-b28b-cda1481e31f6)


</details>
