### PR TITLE
added github-handle to civic-tech-index

### DIFF
--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -16,6 +16,7 @@ leadership:
       github: 'https://github.com/ExperimentsInHonesty'
     picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
   - name: Cynthia Kiser
+    github-handle:
     role: Architectural Advisor
     links: 
       slack: 'https://hackforla.slack.com/team/U04MFPQDN'


### PR DESCRIPTION
Fixes #6168 

### What changes did you make?
  - I added "github-handle: " to _projects/civic-tech-index.md

### Why did you make the changes (we will use this info to test)?
  - It was requested in fix #6168

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before](https://github.com/hackforla/website/assets/67919477/dd318d4e-5e00-4eff-89d8-962bbb9dc2b0)
</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after](https://github.com/hackforla/website/assets/67919477/63f4f415-1dac-4b7b-b1c0-1d12e72aa5cf)


</details>
