### PR TITLE
Replace {{ project.alt }} with single quotes

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -125,7 +125,7 @@ function retrieveProjectDataFromCollection() {
                     "image": `{{ project.image }}`,
                     {%- endif -%}
                     {%- if project.alt -%}
-                    "alt": `{{ project.alt }}`,
+                    "alt": "",
                     {%- endif -%}
                     {%- if project.title -%}
                     "title": `{{ project.title }}`,


### PR DESCRIPTION
Fixes #3861

### What changes did you make?
- Replaced {{ project.alt }} with an empty string on current-projects.js
- This is a duplicate of PR #6281. I created a new branch to reserve a merge conflict. @roslynwythe will expedite review/approval/merge.

### Why did you make the changes (we will use this info to test)?
  - To adhere to WCAG

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

- No visual changes to the website.
- alt="" in code appears as alt when using developer tools to inspect the image's alt text property.
