### PR TITLE
Update Guides Team Page - #6373

### DIFF
--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -34,7 +34,7 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U05JS9NLNQJ'
       github: 'https://github.com/the-techgurl'
     picture: https://avatars.githubusercontent.com/the-techgurl
-links:
+links: 
   - name: GitHub
     url: 'https://github.com/hackforla/guides'
   - name: Slack
@@ -42,13 +42,13 @@ links:
   - name: Overview
     url: '../assets/pdfs/Guides-Team-One-Sheet.pdf'
 looking:
-technologies:
+technologies: 
 location:
   # - Santa Monica
   # - Downtown LA
   - Remote
 partner:
-tools:
+tools: 
 program-area:
   - Civic Tech Infrastructure
 status: Active

--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -1,53 +1,54 @@
 ---
-identification: '386323061'
+identification: "386323061"
 title: Guides Team
 description: The Hack for LA Guides Team project is creating guides and templates from the effective practices that HfLA has developed and iterated from our projects. HfLA Guides aim to share replicable processes and practices from Engineering, UI/UX, Product Management, Data Science, Marketing Fundraising, DevOps, Admin, and Professional Development. The project seeks to further grow HfLA’s peer learning and iterative culture, and ultimately improve outcomes for the entire civic tech ecosystem.
 # card image should be 600px wide x 400px high
 image: /assets/images/projects/guides-team.jpg
-alt: 'Guides Team'
+alt: "Guides Team"
 # hero image should be 1500px wide x 700px high
 image-hero: /assets/images/projects/guides-team-hero.jpg
 leadership:
   - name: Bonnie Wolfe
     role: Agile Coach
     links:
-      slack: 'https://hackforla.slack.com/team/UE1UG1YFP'
-      github: 'https://github.com/ExperimentsInHonesty'
+      slack: "https://hackforla.slack.com/team/UE1UG1YFP"
+      github: "https://github.com/ExperimentsInHonesty"
     picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
   - name: Sarah Edwards
     role: Product Manager
     links:
-      slack: 'https://hackforla.slack.com/team/U03KBU16APN'
-      github: 'https://github.com/edwardsarah'
+      slack: "https://hackforla.slack.com/team/U03KBU16APN"
+      github: "https://github.com/edwardsarah"
     picture: https://avatars.githubusercontent.com/edwardsarah
-  - name: Sarah Levine
+  - name: Ayma Rahman
+    github-handle: aymarmsba
     role: Product Manager
     links:
-      slack: 'https://hackforla.slack.com/team/U05RWQJ8YKU'
-      github: 'https://github.com/levines2017'
-    picture: https://avatars.githubusercontent.com/levines2017
+      slack: https://hackforla.slack.com/team/U06C183Q2HL
+      github: https://github.com/aymarmsba
+    picture: https://avatars.githubusercontent.com/aymarmsba
   - name: Rhoda Michael
     github-handle: the-techgurl
     role: UX Research Lead
     links:
-      slack: 'https://hackforla.slack.com/team/U05JS9NLNQJ'
-      github: 'https://github.com/the-techgurl'
+      slack: "https://hackforla.slack.com/team/U05JS9NLNQJ"
+      github: "https://github.com/the-techgurl"
     picture: https://avatars.githubusercontent.com/the-techgurl
-links: 
+links:
   - name: GitHub
-    url: 'https://github.com/hackforla/guides'
+    url: "https://github.com/hackforla/guides"
   - name: Slack
-    url: 'https://hackforla.slack.com/archives/C028T9XU9S5'
+    url: "https://hackforla.slack.com/archives/C028T9XU9S5"
   - name: Overview
-    url: '../assets/pdfs/Guides-Team-One-Sheet.pdf'
+    url: "../assets/pdfs/Guides-Team-One-Sheet.pdf"
 looking:
-technologies: 
+technologies:
 location:
   # - Santa Monica
   # - Downtown LA
   - Remote
 partner:
-tools: 
+tools:
 program-area:
   - Civic Tech Infrastructure
 status: Active

--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -1,24 +1,24 @@
 ---
-identification: "386323061"
+identification: '386323061'
 title: Guides Team
 description: The Hack for LA Guides Team project is creating guides and templates from the effective practices that HfLA has developed and iterated from our projects. HfLA Guides aim to share replicable processes and practices from Engineering, UI/UX, Product Management, Data Science, Marketing Fundraising, DevOps, Admin, and Professional Development. The project seeks to further grow HfLA’s peer learning and iterative culture, and ultimately improve outcomes for the entire civic tech ecosystem.
 # card image should be 600px wide x 400px high
 image: /assets/images/projects/guides-team.jpg
-alt: "Guides Team"
+alt: 'Guides Team'
 # hero image should be 1500px wide x 700px high
 image-hero: /assets/images/projects/guides-team-hero.jpg
 leadership:
   - name: Bonnie Wolfe
     role: Agile Coach
     links:
-      slack: "https://hackforla.slack.com/team/UE1UG1YFP"
-      github: "https://github.com/ExperimentsInHonesty"
+      slack: 'https://hackforla.slack.com/team/UE1UG1YFP'
+      github: 'https://github.com/ExperimentsInHonesty'
     picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
   - name: Sarah Edwards
     role: Product Manager
     links:
-      slack: "https://hackforla.slack.com/team/U03KBU16APN"
-      github: "https://github.com/edwardsarah"
+      slack: 'https://hackforla.slack.com/team/U03KBU16APN'
+      github: 'https://github.com/edwardsarah'
     picture: https://avatars.githubusercontent.com/edwardsarah
   - name: Ayma Rahman
     github-handle: aymarmsba
@@ -31,16 +31,16 @@ leadership:
     github-handle: the-techgurl
     role: UX Research Lead
     links:
-      slack: "https://hackforla.slack.com/team/U05JS9NLNQJ"
-      github: "https://github.com/the-techgurl"
+      slack: 'https://hackforla.slack.com/team/U05JS9NLNQJ'
+      github: 'https://github.com/the-techgurl'
     picture: https://avatars.githubusercontent.com/the-techgurl
 links:
   - name: GitHub
-    url: "https://github.com/hackforla/guides"
+    url: 'https://github.com/hackforla/guides'
   - name: Slack
-    url: "https://hackforla.slack.com/archives/C028T9XU9S5"
+    url: 'https://hackforla.slack.com/archives/C028T9XU9S5'
   - name: Overview
-    url: "../assets/pdfs/Guides-Team-One-Sheet.pdf"
+    url: '../assets/pdfs/Guides-Team-One-Sheet.pdf'
 looking:
 technologies:
 location:


### PR DESCRIPTION
Fixes #6373

### What changes did you make?
  - Removed Sarah Levine from Guides Team page
  - Added Ayma Rahman to Guides Team page below other existing Product Managers

### Why did you make the changes (we will use this info to test)?
  - I assume Sarah Levine is no longer a Product Manager on the Guides Team and Ayma Rahman has been added as a Product Manager on the Guides Team

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

![6273_before](https://github.com/hackforla/website/assets/122697843/b77bb309-ea12-4b8a-8108-4409e0d2f58a)


</details>

<details>
<summary>Visuals after changes are applied</summary>

![6273_after](https://github.com/hackforla/website/assets/122697843/8b7d2f5f-ff7c-4568-a707-6ec638ada4b1)


</details>
