### PR TITLE
added '_site/' to ignorePaths array

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,7 @@
       "docker-compose.yml",
       "_sass/",
       "_data/internal/credits/",
-      "_includes/design-system-page/examples/"
+      "_includes/design-system-page/examples/",
+      "_site/"
   ]
 }


### PR DESCRIPTION
Fixes #5843

### What changes did you make?
  - added "_site/" to the ignorePaths array in cspell.json

### Why did you make the changes (we will use this info to test)?
  - to populate the spell check configuration file with file paths that should be excluded from spell checking

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No visual changes to the website.
