### PR TITLE
added github-actions/ to the ignorePaths array in cspell.json file

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -25,6 +25,7 @@
       "_includes/design-system-page/examples/",
       "assets/",
       "_config.docker.yml",
-      "_site/"
+      "_site/",
+      "github-actions/"
   ]
 }


### PR DESCRIPTION
Fixes #5844

### What changes did you make?
  - Added "github-actions/" to the ignorePaths array in cspell.json file

### Why did you make the changes (we will use this info to test)?
  - To populate the spell check configuration file with file paths that should be excluded from spell checking
  
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- No visual changes made to site.
