### PR TITLE
added github-handle to member Leah Ellis in civic-tech-jobs.md

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -69,6 +69,7 @@ leadership:
       github: https://github.com/geibu
     picture: https://avatars.githubusercontent.com/geibu
   - name: Leah Ellis
+    github-handle:
     role: UX Researcher
     links:
       slack: https://hackforla.slack.com/team/U04GYTXSP9D


### PR DESCRIPTION
Fixes #6110

### What changes did you make?
In _projects/civic-tech-jobs.md I replaced:

`- name: Leah Ellis `

with:

`- name: Leah Ellis 
  github-handle:`



### Why did you make the changes (we will use this info to test)?

This was done in order to have an added variable called 'github handle' for leadership team member Leah Ellis.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to website
