### PR TITLE
resolve codeQL alert 22 and 24

### DIFF
--- a/pages/guides.html
+++ b/pages/guides.html
@@ -92,13 +92,13 @@ published: false
           text-decoration: none;"></a>
           {% elsif item.links.linked-in %}
           <a href="{{ item.links.linked-in }}" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl" style="margin-right: 13px;
-          text-decoration: none;"></a>
+          text-decoration: none;" rel="noopener noreferrer"></a>
           <div class="no-github"></div>
           <div></div>
           {% else %}
           <div class="no-linked-in"></div>
           <a href="{{ item.links.github }}" target="_blank" title="GitHub Profile" class="fa fa-github fa-xl" style="margin-right: 13px; 
-          text-decoration: none;"></a>
+          text-decoration: none;" rel="noopener noreferrer"></a>
           {% endif %}
         </div>
         {% endfor %}


### PR DESCRIPTION
Fixes #6231 

### What changes did you make?
Replace BOTH instances of

`<a href="{{ item.links.linked-in }}" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl" style="margin-right: 13px; text-decoration: none;"></a>`
with
` <a href="{{ item.links.linked-in }}" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl" style="margin-right: 13px; text-decoration: none;" rel="noopener noreferrer"></a>`

### Why did you make the changes (we will use this info to test)?
  to resolve the "Potentially unsafe external link" alerts which appears in the CodeQL [alert 22](https://github.com/hackforla/website/security/code-scanning/22) and [alert 24](https://github.com/hackforla/website/security/code-scanning/24) by adding the attribute rel="noopener noreferrer"

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="1510" alt="Screenshot 2024-03-14 at 4 15 42 PM" src="https://github.com/hackforla/website/assets/38905894/8a502945-7b00-41e2-8933-06eea786cd74">

</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="1510" alt="Screenshot 2024-03-14 at 4 15 42 PM" src="https://github.com/hackforla/website/assets/38905894/8a502945-7b00-41e2-8933-06eea786cd74">

</details>


