### PR TITLE
Include github-handle variable for Sarah Sanger

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -95,6 +95,7 @@ leadership:
       github: https://github.com/bennyv8
     picture: https://avatars.githubusercontent.com/bennyv8
   - name: Sarah Sanger
+    github-handle:
     role: Developer
     links:
       slack: https://hackforla.slack.com/team/U02M686LYET


### PR DESCRIPTION
Fixes #6125

### What changes did you make?
  - I included the variable named `github-handle` for Sarah Sanger

### Why did you make the changes (we will use this info to test)?
  - I added `github-handle` to hold the github handle for Sarah Sanger of the leadership team (Civic Tech Jobs). Eventually, this variable will be used to replace the `github` and `picture` variables

### Screenshots of Proposed Changes Of The Website

- **Screenshots included to show that the appearance of the project webpage is unchanged**

<details>
<summary>Visuals before changes are applied</summary>

![civic_tech_jobs_before](https://github.com/hackforla/website/assets/23510777/389ee5a1-792c-4ea1-881a-f553fb380a5e)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![civic_tech_jobs_after](https://github.com/hackforla/website/assets/23510777/f90a7825-e5b2-4503-a93b-2aae0d2e0370)

</details>
