### PR TITLE
Adds tools filter to projects and projects-check pages

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -28,7 +28,7 @@ document.addEventListener("DOMContentLoaded",function(){
                 if (window.location.pathname === '/projects-check/') {
                     filterTitle = filterName;                 
                 } else {
-                    filterTitle = 'languages / technologies'  
+                    filterTitle = 'languages / technologies / tools'  
                 }
                 filterValue.sort((a,b)=> {
                     a = a.toLowerCase()

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -235,6 +235,8 @@ function createFilter(sortedProjectData) {
         }).flat();
 
         return {
+            // 'looking': [ ... new Set( (sortedProjectData.map(item => item.project.looking ? item.project.looking.map(item => item.category) : '')).flat() ) ].filter(v=>v!='').sort(),
+            // ^ See issue #1997 for more info on why this is commented out
             'programs': [...new Set(sortedProjectData.map(item => item.project.programAreas ? item.project.programAreas.map(programArea => programArea) : '').flat())].filter(v => v != '').sort(),
             'technologies': [...new Set(combinedData)].filter(v => v != '').sort(),
             'status': [...new Set(sortedProjectData.map(item => item.project.status))].sort()

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -218,23 +218,30 @@ function projectDataSorter(projectdata){
  * Given an array of project object as returned by ``retrieveProjectDataFromCollection()``
  * Returns a filter object -> {filter_type1:[filter_value1,filter_value2], filter_type2:[filter_value1,filter_value2], ... }
 */
-function createFilter(sortedProjectData){
+function createFilter(sortedProjectData) {
     if (window.location.pathname === '/projects-check/') {
         return {
-            'technologies': [...new Set(sortedProjectData.map(item => (item.project.technologies?.length > 0) ? [item.project.technologies].flat() : '').flat() ) ].filter(v=>v!='').sort(),
-            'languages': [...new Set(sortedProjectData.map(item => (item.project.languages?.length > 0) ? [item.project.languages].flat() : '').flat() ) ].filter(v=>v!='').sort(),
-            'tools': [...new Set(sortedProjectData.map(item => (item.project.tools?.length > 0) ? [item.project.tools].flat() : '').flat() ) ].filter(v=>v!='').sort(),
-            }        
+            'technologies': [...new Set(sortedProjectData.map(item => (item.project.technologies?.length > 0) ? [item.project.technologies].flat() : '').flat())].filter(v => v != '').sort(),
+            'languages': [...new Set(sortedProjectData.map(item => (item.project.languages?.length > 0) ? [item.project.languages].flat() : '').flat())].filter(v => v != '').sort(),
+            'tools': [...new Set(sortedProjectData.map(item => (item.project.tools?.length > 0) ? [item.project.tools].flat() : '').flat())].filter(v => v != '').sort(), 
+        }
     } else {
+        let combinedData = sortedProjectData.map(item => {
+            let combined = [];
+            if (item.project.languages?.length > 0) combined.push(...item.project.languages);
+            if (item.project.technologies?.length > 0) combined.push(...item.project.technologies);
+            if (item.project.tools?.length > 0) combined.push(...item.project.tools);
+            return combined;
+        }).flat();
+
         return {
-            // 'looking': [ ... new Set( (sortedProjectData.map(item => item.project.looking ? item.project.looking.map(item => item.category) : '')).flat() ) ].filter(v=>v!='').sort(),
-            // ^ See issue #1997 for more info on why this is commented out
-            'programs': [...new Set(sortedProjectData.map(item => item.project.programAreas ? item.project.programAreas.map(programArea => programArea) : '').flat() ) ].filter(v=>v!='').sort(),
-            'technologies': [...new Set(sortedProjectData.map(item => (item.project.technologies && item.project.languages?.length > 0) ? [item.project.languages, item.project.technologies].flat() : '').flat() ) ].filter(v=>v!='').sort(),
-            'status': [... new Set(sortedProjectData.map(item => item.project.status))].sort()
-        }        
+            'programs': [...new Set(sortedProjectData.map(item => item.project.programAreas ? item.project.programAreas.map(programArea => programArea) : '').flat())].filter(v => v != '').sort(),
+            'technologies': [...new Set(combinedData)].filter(v => v != '').sort(),
+            'status': [...new Set(sortedProjectData.map(item => item.project.status))].sort()
+        }
     }
 }
+
 
 /**
  * Update the history state and the url parameters on checkbox changes


### PR DESCRIPTION
Fixes #6196 

### What changes did you make?
  - Added Tools to filter list of Languages and Technologies on the Projects page
  - Refactored createFilter function so that Tools would be combined on projects page rather than be it's own filter

### Why did you make the changes (we will use this info to test)?
  - To include Tools filter for projects and projects-check pages

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="1470" alt="before" src="https://github.com/hackforla/website/assets/119828225/0dcae5d9-37b3-4452-b3eb-988453d816f6">
<img width="1457" alt="before1" src="https://github.com/hackforla/website/assets/119828225/814f9ec6-0ba2-436e-97ca-a182f0be75d0">

</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="1465" alt="after" src="https://github.com/hackforla/website/assets/119828225/9836a575-d87c-4978-9924-51c4173286fd">
  
<img width="1470" alt="after1" src="https://github.com/hackforla/website/assets/119828225/c718e429-46d1-4e67-9a59-77feb73dc7c2">


</details>
