### PR TITLE
Added github-handle for Ron Fu in Civic Tech Index

### DIFF
--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -83,6 +83,7 @@ leadership:
       github: 'https://github.com/bhaggya'
     picture: https://avatars.githubusercontent.com/bhaggya
   - name: Ron Fu
+    github-handle:
     role: Full Stack Developer
     links:
       slack: 'https://hackforla.slack.com/team/UGWDHDF46'


### PR DESCRIPTION
Fixes #6178 

### What changes did you make?
  - added `github-handle:` variable under Ron Fu's `name` variable. Used spaces to indent.

### Why did you make the changes (we will use this info to test)?
  - To use a single variable `github-handle` to hold the github handle, eventually replacing the github and picture variables, to reduce redundancy in the project file

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Added a variable to the file. No visual changes were made to the website.
