### PR TITLE
Added github-handle for Emerson Castaneda in civic-tech-index.md

### DIFF
--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -62,6 +62,7 @@ leadership:
       github: 'https://github.com/nrrao'
     picture: https://avatars.githubusercontent.com/nrrao
   - name: Emerson Castaneda
+    github-handle: 
     role: Full Stack Developer
     links:
       slack: 'https://hackforla.slack.com/team/U01CSPAFEBV'


### PR DESCRIPTION
Fixes #6175 

### What changes did you make?
  - Added an empty github-handle variable under Emerson Castaneda's name variable.

### Why did you make the changes (we will use this info to test)?
  - It will be eventually used to replace the github and picture variables, reducing redundancy in the project file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - Added an empty variable in the code. No visual changes to the website.
