### PR TITLE
In re Issue 6310: Add Andy Arensman, Belen Garcia Martinez, & June Zhao to Food Oasis Project Leadership

### DIFF
--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -30,6 +30,27 @@ leadership:
       slack: "https://hackforla.slack.com/team/U02G7SBKSV7"
       github: "https://github.com/VirginiaWu11"
     picture: https://avatars.githubusercontent.com/VirginiaWu11
+  - name: Andy Arensman
+    github-handle: andyarensman
+    role: Full Stack Engineer
+    links:
+      slack: https://hackforla.slack.com/team/U04PFGPR19Q
+      github: https://github.com/andyarensman
+    picture: https://avatars.githubusercontent.com/andyarensman
+  - name: Belen Garcia Martinez
+    github-handle: 93Belen
+    role: Full Stack Engineer
+    links:
+      slack: https://hackforla.slack.com/team/U056TQ9UA3C
+      github: https://github.com/93Belen
+    picture: https://avatars.githubusercontent.com/93Belen
+  - name: June Zhao
+    github-handle: junjun107
+    role: Full Stack Engineer
+    links:
+      slack: https://hackforla.slack.com/team/U03UWG0EP7V
+      github: https://github.com/junjun107
+    picture: https://avatars.githubusercontent.com/junjun107
   - name: Hannah Zulueta
     role: Lead Developer
     links:


### PR DESCRIPTION
Fixes #6310 

### What changes did you make?
  - added blocks for full-stack devs Andy Arensman, Belen Garcia Martinez, & June Zhao to Food Oasis Project Leadership section in _projects/food-oasis.md between full stack dev Virginia Wu & lead dev Hannah Zulueta

### Why did you make the changes (we will use this info to test)?
  - To keep information on Food Oasis page current so visitors to the page receive accurate information

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot (26)](https://github.com/hackforla/website/assets/67331818/30d04832-0978-4a88-a342-9e2c859d29bb)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot (27)](https://github.com/hackforla/website/assets/67331818/239fb220-7c57-4107-91c2-28d55101ff2f)

</details>
