### PR TITLE
Update Project Meeting page text and Events page text

### DIFF
--- a/_includes/events-page/right-col-content.html
+++ b/_includes/events-page/right-col-content.html
@@ -8,12 +8,7 @@
             <img class="step-img-2" src="../assets/images/hack-nights/org-projects.png" alt="">
         </div>
         <div id="text-content-1">
-            <p>
-                Please review the listing of project team meeting times to find a
-                project that fits your schedule. You are welcome to attend a project
-                team meeting after you have completed
-                <a href="https://www.hackforla.org/getting-started" target="_blank">Onboarding</a>.
-            </p>
+            <p>We have teams that meet at various times. You are welcome to attend a project team meeting after you have completed Onboarding, and if the team currently has an open role. You can find open roles at the end of the <a href="https://www.hackforla.org/getting-started" target="_blank">Onboarding</a>.</p>
         </div>
     </div>
     <div class="days-display-1">

--- a/pages/project-meetings.html
+++ b/pages/project-meetings.html
@@ -9,10 +9,7 @@ permalink: /project-meetings
 <div class="header-container flex-container">
     <div class="header-text">
         <h1 class="title1">Project Team Meetings</h1>
-        <p>Please review the listing of project team meeting times to find a project that fits your schedule.
-            You are welcome to attend a project team meeting after you have completed <a href="/getting-started">Onboarding</a>.
-            Details about a team's meeting can be obtained in each team's slack channel.
-        </p>
+        <p>We have teams that meet at various times. You are welcome to attend a project team meeting after you have completed Onboarding, and if the team currently has an open role. You can find open roles at the end of the <a href="https://www.hackforla.org/getting-started" target="_blank">Onboarding</a>.</p>
     </div>
     <img class="header-hero-image" src="../assets/images/project-meetings-page/project-meetings-banner-image.png" alt="project meetings banner image">
 </div>


### PR DESCRIPTION
Fixes #6539

### What changes did you make?
  - Update text for attending project meetings in the Project Meeting page
  - Update text for attending project meetings in the Events page

### Why did you make the changes (we will use this info to test)?
  - To clarify that people can attend any team meetings only if that team has an open role

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Project Meeting Page Before](https://github.com/hackforla/website/assets/121467173/2d7adf67-e17f-4350-9ff3-48a0c735cca2)
![Events Page Before](https://github.com/hackforla/website/assets/121467173/26d04b9d-fad4-4e4c-bd12-68eec98fbecc)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Project Meeting Page After](https://github.com/hackforla/website/assets/121467173/472099e6-1558-4462-b75f-9cab832fb37d)
![Events Page After](https://github.com/hackforla/website/assets/121467173/7c7aa526-7915-438d-bed7-64103531f1a1)

</details>
