### PR TITLE
resolve codeQL alert3 6044

### DIFF
--- a/_includes/current-guides.html
+++ b/_includes/current-guides.html
@@ -74,7 +74,7 @@
                         {%- endif -%}
 
                         <div class="toolkit-info-container">
-                            <h3><a href="{{item.resource-url}}" target="_blank">{{ item.title }}</a></h3>
+                            <h3><a href="{{item.resource-url}}"  target="_blank" rel="noopener noreferrer">{{ item.title }}</a></h3>
                             <p>{{ item.description }}</p>
                         </div>
                         <a href="{{item.resource-url}}" class="toolkit-flex-item-status" target="_blank">


### PR DESCRIPTION
Fixes #6044

### What changes did you make? 
In _includes/current-guides.html I replaced this line: 

`<h3><a href="{{item.resource-url}}" target="_blank">{{ item.title }}</a></h3>
`

with this: 

`<h3><a href="{{item.resource-url}}"  target="_blank" rel="noopener noreferrer">{{ item.title }}</a></h3>`

### Why did you make the changes (we will use this info to test)?

To resolve the alert "Potentially unsafe external link" which appears in the CodeQL alert 3

### Screenshots of Proposed Changes
No visual changes to website

