### PR TITLE
Resolved codeql alert 98

### DIFF
--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -47,7 +47,7 @@ permalink: /communities-of-practice
                 <div class='leader-list--communities'>
                 {% for leader in community[1].leadership %}
                 <div class='leader-card--communities'>
-                    <a href='{{ leader.links.github }}' target='_blank' title='GitHub Profile'><img class='leader-img--communities' src='{{ leader.picture }}' rel='noopener noreferrer'/></a>
+                    <a href='{{ leader.links.github }}' target='_blank' title='GitHub Profile' rel='noopener noreferrer'><img class='leader-img--communities' src='{{ leader.picture }}' /></a>
                     <div class='leader-description'>
                         <p class='leader-description-field'><strong>Name: </strong>
                         {% if page.status == "Completed" and item.links.linkedin %}


### PR DESCRIPTION
Fixes #6309

### What changes did you make?
  - Moved the attribute rel="noopener noreferrer" from the `img` to `a` tag.

### Why did you make the changes (we will use this info to test)?
  - To resolve the alert "Potentially unsafe external link"
 
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

Moving files to another directory. No visual changes to the website.

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
Moving files to another directory. No visual changes to the website.

</details>
