### PR TITLE
Bug fix- Devs should not be unassigned from their own Pre-work Checklist 

### DIFF
--- a/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
@@ -50,7 +50,10 @@ async function makeComment(){
     }
   }
 
-  const isDraft = context.payload.issue.labels.find((label) => label.name == 'Draft') ? true : false;
+  // Exclude for case when issue includes one of the following labels
+  const excludeLabels = [ 'Draft', 'Complexity: Prework' ];
+  const issueLabels = context.payload.issue.labels.map(data => data.name);
+  const excludeLabelPresent = issueLabels.some(label => excludeLabels.includes(label));
 
   const queryColumn = `query($owner:String!, $name:String!, $number:Int!) {
     repository(owner:$owner, name:$name) {
@@ -76,7 +79,7 @@ async function makeComment(){
   let filename = 'preliminary-update.md';
 
   // Unassign if issue is in New Issue Approval column of Project Board and is not labeled 'Draft'
-  if (!isDraft && columnName == 'New Issue Approval') {
+  if (!excludeLabelPresent && columnName == 'New Issue Approval') {
     filename = 'unassign-from-NIA.md';
 
     await github.rest.issues.removeAssignees({

--- a/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
@@ -78,7 +78,7 @@ async function makeComment(){
 
   let filename = 'preliminary-update.md';
 
-  // Unassign if issue is in New Issue Approval column of Project Board and is not labeled 'Draft'
+  // Unassign if issue is in New Issue Approval column of Project Board and is not labeled `Draft` or `Complexity: Prework`
   if (!excludeLabelPresent && columnName == 'New Issue Approval') {
     filename = 'unassign-from-NIA.md';
 

--- a/github-actions/trigger-issue/add-preliminary-comment/unassign-from-NIA.md
+++ b/github-actions/trigger-issue/add-preliminary-comment/unassign-from-NIA.md
@@ -1,3 +1,5 @@
 <!-- Template for a notification to the assignee that they will be unassigned because the issue is in the "New Issue Approval" column -->
 
-Hi @${issueAssignee}, HfLA appreciates your interest in this issue, but please note that it is in the `New Issue Approval` column of the Project Board because it has not been finalized, approved or prioritized, and so it is not ready for assignment.  For this reason, you have been unassigned from this issue.  Please remember to assign issues only from the `Prioritized Backlog` column.  The one exception to this rule is if you are writing an issue and the `Draft` label is applied.  
+Hi @${issueAssignee}, HfLA appreciates your interest in this issue, but please note that it is in the  **"New Issue Approval"**  column of the Project Board because it has not been finalized, approved or prioritized, and so it is not ready for assignment.  For this reason, you have been unassigned from this issue.  Please remember to assign issues only from the  **"Prioritized Backlog"**  column.  
+
+The only exceptions to this rule are if you are writing an issue and the `Draft` label is applied, or if you are self-assigning to your "Pre-work Checklist" (issue includes the `Complexity: Prework` label).  


### PR DESCRIPTION
Fixes #6555 

### What changes did you make?
  - Changed check for whether `Draft` label is present, to instead check whether either [`Draft`, `Complexity: Prework`] are present
  - Edited message to note that "Pre-work Checklist"s are excluded- that is, OK for a dev to self-assign to their "Pre-work Checklist" from "New Issue Approval"


### Why did you make the changes (we will use this info to test)?
  - To exclude "Pre-work Checklist"s from this action


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- [Self repo #580](https://github.com/t-will-gillis/website/issues/580) showing the message and unassigning except for when `Draft` or `Complexity: Prework` on issue.