### PR TITLE
Issue #6236: Add github-handle to Layne Mostyn in ballot-nav

### DIFF
--- a/_projects/ballot-nav.md
+++ b/_projects/ballot-nav.md
@@ -19,6 +19,7 @@ leadership:
       github: 'https://github.com/staceyrebekahscott'
     picture: 'https://avatars.githubusercontent.com/staceyrebekahscott'
   - name: Layne Mostyn
+    github-handle:
     role: Product Manager
     links:
       slack: 'https://hackforla.slack.com/team/U032H8FJX6U'


### PR DESCRIPTION
Fixes #6236

### What changes did you make?
  - Added the new gh-handle variable under Layne Mostyn in ballot-nav.md

### Why did you make the changes (we will use this info to test)?
  - Creates a single variable github-handle to hold the github handle for each member of the leadership team. Reduces redundancy by progressively replacing the github and picture variables in the project file.
  
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - No Visual changes (Confirmed via docker)