### PR TITLE
Added _sass/ to cspell.json ignorePaths array

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,7 @@
       "node_modules",
       ".github",
       "test/",
-      "docker-compose.yml"
+      "docker-compose.yml",
+      "_sass/"
   ]
 }


### PR DESCRIPTION
Fixes #5841

### What changes did you make?
  - Added "_sass/" to the cspell.json ignorePaths array 

### Why did you make the changes (we will use this info to test)?
  - To prevent files under the "_sass/" folder from being spell checked

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Added "_sass/" to the cspell.json ignorePaths array. No visual changes to website
