### PR TITLE
Resolve Code QL alert 19

### DIFF
--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -51,7 +51,7 @@ permalink: /communities-of-practice
                     <div class='leader-description'>
                         <p class='leader-description-field'><strong>Name: </strong>
                         {% if page.status == "Completed" and item.links.linkedin %}
-                            <a href='{{ leader.links.linkedin }}' target='_blank' title='Linkedin Profile'>
+                        <a href='{{ leader.links.linkedin }}' target='_blank' title='Linkedin Profile' rel="noopener noreferrer">
                         {% elsif page.status == "Completed" %}
                             <a href='{{ leader.links.github }}' target='_blank' title='GitHub Profile' rel="noopener noreferrer">
                         {% else %}


### PR DESCRIPTION
Fixes #6053

### What changes did you make?
  - in ```pages/communities-of-practice.html```, changed line 54 from
  
 ```<a href='{{ leader.links.linkedin }}' target='_blank' title='Linkedin Profile'>```
to
 ```<a href='{{ leader.links.linkedin }}' target='_blank' title='Linkedin Profile' rel="noopener noreferrer">```


### Why did you make the changes (we will use this info to test)?
  - to resolve Code QL alert 19 "Potentially unsafe external link"

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes.