### PR TITLE
Added github handle to Benny Van section

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -90,6 +90,7 @@ leadership:
       github: https://github.com/bzzz-coding
     picture: https://avatars.githubusercontent.com/bzzz-coding
   - name: Benny Van
+    github-handle:
     role: Developer
     links:
       slack: https://hackforla.slack.com/team/U05JP90EHMK


### PR DESCRIPTION
Fixes [#6124](https://github.com/hackforla/website/issues/6124)

### What changes did you make?
  - Added additional var called `github-handle`

### Why did you make the changes (we will use this info to test)?
  - Changes were already made in the requirements.`github-handle` will eventually be used deprecate redundant variables and have one singular variable to replace them.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1438" alt="image" src="https://github.com/hackforla/website/assets/14044314/5ff7185a-ab3f-4b9b-bdaa-7199de8e9599">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1434" alt="image" src="https://github.com/hackforla/website/assets/14044314/9902a012-2a8f-41d6-9345-f5f9b9dde1d1">

</details>