### PR TITLE
Added in Closing Span Tag on the About Us Page - Workforce Development Section

### DIFF
--- a/_includes/about-page/about-card-platform.html
+++ b/_includes/about-page/about-card-platform.html
@@ -4,7 +4,7 @@
     </div>
     <div class="about-us-section-content">
         <div class="sub-card">
-            <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/workforce-development.svg" alt=""></span><span class="sub-head-text color-dodgerblue">Workforce Development</div>
+            <div class="sub-card-head"><span class="sub-head-image"><img src="/assets/images/about/platform-header-elements/workforce-development.svg" alt=""></span><span class="sub-head-text color-dodgerblue">Workforce Development</span></div>
             <p class="sub-card-content border-dodgerblue">
                 Enlightened self-interest is a powerful motivator. Our members have access to mentorship,
                 one-on-one help with job searches, and resume coaching. We do project matching to fit skill


### PR DESCRIPTION
Fixes #5365

### What changes did you make?
  - Added in a Closing span tag on the About Us Page in the Workforce Development Section
  - Compared Docker local host to the existing website, and visually the section has not changed.

### Why did you make the changes (we will use this info to test)?
  - This was added in to resolve a linter error

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
 - No visible changes made to page
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing ### 
Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Moving files to another directory. No visual changes to the website.
