### PR TITLE
Added github handle variable to markdown file

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -26,7 +26,8 @@ leadership:
       slack: https://hackforla.slack.com/team/U05GDBDPEDR
       github: https://github.com/sabheasley
     picture: https://avatars.githubusercontent.com/sabheasley
-  - name: Jen Chung
+  - name: Jen Chung 
+    github-handle: 
     role: UX/UI Design Lead
     links:
       slack: https://hackforla.slack.com/team/U02A6H5PVAA


### PR DESCRIPTION
Fixes #5879 

### What changes did you make?
  - I added the github handle variable to the civic tech jobs markdown file
  - I ensured that there were no changes visible on the project webpage.

### Why did you make the changes (we will use this info to test)?
  - There needs to be a github handle variable for each member of the team, which will eventually replace the github and picture variables.
  
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visible changes to website.