### PR TITLE
Add '_includes/design-system-page/examples/' to 'ignorePaths' in cspell.json #5839

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -19,6 +19,7 @@
       "test/",
       "docker-compose.yml",
       "_sass/",
-      "_data/internal/credits/"
+      "_data/internal/credits/",
+      "_includes/design-system-page/examples/"
   ]
 }


### PR DESCRIPTION
Fixes #5839

### What changes did you make?
  - Added '_includes/design-system-page/examples/' to 'ignorePaths' in cspell.json

### Why did you make the changes (we will use this info to test)?
  - The issue was the cspell needed to be updated

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double c heck the syntax or add a newline after the closing </summary> tag -->

Only changes were edits to cspell.json. No visual changes to the website.

