### PR TITLE
removed Adrian Ang from website project profile

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -60,12 +60,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U04U531MS5P
       github: https://github.com/kwangric
     picture: https://avatars.githubusercontent.com/kwangric
-  - name: Adrian Ang
-    role: Merge Team
-    links:
-      slack: 'https://hackforla.slack.com/team/U0596J2AZEE'
-      github: 'https://github.com/adrianang'
-    picture: https://avatars.githubusercontent.com/adrianang
   - name: J Pham
     github-handle: jphamtv
     role: Merge Team


### PR DESCRIPTION
Fixes #6377  

### What changes did you make?
  - Deleted the data on Adrian Ang in the website project profile
  - This includes his role, slack link, github link, and profile image
 

### Why did you make the changes (we will use this info to test)?
  - To keep the website's project page up to date
 


### Screenshots of Proposed Changes Of The Website

<details>
<summary>Visuals before changes are applied</summary>

![hfla-issue-6377-b4](https://github.com/hackforla/website/assets/113950695/63fc1081-d595-4d74-8be4-990f72524ea3)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![hfla-issue-6377](https://github.com/hackforla/website/assets/113950695/97699385-46ae-4382-94c8-57f99b004bb8)

</details>
