### PR TITLE
Added github handle for Evan Stalker in _projects brigade-organizers-playbook.md 6155

### DIFF
--- a/_projects/brigade-organizers-playbook.md
+++ b/_projects/brigade-organizers-playbook.md
@@ -23,6 +23,7 @@ leadership:
       github: 'https://github.com/ag2463'
     picture: https://avatars.githubusercontent.com/ag2463
   - name: Evan Stalker
+    github-handle:
     role: Lead Designer
     links:
       slack: 'https://hackforla.slack.com/team/U04M979AY3G'


### PR DESCRIPTION
Fixes #6155

### What changes did you make?
  I went into `_projects/brigade-organizers-playbook.md` and added a variable 'github-handle:' under the name Evan Stalker

### Why did you make the changes (we will use this info to test)?
  Because eventually github-handle will replace github and picture variables to reduce redundancy in the project file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to website
