### PR TITLE
Update Project Profile: Remove Ronald Paek from HfLA Website #6257

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -60,12 +60,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U059K7A1VFB
       github: https://github.com/LRenDO
     picture: https://avatars.githubusercontent.com/LRenDO
-  - name: Ronald Paek
-    role: Merge Team
-    links:
-      slack: 'https://hackforla.slack.com/team/U04RS2BCESX'
-      github: 'https://github.com/ronaldpaek'
-    picture: https://avatars.githubusercontent.com/ronaldpaek
   - name: Richard Kwang
     role: Merge Team
     links:


### PR DESCRIPTION
Fixes #6257

### What changes did you make?

 - Removed Ronald Paek's card from the leadership section in _projects/website.md. 

### Why did you make the changes (we will use this info to test)?

 - To update the project profiles and remove Ronald Paek's card.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-02-27 at 2 57 50 PM](https://github.com/hackforla/website/assets/86250436/9753b5b0-aa60-4b06-a4ec-1d44c162f1e2)



</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-02-27 at 2 59 15 PM](https://github.com/hackforla/website/assets/86250436/ea50ee05-cc7c-4114-b88b-4e7a901c5b09)


</details>

