### PR TITLE
Update Communities of Practice: Ops (Add Nayan Bhatt, Zoey Zhang)

### DIFF
--- a/_data/internal/communities/ops.yml
+++ b/_data/internal/communities/ops.yml
@@ -31,6 +31,18 @@ leadership:
       slack: https://hackforla.slack.com/team/UJR0UKBN1
       github: https://github.com/Rankazze
     picture: https://avatars.githubusercontent.com/Rankazze
+  - name: Nayan Bhatt
+    role: Co-lead
+    links:
+      slack: https://hackforla.slack.com/team/U05TZLLJAUV
+      github: https://github.com/freaky4wrld
+    picture: https://avatars.githubusercontent.com/freaky4wrld
+  - name: Zoey Zhang
+    role: Co-lead
+    links:
+      slack: https://hackforla.slack.com/team/U06DT2CA92T
+      github: https://github.com/abbyz123
+    picture: https://avatars.githubusercontent.com/abbyz123
 
 links:
   - name: Slack


### PR DESCRIPTION
Fixes #6372 

### What changes did you make?
  - Added the following lines to _data/internal/communities/ops.yml under the leadership variable (lines 34-45):
```
  - name: Nayan Bhatt
    role: Co-lead
    links:
      slack: https://hackforla.slack.com/team/U05TZLLJAUV
      github: https://github.com/freaky4wrld
    picture: https://avatars.githubusercontent.com/freaky4wrld
  - name: Zoey Zhang
    role: Co-lead
    links:
      slack: https://hackforla.slack.com/team/U06DT2CA92T
      github: https://github.com/abbyz123
    picture: https://avatars.githubusercontent.com/abbyz123
```
- Confirmed that the user's name and GitHub avatar link out to their Slack and GitHub profiles respectively.

### Why did you make the changes (we will use this info to test)?
  - Per issue, we need to keep communities of practice information up to date so that visitors to the website can find accurate information.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
  
![Screen Shot 2024-02-26 at 5 16 15 PM](https://github.com/hackforla/website/assets/146603843/86077b51-2c8f-4035-83b3-b0bc613be83e)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![Screen Shot 2024-02-26 at 5 16 31 PM](https://github.com/hackforla/website/assets/146603843/1940695e-93bb-4594-ab44-124153883572)

</details>
