### PR TITLE
Updates profiles in the civic tech jobs page

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -20,27 +20,13 @@ leadership:
       slack: https://hackforla.slack.com/team/U02E7ATACAV
       github: https://github.com/kchotani
     picture: https://avatars.githubusercontent.com/kchotani
-  - name: Jen Chung 
-    github-handle: 
-    role: UX/UI Design Lead
+  - name: Lu Feng
+    github-handle: fenglugithub
+    role: UI/UX Lead
     links:
-      slack: https://hackforla.slack.com/team/U02A6H5PVAA
-      github: https://github.com/jenchuu
-    picture: https://avatars.githubusercontent.com/jenchuu
-  - name: Melinda Sukosd
-    github-handle: 
-    role: UX Research Lead
-    links:
-      slack: https://hackforla.slack.com/team/U03T1G9F46P
-      github: https://github.com/melkosm
-    picture: https://avatars.githubusercontent.com/melkosm
-  - name: Jenn Wu
-    github-handle:
-    role: UX Researcher Lead
-    links:
-      slack: https://hackforla.slack.com/team/U05JS3V38TV
-      github: https://github.com/jayywu
-    picture: https://avatars.githubusercontent.com/jayywu 
+      slack: https://hackforla.slack.com/team/U03NV47TG4X
+      github: https://github.com/fenglugithub
+    picture: https://avatars.githubusercontent.com/fenglugithub    
   - name: Tin Wei Chung
     github-handle:
     role: UX/UI Designer
@@ -48,13 +34,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U03P6Q6FSQ5
       github: https://github.com/TCUX
     picture: https://avatars.githubusercontent.com/TCUX
-  - name: Lu Feng
-    github-handle:
-    role: UX/UI Designer
-    links:
-      slack: https://hackforla.slack.com/team/U03NV47TG4X
-      github: https://github.com/fenglugithub
-    picture: https://avatars.githubusercontent.com/fenglugithub
   - name: Gabriel Vicencio
     github-handle:
     role: UX/UI Designer


### PR DESCRIPTION
Fixes #6638 

### What changes did you make?
  - Removed Jen Chung, Melinda Sukosd, and Jenn Wu's profiles
  - Moved and updated Lu Feng's profile

### Why did you make the changes (we will use this info to test)?
  - Keeps civic tech jobs project profiles and information up to date

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image]<img width="1512" alt="Screenshot 2024-04-25 at 7 48 27 PM" src="https://github.com/hackforla/website/assets/67129178/caeafd26-4b93-4d66-9053-e4bda0141b50">
</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image]<img width="1512" alt="Screenshot 2024-04-25 at 7 45 20 PM" src="https://github.com/hackforla/website/assets/67129178/3920ce98-4a2d-47b0-b29e-3e122c60ab60">
</details>
