### PR TITLE
updates projects filter to include tools

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -28,7 +28,7 @@ document.addEventListener("DOMContentLoaded",function(){
                 if (window.location.pathname === '/projects-check/') {
                     filterTitle = filterName;                 
                 } else {
-                    filterTitle = 'languages / technologies'  
+                    filterTitle = 'languages / technologies / tools'  
                 }
                 filterValue.sort((a,b)=> {
                     a = a.toLowerCase()

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -218,23 +218,30 @@ function projectDataSorter(projectdata){
  * Given an array of project object as returned by ``retrieveProjectDataFromCollection()``
  * Returns a filter object -> {filter_type1:[filter_value1,filter_value2], filter_type2:[filter_value1,filter_value2], ... }
 */
-function createFilter(sortedProjectData){
+function createFilter(sortedProjectData) {
     if (window.location.pathname === '/projects-check/') {
         return {
-            'technologies': [...new Set(sortedProjectData.map(item => (item.project.technologies?.length > 0) ? [item.project.technologies].flat() : '').flat() ) ].filter(v=>v!='').sort(),
-            'languages': [...new Set(sortedProjectData.map(item => (item.project.languages?.length > 0) ? [item.project.languages].flat() : '').flat() ) ].filter(v=>v!='').sort(),
-            'tools': [...new Set(sortedProjectData.map(item => (item.project.tools?.length > 0) ? [item.project.tools].flat() : '').flat() ) ].filter(v=>v!='').sort(),
-            }        
+            'technologies': [...new Set(sortedProjectData.map(item => (item.project.technologies?.length > 0) ? [item.project.technologies].flat() : '').flat())].filter(v => v != '').sort(),
+            'languages': [...new Set(sortedProjectData.map(item => (item.project.languages?.length > 0) ? [item.project.languages].flat() : '').flat())].filter(v => v != '').sort(),
+            'tools': [...new Set(sortedProjectData.map(item => (item.project.tools?.length > 0) ? [item.project.tools].flat() : '').flat())].filter(v => v != '').sort(), 
+        }
     } else {
+        let combinedData = sortedProjectData.map(item => {
+            let combined = [];
+            if (item.project.languages?.length > 0) combined.push(...item.project.languages);
+            if (item.project.technologies?.length > 0) combined.push(...item.project.technologies);
+            if (item.project.tools?.length > 0) combined.push(...item.project.tools);
+            return combined;
+        }).flat();
+
         return {
-            // 'looking': [ ... new Set( (sortedProjectData.map(item => item.project.looking ? item.project.looking.map(item => item.category) : '')).flat() ) ].filter(v=>v!='').sort(),
-            // ^ See issue #1997 for more info on why this is commented out
-            'programs': [...new Set(sortedProjectData.map(item => item.project.programAreas ? item.project.programAreas.map(programArea => programArea) : '').flat() ) ].filter(v=>v!='').sort(),
-            'technologies': [...new Set(sortedProjectData.map(item => (item.project.technologies && item.project.languages?.length > 0) ? [item.project.languages, item.project.technologies].flat() : '').flat() ) ].filter(v=>v!='').sort(),
-            'status': [... new Set(sortedProjectData.map(item => item.project.status))].sort()
-        }        
+            'programs': [...new Set(sortedProjectData.map(item => item.project.programAreas ? item.project.programAreas.map(programArea => programArea) : '').flat())].filter(v => v != '').sort(),
+            'technologies': [...new Set(combinedData)].filter(v => v != '').sort(),
+            'status': [...new Set(sortedProjectData.map(item => item.project.status))].sort()
+        }
     }
 }
+
 
 /**
  * Update the history state and the url parameters on checkbox changes


### PR DESCRIPTION
Fixes #6196 

### What changes did you make?
  - Updated the filters for the projects and project-check pages

### Why did you make the changes (we will use this info to test)?
  - To update the projects and project-check pages filters to include the tools filter for more accurate filings

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before](https://github.com/hackforla/website/assets/119828225/2d9b4130-8d41-4c01-9633-89859b2d19ec)
![before1](https://github.com/hackforla/website/assets/119828225/6d004033-5c63-48c1-8d7a-851d75aa6077)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after](https://github.com/hackforla/website/assets/119828225/7628669a-bbfd-4696-8e24-0d092e527f3b)
![after1](https://github.com/hackforla/website/assets/119828225/901281bf-6d90-48a7-95f2-4005243e6aa2)

</details>
