### PR TITLE
Add GitHub handle in brigade-organizers-playbook.md

### DIFF
--- a/_projects/brigade-organizers-playbook.md
+++ b/_projects/brigade-organizers-playbook.md
@@ -30,6 +30,7 @@ leadership:
       github: 'https://github.com/ejstalker'
     picture: https://avatars.githubusercontent.com/ejstalker
   - name: Liz Brown
+    github-handle:
     role: UX Designer
     links:
       slack: 'https://hackforla.slack.com/team/U052DR4HVJS'


### PR DESCRIPTION
Fixes #6156 

### What changes did you make?
  - Add github-handle for Liz Brown in brigade-organizers-playbook.md


### Why did you make the changes (we will use this info to test)?
  - Because we need to create a single variable github-handle to hold the github handle for each member of the leadership team

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes. 
