### PR TITLE
Add github-handle for Bruce Lai in civic-tech-index.md

### DIFF
--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -69,6 +69,7 @@ leadership:
       github: 'https://github.com/emecas'
     picture: https://avatars.githubusercontent.com/emecas
   - name: Bruce Lai
+    github-handle:
     role: Full Stack Developer
     links:
       slack: 'https://hackforla.slack.com/team/U01NT0K7XC6'


### PR DESCRIPTION
Fixes #6176 

### What changes did you make?
  - added `github-handle` for Bruce Lai in civic-tech-index.md

### Why did you make the changes (we will use this info to test)?
  - to use a single variable github-handle to hold the github handle, eventually replacing the github and picture variables, reducing redundancy in the project file. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Adding variable to civic-tech-index.md, no visual changes to the website (verified for desktop, phone and tablet screen sizes using Chrome Developer mode)


