### PR TITLE
Updated description text alignment in sgd card

### DIFF
--- a/_sass/components/_project-page.scss
+++ b/_sass/components/_project-page.scss
@@ -264,6 +264,7 @@
   background: $color-whitesmoke;
   border-radius: 0px 0px 10px 10px;
   height: 80%;
+  text-align: left;
 
   @media #{$bp-below-tablet} {
     padding-top: 0px;


### PR DESCRIPTION
Fixes #6683 

### What changes did you make?
- Added `text-align: left;` to `.sdg-description-grid-item` style to align the description text to the left.

### Why did you make the changes (we will use this info to test)?
- To enhance the readability of the card description.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)


<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1728" alt="image" src="https://github.com/hackforla/website/assets/76270077/625dcbf9-a4dc-4347-a393-0cc1ef2c6854">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1728" alt="image" src="https://github.com/hackforla/website/assets/76270077/70aa8b3e-7bcf-4739-9467-9d7f55ed4935">

</details>
