### PR TITLE
Add github-handle property to Isaiah Ozadhe

### DIFF
--- a/_projects/civic-tech-index.md
+++ b/_projects/civic-tech-index.md
@@ -94,6 +94,7 @@ leadership:
       github: 'https://github.com/rfvisuals'
     picture: https://avatars.githubusercontent.com/rfvisuals
   - name: Isaiah Ozadhe
+    github-handle: 
     role: Full Stack Developer
     links:
       slack: 'https://hackforla.slack.com/team/U034X04V2H5'


### PR DESCRIPTION
Fixes #6179 

### What changes did you make?

- Replaced:
  `name: Isaiah Ozadhe`
- With:
  `name: Isaiah Ozadhe`
  `github-handle: `
- Did not use the tab key to indent github-handle, but used spaces, as YAML does not accept tabs.
- Using docker, confirmed that the appearance of the project webpage is unchanged at all screen sizes.

### Why did you make the changes (we will use this info to test)?

- To create a single variable github-handle to hold the GitHub handle for each member of the leadership team.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Update to a markdown file. No visual changes to the website.
