### PR TITLE
Add rel="noopener noreferrer" to external links in communities-of-practice.html

### DIFF
--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -53,7 +53,7 @@ permalink: /communities-of-practice
                         {% if page.status == "Completed" and item.links.linkedin %}
                             <a href='{{ leader.links.linkedin }}' target='_blank' title='Linkedin Profile'>
                         {% elsif page.status == "Completed" %}
-                            <a href='{{ leader.links.github }}' target='_blank' title='GitHub Profile'>
+                            <a href='{{ leader.links.github }}' target='_blank' title='GitHub Profile' rel="noopener noreferrer">
                         {% else %}
                             <a href='{{ leader.links.slack }}' target='_blank' title='Slack Direct Message' rel="noopener noreferrer">
                         {%  endif %}


### PR DESCRIPTION
Fixes #6052 

### What changes did you make?
  - I added rel="noopener noreferrer" to external links in the pages/communities-of-practice.html file.
  - Ensured that the addition does not visually alter the webpage by testing on Docker at http://localhost:4000/communities-of-practice.html.
  - Committed the changes to a new branch named fix-CodeQL-alert-18 for submission

### Why did you make the changes (we will use this info to test)?
  - To enhance security by preventing potential phishing attacks through the use of rel="noopener noreferrer" on external links.
  - Testing the changes locally via Docker ensures that the addition of the rel="noopener noreferrer" attribute does not affect the site's layout or functionality across different devices and screen sizes.
  - Creating a dedicated branch for this fix allows for a clear, isolated review and merge process on GitHub, facilitating a smoother integration of the security fix.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
n/a

</details>

<details>
<summary>Visuals after changes are applied</summary>
 n/a

</details>
