### PR TITLE
Add github-handle variable to Zuri Smith #6238

### DIFF
--- a/_projects/ballot-nav.md
+++ b/_projects/ballot-nav.md
@@ -35,6 +35,7 @@ leadership:
       github: 'https://github.com/aNullValue'
     picture: 'https://avatars.githubusercontent.com/aNullValue'
   - name: Zuri Smith
+    github-handle: 
     role: UX Researcher
     links:
       slack: 'https://hackforla.slack.com/team/U035UP9N5PG'


### PR DESCRIPTION
Fixes #6238 

### What changes did you make?
  - Added github-handle variable under Zuri Smith
  - Used spaces, not tabs, to indent github-handle
  - Using Docker, confirmed that appearance of project webpage is unchanged

### Why did you make the changes (we will use this info to test)?
  - To hold the GitHub handle for a member of the leadership team

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

Adding new variable. No visual changes to the website.