### PR TITLE
Update slack link to "archive" for project HelloGOV

### DIFF
--- a/_projects/hellogov.md
+++ b/_projects/hellogov.md
@@ -29,7 +29,7 @@ links:
   - name: Readme
     url: 'https://github.com/helloGov/webapp/blob/master/README.md'
   - name: Slack
-    url: 'https://hackforla.slack.com/messages/CDA23KHKP'
+    url: 'https://hackforla.slack.com/archives/CDA23KHKP'
 looking:
 location:
   # - Santa Monica


### PR DESCRIPTION
Fixes #6513 

### What changes did you make?
  - changed slack url in `links` section from `messages` to `archives`


### Why did you make the changes (we will use this info to test)?
  - Edited the Slack link in an effort to have continuity between project Slack links.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

Changing URL only. No visual changes to the website.
