### PR TITLE
update project profile food oasis reorder leadership member

### DIFF
--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -12,6 +12,12 @@ leadership:
       slack: "https://hackforla.slack.com/team/UFLDX9V19"
       github: "https://github.com/entrotech"
     picture: https://avatars.githubusercontent.com/entrotech
+  - name: Hannah Zulueta
+    role: Lead Developer
+    links:
+      slack: "https://hackforla.slack.com/team/U9SCMTNK0"
+      github: "https://github.com/hanapotski"
+    picture: https://avatars.githubusercontent.com/hanapotski
   - name: Bryan Wu
     role: UX/UR Lead
     links:
@@ -51,12 +57,7 @@ leadership:
       slack: https://hackforla.slack.com/team/U03UWG0EP7V
       github: https://github.com/junjun107
     picture: https://avatars.githubusercontent.com/junjun107
-  - name: Hannah Zulueta
-    role: Lead Developer
-    links:
-      slack: "https://hackforla.slack.com/team/U9SCMTNK0"
-      github: "https://github.com/hanapotski"
-    picture: https://avatars.githubusercontent.com/hanapotski
+
 
 links:
   - name: GitHub


### PR DESCRIPTION
Fixes #6313

### What changes did you make?
  - In _projects/food-oasis.md
  - moved Hannah Zulueta's profile information to be under John Darragh's profile information
  - verified changes on local system

### Why did you make the changes (we will use this info to test)?
  - We need to reorder the way the leadership team members are displayed on the Food Oasis page 
  - Members with the same role need to be grouped

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before](https://github.com/hackforla/website/assets/26665132/786cd1f6-52a2-4f44-913d-415d3c875a04)



</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after](https://github.com/hackforla/website/assets/26665132/2b162b08-f802-46ab-8662-d6079ebcbb8a)



</details>
