### PR TITLE
Github Action that handles self assigning an issue from `New Issue Approval` column

### DIFF
--- a/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
@@ -4,8 +4,8 @@ const formatComment = require('../../utils/format-comment');
 const getTimeline = require('../../utils/get-timeline');
 
 // Global variables
-var github
-var context
+var github;
+var context;
 
 /**
  * @description - This function is the entry point into the javascript file, it formats the md file based on the result of the previous step and then posts it to the issue
@@ -25,7 +25,7 @@ async function main({ g, c }, { shouldPost, issueNum }){
   }
   //Else we make the comment with the issuecreator's github handle instead of the placeholder.
   else{
-    const instructions = await makeComment()
+    const instructions = await makeComment();
     if(instructions !== null){
       // the actual creation of the comment in github
       await postComment(issueNum, instructions, github, context);
@@ -41,11 +41,11 @@ async function main({ g, c }, { shouldPost, issueNum }){
 async function makeComment(){
   // Setting all the variables which formatComment is to be called with
   let issueAssignee = context.payload.issue.assignee.login;
-  const eventdescriptions = await getTimeline(context.payload.issue.number, github, context);
+  const eventDescriptions = await getTimeline(context.payload.issue.number, github, context);
   //adding the code to find out the latest person assigned the issue
-  for(let i = eventdescriptions.length - 1; i >= 0; i -= 1){
-    if(eventdescriptions[i].event == 'assigned'){
-      issueAssignee = eventdescriptions[i].assignee.login;
+  for(let i = eventDescriptions.length - 1; i >= 0; i -= 1){
+    if(eventDescriptions[i].event == 'assigned'){
+      issueAssignee = eventDescriptions[i].assignee.login;
       break;
     }
   }
@@ -94,7 +94,7 @@ async function makeComment(){
     placeholderString: '${issueAssignee}',
     filePathToFormat: filePathToFormat,
     textToFormat: null
-  }
+  };
 
   // creating the comment with issue assignee's name and returning it!
   const commentWithIssueAssignee = formatComment(commentObject, fs);

--- a/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
@@ -1,6 +1,6 @@
-var fs = require("fs")
-const postComment = require('../../utils/post-issue-comment')
-const formatComment = require('../../utils/format-comment')
+const fs = require("fs");
+const postComment = require('../../utils/post-issue-comment');
+const formatComment = require('../../utils/format-comment');
 const getTimeline = require('../../utils/get-timeline');
 
 // Global variables
@@ -16,19 +16,19 @@ var context
  */
 
 async function main({ g, c }, { shouldPost, issueNum }){
-  github = g
-  context = c
+  github = g;
+  context = c;
   // If the previous action returns a false, stop here
   if(shouldPost === false){
-    console.log('No need to post comment.')
-    return
+    console.log('No need to post comment.');
+    return;
   }
   //Else we make the comment with the issuecreator's github handle instead of the placeholder.
   else{
     const instructions = await makeComment()
     if(instructions !== null){
       // the actual creation of the comment in github
-      await postComment(issueNum, instructions, github, context)
+      await postComment(issueNum, instructions, github, context);
     }
   }
 }
@@ -40,14 +40,13 @@ async function main({ g, c }, { shouldPost, issueNum }){
 
 async function makeComment(){
   // Setting all the variables which formatComment is to be called with
-  var issueAssignee = context.payload.issue.assignee.login
-  const eventdescriptions = await getTimeline(context.payload.issue.number, github, context)
-  console.log(eventdescriptions.length)
+  let issueAssignee = context.payload.issue.assignee.login;
+  const eventdescriptions = await getTimeline(context.payload.issue.number, github, context);
   //adding the code to find out the latest person assigned the issue
-  for(var i = eventdescriptions.length - 1 ; i>=0; i-=1){
+  for(let i = eventdescriptions.length - 1; i >= 0; i -= 1){
     if(eventdescriptions[i].event == 'assigned'){
-      issueAssignee = eventdescriptions[i].assignee.login
-      break
+      issueAssignee = eventdescriptions[i].assignee.login;
+      break;
     }
   }
 
@@ -98,8 +97,8 @@ async function makeComment(){
   }
 
   // creating the comment with issue assignee's name and returning it!
-  const commentWithIssueAssignee = formatComment(commentObject, fs)
-  return commentWithIssueAssignee
+  const commentWithIssueAssignee = formatComment(commentObject, fs);
+  return commentWithIssueAssignee;
 }
   
-module.exports = main
+module.exports = main;

--- a/github-actions/trigger-issue/add-preliminary-comment/unassign-from-NIA.md
+++ b/github-actions/trigger-issue/add-preliminary-comment/unassign-from-NIA.md
@@ -1,5 +1,3 @@
 <!-- Template for a notification to the assignee that they will be unassigned because the issue is in the "New Issue Approval" column -->
-```
-Hi @${issueAssignee}, HfLA appreciates your interest in this issue, but please note that it is in the `New Issue Approval` column of the Project Board because it has not been finalized, approved or prioritized, and so it is not ready for assignment.  For this reason, you have been unassigned from this issue.  Please remember to assign issues only from the `Prioritized Backlog` column.  The one exception to this rule is if you are writing an issue and the `Draft` label is applied.  
 
-```
+Hi @${issueAssignee}, HfLA appreciates your interest in this issue, but please note that it is in the `New Issue Approval` column of the Project Board because it has not been finalized, approved or prioritized, and so it is not ready for assignment.  For this reason, you have been unassigned from this issue.  Please remember to assign issues only from the `Prioritized Backlog` column.  The one exception to this rule is if you are writing an issue and the `Draft` label is applied.  

--- a/github-actions/trigger-issue/add-preliminary-comment/unassign-from-NIA.md
+++ b/github-actions/trigger-issue/add-preliminary-comment/unassign-from-NIA.md
@@ -1,0 +1,5 @@
+<!-- Template for a notification to the assignee that they will be unassigned because the issue is in the "New Issue Approval" column -->
+```
+Hi @${issueAssignee}, HfLA appreciates your interest in this issue, but please note that it is in the `New Issue Approval` column of the Project Board because it has not been finalized, approved or prioritized, and so it is not ready for assignment.  For this reason, you have been unassigned from this issue.  Please remember to assign issues only from the `Prioritized Backlog` column.  The one exception to this rule is if you are writing an issue and the `Draft` label is applied.  
+
+```


### PR DESCRIPTION
Fixes #4821

### What changes did you make?
  - Added the markdown file used for the comment
  - Modified the action script to look for draft label and issue's card column in project board
  - Create a comment accordingly and remove the self assigned contributor

### Why did you make the changes (we will use this info to test)?
  - Automate processes

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
All changes made have no impact on appearance.