### PR TITLE
Added github-handle to civic-tech-jobs.md

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -58,6 +58,7 @@ leadership:
       github: https://github.com/fenglugithub
     picture: https://avatars.githubusercontent.com/fenglugithub
   - name: Gabriel Vicencio
+    github-handle:
     role: UX/UI Designer
     links:
       slack: https://hackforla.slack.com/team/U03P33ZNPGW


### PR DESCRIPTION
Fixes #6108

### What changes did you make?
  - Added github-handle under Gabriel Vicencio in civic-tech-jobs.md

### Why did you make the changes (we will use this info to test)?
  - To hold the github handle for this member of the leadership team

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes. Added variable to md file
