### PR TITLE
Secured `wins.js` from XSS vulnerability by replacing `innerHTML`

### DIFF
--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -236,8 +236,8 @@
   	if (document.querySelectorAll('.wins-card').length == 0) {
   		const page = document.querySelector('.wins-page-contain');
   		const p = document.createElement('p');
+  		p.textContent = "No one has shared a win yet...be the first!";
   		page.appendChild(p);
-  		p.innerHTML = "No one has shared a win yet...be the first!";
   	}
   }
 

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -496,7 +496,7 @@ function changeSeeMoreBtn(x) {
 	  	bigQuoteImg.alt = "Quote from " + data[i][name];
 
   		const overlayIcons = document.querySelector('#overlay-icons');
-  		overlayIcons.innerHTML = "";
+  		overlayIcons.textContent = "";
 
   		if (data[i][linkedin_url].length > 0) {
   			makeIcon(data[i][linkedin_url], overlayIcons, 'linkedin-icon', '/assets/images/wins-page/icon-linkedin-small.svg', 'LinkedIn profile for ' + data[i][name]);
@@ -505,16 +505,16 @@ function changeSeeMoreBtn(x) {
   		}
 
   		const overlayName = document.querySelector('#overlay-name');
-		overlayName.innerHTML = data[i][name];
+		overlayName.textContent = data[i][name];
 
   		const overlayTeams = document.querySelector('#overlay-teams');
-  		overlayTeams.innerHTML = `Team(s): ${data[i][team]}`;
+  		overlayTeams.textContent = `Team(s): ${data[i][team]}`;
 
   		const overlayRoles = document.querySelector('#overlay-roles');
-  		overlayRoles.innerHTML = `Role(s): ${data[i][role]}`;
+  		overlayRoles.textContent = `Role(s): ${data[i][role]}`;
 
   		const overlayOverview = document.querySelector('#overlay-overview');
-  		overlayOverview.innerHTML = data[i][overview];
+  		overlayOverview.textContent = data[i][overview];
 
 		insertIcons('#overlay-info', data[i][win], 'overlay')
 
@@ -537,7 +537,7 @@ function changeSeeMoreBtn(x) {
 
 	  const overlayInfo = document.querySelector('#overlay-info');
 
-	  overlayInfo.innerHTML = '';
+	  overlayInfo.textContent = '';
   }
 
 

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -338,11 +338,11 @@
 
 		const teamSpanElement = document.createElement('span');
 		teamSpanElement.classList.add('wins-team-role-color');
-		teamSpanElement.textContent = `Team(s): ${cards[team]}`;
+		teamSpanElement.textContent = `Team(s): ${card[team]}`;
 
 		const roleSpanElement = document.createElement('span');
 		roleSpanElement.classList.add('wins-team-role-color');
-		roleSpanElement.textContent = `Role(s): ${cards[role]}`;
+		roleSpanElement.textContent = `Role(s): ${card[role]}`;
 		
 		cloneCardTemplate
 			.querySelector('.project-inner.wins-card-team')

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -336,8 +336,21 @@
 			cloneCardTemplate.querySelector('.wins-card-github-icon').setAttribute('hidden', 'true')
 		}
 
-		cloneCardTemplate.querySelector('.project-inner.wins-card-team').innerHTML = `<span class="wins-team-role-color">Team(s): </span> ${card[team]}`;
-		cloneCardTemplate.querySelector('.project-inner.wins-card-role').innerHTML = `<span class="wins-team-role-color">Role(s): </span> ${card[role]}`;
+		const teamSpanElement = document.createElement('span');
+		teamSpanElement.classList.add('wins-team-role-color');
+		teamSpanElement.textContent = `Team(s): ${cards[team]}`;
+
+		const roleSpanElement = document.createElement('span');
+		roleSpanElement.classList.add('wins-team-role-color');
+		roleSpanElement.textContent = `Role(s): ${cards[role]}`;
+		
+		cloneCardTemplate
+			.querySelector('.project-inner.wins-card-team')
+			.appendChild(teamSpanElement);
+		
+		cloneCardTemplate
+			.querySelector('.project-inner.wins-card-role')
+			.appendChild(roleSpanElement);
 
 		cloneCardTemplate.querySelector('.wins-card-overview').textContent = card[overview];
 		cloneCardTemplate.querySelector('.wins-icon-container').setAttribute('data-index', index)

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -432,13 +432,13 @@ function changeSeeMoreBtn(x) {
 	const span = document.querySelectorAll(".see-more-div");
 	if (x.matches) {
 		for(let i = 0; i < span.length; i++) {
-			span[i].innerHTML = ''
+			span[i].textContent = ''
 		}
 	} else {
 		for(let i = 0; i < span.length; i++) {
 			// removes show-less-btn class
 			span[i].setAttribute('class', 'see-more-div');
-			span[i].innerHTML = "See More";
+			span[i].textContent = "See More";
 		}
 	}
   }

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -336,21 +336,26 @@
 			cloneCardTemplate.querySelector('.wins-card-github-icon').setAttribute('hidden', 'true')
 		}
 
