### PR TITLE
update Slack icon name in resource card

### DIFF
--- a/_includes/resource-card.html
+++ b/_includes/resource-card.html
@@ -8,8 +8,10 @@
     <li class='resource-card'>
         <!--Where the images will be-->
         <div {% if image %} class='resource-img resource-img-provided' {% else %} role="img" aria-label="{{name}}" class='resource-img' {% endif %}>
-            {% if lowercaseName == 'github' or name == 'Slack' %}
-                {% include {{ name | prepend: 'svg/icon-' | append: '-color.svg' | downcase }} %}
+            {% if lowercaseName == 'github' %}
+                {% include svg/icon-github-color.svg %}
+            {% elsif lowercaseName == 'slack' %}
+                {% include svg/icon-slack.svg %}
             {% elsif name == 'Getting Started' %}
                 {% include svg/logo-hfla-small.svg %}
             {% elsif image %}


### PR DESCRIPTION
Fixes #5826

### What changes did you make?
  - in `includes/resource-card.html`, changed Slack icon reference from `svg/icon-slack-color.svg` to `svg/icon-slack.svg`

### Why did you make the changes (we will use this info to test)?
  - to dedupe Slack icons as part of #5758

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1552" alt="image" src="https://github.com/hackforla/website/assets/9038965/05e167a6-5c8b-4419-a70f-45494e2f15ef">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1552" alt="image" src="https://github.com/hackforla/website/assets/9038965/2d6b94a2-bfd0-45ad-8b3b-fbfe46c9c0d4">

</details>
