### PR TITLE
ignore _config.yml in cspell config

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -8,7 +8,9 @@
       "Cleantech",
       "Inclusivity",
       "Collabathon",
-      "Undebate"
+      "Undebate",
+      "hackforla",
+      "redirections"
   ],
   "ignoreWords": [
       "Harish"

--- a/cspell.json
+++ b/cspell.json
@@ -20,7 +20,6 @@
       "docker-compose.yml",
       "_sass/",
       "_data/internal/credits/",
-      "_includes/design-system-page/examples/",
-      "_config.yml"
+      "_includes/design-system-page/examples/"
   ]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,7 @@
       "docker-compose.yml",
       "_sass/",
       "_data/internal/credits/",
-      "_includes/design-system-page/examples/"
+      "_includes/design-system-page/examples/",
+      "_config.yml"
   ]
 }


### PR DESCRIPTION
Fixes #5850 

### What changes did you make?
  - added `hackforla` and `redirections` to list of words for cspell to ignore

### Why did you make the changes (we will use this info to test)?

This issue is part of #5450, the purpose of which is to spell-check text that will be displayed on the website. The issue recommends adding _config.yml to `ignorePaths`. However, _config.yml contains some strings which are user-facing, like the site's meta description. So it may be a better idea to keep spell-checking the whole file, and instead silence cspell's errors by ignoring the 2 offending words.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

n/a