### PR TITLE
Changed Slack URL for Tech Work Experience project

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -95,7 +95,7 @@ links:
   - name: Github
     url: 'https://github.com/hackforla/internship'
   - name: Slack
-    url: 'https://hackforla.slack.com/messages/C01VAUPU788'
+    url: 'https://hackforla.slack.com/archives/C01VAUPU788'
   - name: Wiki
     url: 'https://github.com/hackforla/internship/wiki'
   - name: Overview


### PR DESCRIPTION
Fixes #6515 

### What changes did you make?
  - changed the project's Slack URL to `https://hackforla.slack.com/archives/C01VAUPU788`

### Why did you make the changes (we will use this info to test)?
  - Per the instructions, did this to create "continuity between project Slack links".

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Changed Slack link's URL text. No visual changes to the website.