### PR TITLE
added github handle variable for Bitian Zhang to civic-tech-jobs.md  

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -82,6 +82,7 @@ leadership:
       github: https://github.com/MattPereira
     picture: https://avatars.githubusercontent.com/MattPereira 
   - name: Bitian Zhang
+    github-handle:
     role: Developer
     links:
       slack: https://hackforla.slack.com/team/U04H6PYK14N


### PR DESCRIPTION
Fixes #6123 

### What changes did you make?
  - Added " github-handle:" to line 85 in _projects/civic-tech-jobs.md
 
### Why did you make the changes (we will use this info to test)?
  - this variable will replace the existing github and picture variables, reducing redundancy in the project data

Creating new var in md file, no visual changes to the website.