### PR TITLE
updated project page filters to show tools

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -28,7 +28,7 @@ document.addEventListener("DOMContentLoaded",function(){
                 if (window.location.pathname === '/projects-check/') {
                     filterTitle = filterName;                 
                 } else {
-                    filterTitle = 'languages / technologies'  
+                    filterTitle = 'languages / technologies / tools'  
                 }
                 filterValue.sort((a,b)=> {
                     a = a.toLowerCase()
@@ -230,7 +230,7 @@ function createFilter(sortedProjectData){
             // 'looking': [ ... new Set( (sortedProjectData.map(item => item.project.looking ? item.project.looking.map(item => item.category) : '')).flat() ) ].filter(v=>v!='').sort(),
             // ^ See issue #1997 for more info on why this is commented out
             'programs': [...new Set(sortedProjectData.map(item => item.project.programAreas ? item.project.programAreas.map(programArea => programArea) : '').flat() ) ].filter(v=>v!='').sort(),
-            'technologies': [...new Set(sortedProjectData.map(item => (item.project.technologies && item.project.languages?.length > 0) ? [item.project.languages, item.project.technologies].flat() : '').flat() ) ].filter(v=>v!='').sort(),
+            'technologies': [...new Set(sortedProjectData.map(item => (item.project.technologies && item.project.languages?.length > 0 && item.project.tools?.length > 0) ? [item.project.languages, item.project.technologies, item.project.tools].flat() : '').flat() ) ].filter(v=>v!='').sort(),
             'status': [... new Set(sortedProjectData.map(item => item.project.status))].sort()
         }        
     }
@@ -654,12 +654,18 @@ function clearAllEventHandler(){
 /**
  * Takes a single project object and returns the html string representing the project card
 */
-function projectCardComponent(project){
+function projectCardComponent(project) {
+    const projectLanguages = project.languages ? [... new Set(project.languages.map(lang => lang))] : ""
+    const projectTechnologies = project.technologies ? [... new Set(project.technologies.map(t => t))] : ""
+    const projectTools = project.tools ? [... new Set(project.tools.map(t => t))] : ""
+    // the data-technologies attr will be used by UpdateFilterFrequency
+    // to generate Filter's Object
+    const dataTechnologiesArr = [...projectLanguages, ...projectTechnologies, ...projectTools]
     return `
             <li class="project-card" id="${ project.identification }"
                 data-status="${project.status}"
                 data-looking="${project.looking ? [... new Set(project.looking.map(looking => looking.category)) ] : ''}"
-                data-technologies="${(project.technologies && project.languages) ? [... new Set(project.technologies.map(tech => tech)), project.languages.map(lang => lang)] : project.languages.map(lang => lang) }"
+                data-technologies="${[...dataTechnologiesArr]}"
                 data-languages="${project.languages ? [... new Set(project.languages.map(lang => lang))] : '' }"
                 data-tools="${project.tools ? [... new Set(project.tools.map(tool => tool))] : '' }"             
 		        data-location="${project.location? project.location.map(city => city) : '' }"

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -40,8 +40,9 @@ document.addEventListener("DOMContentLoaded",function(){
             } else {
                 filterTitle = filterName;
             }
-            // Partap
             // for issue #4648, needed to add languages inside the technologies filter-item group,  might be able to optimize for future iterations
+
+            // This ensures that the /projects-check page does not change
             if ((filterName === 'languages' || filterName === 'tools') && window.location.pathname === '/projects/') {
               // remove the view all button
               document.querySelector(`#technologies`).lastElementChild.remove()
@@ -493,7 +494,6 @@ function updateProjectCardDisplayState(filterParams){
                 projectCardObj[key] = projectCard.dataset[key].split(",");
             }
             else {
-                // partap
                 const searchAreas=['technologies','description','partner','programs','title','languages', 'tools'];
                 for(const area of searchAreas){
                     projectCardObj[area]=projectCard.dataset[area].split(",");


### PR DESCRIPTION
Fixes #6196 

### What changes did you make?
  - Added `Tools` into `Languages/Technologies` filter on the projects page, revising it to `Languages/Technologies/Tools`
  - Update `projectCardComponent` to include Tools in the file for frequency tracking
  - Refactored `createFilter` function so that Tools is added as a filter
  - Added `tools` into updateProjectCardDisplayState
  - Added `tools` to be tracked with technologies in the `updateCategoryCounter`

### Why did you make the changes (we will use this info to test)?
  - Provide users with the ability to filter projects based on Tools.
  - Ensure that when a Tool is selected as a filter, it displays correctly as `Tool: <tool-name>`
  - Ensure that `projects-check` page does not change


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>


![image](https://github.com/hackforla/website/assets/24577323/93170905-026f-46db-9459-3241d2a7e25d)

![image](https://github.com/hackforla/website/assets/24577323/98f803f8-2a4d-4adc-beb3-63aed6b1531c)

</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="1200" alt="Screenshot 2024-03-29 at 5 26 21 PM" src="https://github.com/hackforla/website/assets/24577323/93716472-dee2-4b97-9f4b-20a4ca7b8182">
<img width="549" alt="Screenshot 2024-04-01 at 7 44 01 PM" src="https://github.com/hackforla/website/assets/24577323/b0d3d920-dd6c-49b4-903c-bf65a7a16396">
<img width="918" alt="Screenshot 2024-04-01 at 7 44 12 PM" src="https://github.com/hackforla/website/assets/24577323/0871971c-4184-4576-8add-f8ba7fd93409">


![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
