### PR TITLE
change single quotes to double quotes in order to resolve linter error

### DIFF
--- a/_guide-pages/2FA.html
+++ b/_guide-pages/2FA.html
@@ -42,7 +42,7 @@ resource-url-depreciated:
     </div>
 
 
-    <div class="section-container">
+    <div class='section-container'>
         <a class="anchor" id="FAQ"></a>
         <div class="step-header">
             <h3>Frequently Asked Questions</h3>

--- a/_guide-pages/2FA.html
+++ b/_guide-pages/2FA.html
@@ -42,8 +42,8 @@ resource-url-depreciated:
     </div>
 
 
-    <div class='section-container'>
-        <a class='anchor' id='FAQ'></a>
+    <div class="section-container">
+        <a class="anchor" id="FAQ"></a>
         <div class="step-header">
             <h3>Frequently Asked Questions</h3>
         </div>


### PR DESCRIPTION
Fixes #5711 

### What changes did you make?
  - Changed single quotes to double quotes for `anchor` class and `FAQ` id.

### Why did you make the changes (we will use this info to test)?
  - Per issue: "We want to update an HTML tag to resolve the linter error "Value of attribute [class] must be in double quotes""


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes made to the site.
