### PR TITLE
Add _data/internal/credits/ to ignorePaths array in cspell.json

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
       ".github",
       "test/",
       "docker-compose.yml",
-      "_sass/"
+      "_sass/",
+      "_data/internal/credits/"
   ]
 }


### PR DESCRIPTION
Fixes #5838 

### What changes did you make?
  - Add "_data/internal/credits/" to ignorePaths array in cspell.json (line 22)
  - Add "," after previous path in array (line 21)

### Why did you make the changes (we will use this info to test)?
  - Per issue: we need to populate the spell check configuration file with file paths that should be excluded from spell checking.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- Added path to cspell.json. No visual changes to the website.
- Tested update by confirming that files in "_data/internal/credits/" path are not spell checked.