### PR TITLE
Refactoring to avoid race condition and resolve CodeQL returnless function alert 56

### DIFF
--- a/assets/js/project-meetings.js
+++ b/assets/js/project-meetings.js
@@ -6,8 +6,6 @@ import { getEventData, insertEventSchedule } from "./utility/api-events.js";
 (async function main() {
   const eventData = await getEventData();
 
-  //Displays/Inserts event schedule to DOM
-
   // If the document is still loading, add an EventListener. There is no race conditiion because JavaScript has run-to-completion semantics
   if (document.readyState === "loading")
   {
@@ -19,7 +17,7 @@ import { getEventData, insertEventSchedule } from "./utility/api-events.js";
 
   // If the document is not in the loading state, the DOM content has loaded and the event schedule can be populated
   else {insertEventSchedule(eventData, "project-meetings")}
-
+  
   //Displays/Inserts the user's time zone in the DOM
   document
     .querySelector("#userTimeZone")

--- a/assets/js/project-meetings.js
+++ b/assets/js/project-meetings.js
@@ -7,10 +7,19 @@ import { getEventData, insertEventSchedule } from "./utility/api-events.js";
   const eventData = await getEventData();
 
   //Displays/Inserts event schedule to DOM
-  document.addEventListener(
+
+  // If the document is still loading, add an EventListener. There is no race conditiion because JavaScript has run-to-completion semantics
+  if (document.readyState === "loading")
+  {
+    document.addEventListener(
     "DOMContentLoaded",
-    insertEventSchedule(eventData, "project-meetings")
-  );
+    function(){insertEventSchedule(eventData, "project-meetings")}
+    );
+  }
+
+  // If the document is not in the loading state, the DOM content has loaded and the event schedule can be populated
+  else {insertEventSchedule(eventData, "project-meetings")}
+
   //Displays/Inserts the user's time zone in the DOM
   document
     .querySelector("#userTimeZone")


### PR DESCRIPTION
Fixes #5473 

### What changes did you make?
  - Replaced a returnless function with an anonymous function to avoid CodeQL alert 56
  - Added an if conditional to set up an event listener only if the document is still in the loading state
  - Added an else clause to run InsertEventSchedule if the document is not in the loading state 

### Why did you make the changes (we will use this info to test)?
  - Because the original function passed to the addEventListener contained parameters, the function was called immediately and the event listener expected its parameter to be that function's return value. Using an anonymous function (without parameters) to then call the InsertEventSchedule ensured the event listener only fired the function once the necessary event occured. 
  - The previous code was only functional because the event listener was set up incorrectly, otherwise the event listener would have missed the DOMContentLoaded event and never run its callback function. This made it necessary to re-format the script to load the event schedule without the race condition of the DOM content. 
  - If the document readyState is still loading, the event listener can be added to wait for the DOMContentLoaded event before populating the event schedule. If the readyState is past the loading state ('interactive'), the DOM content has already loaded and the event schedule can be populated. 

### Video of Proposed Changes to The Website
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>


https://github.com/hackforla/website/assets/19783179/a233f4ed-d650-478c-a5da-a84c250d65a1



</details>

<details>
<summary>Visuals after changes are applied</summary>
  


https://github.com/hackforla/website/assets/19783179/c57d9713-f6f7-40a8-acab-0b65a46bba35




</details>
