### PR TITLE
fix: added Ruby and Svelte to project technologies

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -209,7 +209,20 @@ function createFilter(sortedProjectData){
             // 'looking': [ ... new Set( (sortedProjectData.map(item => item.project.looking ? item.project.looking.map(item => item.category) : '')).flat() ) ].filter(v=>v!='').sort(),
             // ^ See issue #1997 for more info on why this is commented out
             'programs': [...new Set(sortedProjectData.map(item => item.project.programAreas ? item.project.programAreas.map(programArea => programArea) : '').flat() ) ].filter(v=>v!='').sort(),
-            'technologies': [...new Set(sortedProjectData.map(item => (item.project.technologies && item.project.languages?.length > 0) ? [item.project.languages, item.project.technologies].flat() : '').flat() ) ].filter(v=>v!='').sort(),
+            'technologies': [
+                ...new Set(
+                    sortedProjectData.map(item => {
+                        let combined = [];
+                        if (item.project.languages?.length > 0) {
+                            combined = combined.concat(item.project.languages);
+                        }
+                        if (item.project.technologies?.length > 0) {
+                            combined = combined.concat(item.project.technologies);
+                        }
+                        return combined;
+                    }).flat()
+                )
+            ].filter(v => v).sort(),
             'status': [... new Set(sortedProjectData.map(item => item.project.status))].sort()
         }        
     }


### PR DESCRIPTION
Fixes #6274

### What changes did you make?
  - Combined technologies and languages before filtering

### Why did you make the changes (we will use this info to test)?
  - To ensure that the technologies are filtered correctly.
  - There was problem with the previous filtering that excluded Ruby and Svelte