### PR TITLE
Add new variable "github-handle" to member Jenn Wu

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -40,6 +40,7 @@ leadership:
       github: https://github.com/melkosm
     picture: https://avatars.githubusercontent.com/melkosm
   - name: Jenn Wu
+    github-handle:
     role: UX Researcher Lead
     links:
       slack: https://hackforla.slack.com/team/U05JS3V38TV


### PR DESCRIPTION
Fixes #5881 

### What changes did you make?
  - Add new variable `github-handle` for Jenn Wu (line 43)
 
### Why did you make the changes (we will use this info to test)?
  - Per issue: "Eventually `github-handle` will replace the `github` and `picture` variables, reducing redundancy in the project file."
  

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Added variable. No visual changes to the website.
