### PR TITLE
Updated scope of variable 'project' line 95

### DIFF
--- a/github-actions/trigger-schedule/github-data/get-project-data.js
+++ b/github-actions/trigger-schedule/github-data/get-project-data.js
@@ -92,7 +92,7 @@ function getLocalData(){
  */
 function projectListToMap(projectList) {
   let projectMap = {};
-  for(project of projectList){
+  for(let project of projectList){
     projectMap[project.id] = project;
   }
   return projectMap;


### PR DESCRIPTION
Fixes #6482 

### What changes did you make?
  - limit scope of variable `project` within loop, line 95 

### Why did you make the changes (we will use this info to test)?
  - Variable `project` is currently being treated as a global variable. Limiting variable scope to loop body, can help prevent future bugs or unexpected behavior if codebase grows or `project` is used anywhere else in the script

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visible changes to website.