+		// Avoiding using innerHTML due to security risks
+		// Creating the elements 
+		const teamContainer = cloneCardTemplate.querySelector('.project-inner.wins-card-team');
+		const roleContainer = cloneCardTemplate.querySelector('.project-inner.wins-card-role');
 		const teamSpanElement = document.createElement('span');
 		teamSpanElement.classList.add('wins-team-role-color');
-		teamSpanElement.textContent = `Team(s): ${card[team]}`;
-
 		const roleSpanElement = document.createElement('span');
 		roleSpanElement.classList.add('wins-team-role-color');
-		roleSpanElement.textContent = `Role(s): ${card[role]}`;
 		
-		cloneCardTemplate
-			.querySelector('.project-inner.wins-card-team')
-			.appendChild(teamSpanElement);
-		
-		cloneCardTemplate
-			.querySelector('.project-inner.wins-card-role')
-			.appendChild(roleSpanElement);
+		// Preparing the text of the elements 
+		teamSpanElement.textContent = "Team(s): ";
+		const teamTextNode = document.createTextNode(card[team]);
+		roleSpanElement.textContent = "Role(s): ";
+		const roleTextNode = document.createTextNode(card[role]);
+
+		// Inserting the elements into the DOM
+		teamContainer.appendChild(teamSpanElement);
+		teamContainer.appendChild(teamTextNode);
+		roleContainer.appendChild(roleSpanElement);
+		roleContainer.appendChild(roleTextNode);
 
 		cloneCardTemplate.querySelector('.wins-card-overview').textContent = card[overview];
 		cloneCardTemplate.querySelector('.wins-icon-container').setAttribute('data-index', index)


### PR DESCRIPTION
Fixes #6303 

### What changes did you make?
- Updated 10 instances of `.innerHTML()` to use `.textContent()`.

### Why did you make the changes (we will use this info to test)?
-  These changes protect against XSS vulnerabilities caused by using `.innerHTML()`.
   - 8 out of 10 instances were simple swaps. 
   - 2 out of 10 instances required further modifications to ensure original code intent and visual changes were preserved. Refer to text and history of commit 8b290112140ab3ff669f634c93ddabc6b885bc6c and commit 6d2ed907e83df62534ddeb40fe11895ecb8604c9 for further explanation 
 - Further reading on XSS vulnerabilities of `innerHTML`:
     - [Medium: JavaScript innerHTML, innerText, and textContent](https://medium.com/front-end-weekly/javascript-innerhtml-innertext-and-textcontent-b75ec895cbe3)
     - [Medium: How I Found Multiple XSS Vulnerabilities Using Unknown Techniques](https://infosecwriteups.com/how-i-found-multiple-xss-vulnerabilities-using-unknown-techniques-74f8e705ea0d)

### Screenshots of Proposed Changes Of The Website
  - No visual changes to report.