### PR TITLE
added assets/ to cspell.json

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,7 @@
       "docker-compose.yml",
       "_sass/",
       "_data/internal/credits/",
-      "_includes/design-system-page/examples/"
+      "_includes/design-system-page/examples/",
+      "assets/"
   ]
 }


### PR DESCRIPTION
Fixes #5842 

### What changes did you make?
  - I added "assets/" to the end of the array "ignorePaths" in cspell.json
  
### Why did you make the changes (we will use this info to test)?
  - I completed issue #5842, which prevents the assets/ path from triggering a cspell error.
  
### Screenshots of Proposed Changes Of The Website
No visual changes to the website.
