### PR TITLE
Correct misspelling in alt text in Communities of Practice page

### DIFF
--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -21,7 +21,7 @@ permalink: /communities-of-practice
                 <p class="alert--communities">To join the Slack channels below, you first need to be a member of our Hack for LA Slack Community. If you have not joined yet, please follow the steps in <a href="/getting-started" target="_blank">Getting Started</a>.
             </p></div>
     </div>
-    <img class="header-hero-image" src="/assets/images/communities-of-practice/comm-prac-header.svg" alt="commmunity of practice header" />
+    <img class="header-hero-image" src="/assets/images/communities-of-practice/comm-prac-header.svg" alt="community of practice header" />
 </div>
 
 <section class="content-section content--communities">


### PR DESCRIPTION
Fixes #6232

### What changes did you make?
  - Correct the spelling from "commmunity" to "community" in the alt text of an image on the Community of Practice page

### Why did you make the changes (we will use this info to test)?
  - To remove a misspelling from the website

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Corrected the spelling in the alt text. No visual changes to the website.