### PR TITLE
Replace {{ project.alt }} with an empty string on current-projects.js

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -120,7 +120,7 @@ function retrieveProjectDataFromCollection(){
                             "image": '{{ project.image }}'
                             {%- endif -%}
                             {%- if project.alt -%},
-                            "alt": `{{ project.alt }}`
+                            "alt": ""
                             {%- endif -%}
                             {%- if project.title -%},
                             "title": `{{ project.title }}`


### PR DESCRIPTION
Fixes #3861

### What changes did you make?
  - Replaced {{ project.alt }} with an empty string on current-projects.js
  - NOTE: In my code, the only instance of {{ project.alt }} on current-projects.js was on line 123, while the ticket specified line 89. Since there was only one instance on the page, I went ahead with the changes. 

### Why did you make the changes (we will use this info to test)?
  - To adhere to WCAG

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

- No visual changes to the website.
- alt="" in code appears as alt when using developer tools to inspect the image's alt text property.
