### PR TITLE
Update Media Query to Prevent Dropdown Wrapping in Wins Page

### DIFF
--- a/_sass/elements/_old_dropdown_filters.scss
+++ b/_sass/elements/_old_dropdown_filters.scss
@@ -168,7 +168,8 @@ a.old-clear-filter-tags {
   }
 }
 
-@media (max-width: 659px) {
+//media query is up to the browser defined laptop size to eliminate wrapping
+@media (max-width: 1024px) {
   //creating 2 rows and 2 columns to display categories on mobile
   ul.old-filter-list {
     display: grid;

--- a/_sass/elements/_old_dropdown_filters.scss
+++ b/_sass/elements/_old_dropdown_filters.scss
@@ -168,8 +168,7 @@ a.old-clear-filter-tags {
   }
 }
 
-//media query is up to the browser defined laptop size to eliminate wrapping
-@media (max-width: 1024px) {
+@media #{$bp-below-desktop-medium} {
   //creating 2 rows and 2 columns to display categories on mobile
   ul.old-filter-list {
     display: grid;

--- a/_sass/variables/_layout.scss
+++ b/_sass/variables/_layout.scss
@@ -4,6 +4,7 @@
  * These are the most commonly used breakpoints for different device widths.
  */
 $screen-desktop-large: 1632px;
+$screen-desktop-medium: 1024px;
 $screen-desktop: 960px;
 $screen-tablet: 768px;
 $screen-mobile: 480px;
@@ -18,6 +19,8 @@ $screen-mobile: 480px;
  */
 $bp-desktop-large-up: '(min-width: #{$screen-desktop-large})';
 $bp-below-desktop-large: '(max-width: #{$screen-desktop-large - .02})';
+$bp-desktop-medium-up: '(min-width: #{$screen-desktop-medium})';
+$bp-below-desktop-medium: '(max-width: #{$screen-desktop-medium - .02})';
 $bp-desktop-up: '(min-width: #{$screen-desktop})';
 $bp-below-desktop: '(max-width: #{$screen-desktop - .02})';
 $bp-tablet-up: '(min-width: #{$screen-tablet})';


### PR DESCRIPTION
Fixes #6272 

### What changes did you make?
 - Identified where wrapping takes place: up to `1000px`
 - Defined a new breakpoint`$screen-desktop-medium: 1024px` in `_sass/variables/_layout.scss` taken from the default 'Laptop' screen size in the document inspector. This changes the dropdown size to two columns when screen is in tablet and desktop, covering all breakpoints where wrapping occurs (up to `1000px`), while ensuring that the original layout is still retained for some screen sizes, specifically from `screen-desktop-medium` to`screen-desktop-xl` (`1024px` and above).
  - Increased max-width of existing media query to `below-screen-desktop-medium` to cover tablet to desktop sizes. 

### Why did you make the changes (we will use this info to test)?
  - To improve user experience when viewing our website with different devices. 
  - To make sufficient changes will retaining our original design.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->


Breakpoints and dropdown were selected based on which dropdown resulted in wrapping at specified breakpoints

**Tablet Size 768px (Teams Dropdown):**
<details>
<summary>Visuals before changes are applied</summary>
<img width="837" alt="tablet-wrap" src="https://github.com/hackforla/website/assets/110444314/ad2bdde4-7d9c-4c67-8767-0d3720ea6592">
</details>

<details>
<summary>Visuals after changes are applied:</summary>
<img width="879" alt="tablet-nowrap2" src="https://github.com/hackforla/website/assets/110444314/9d31e125-a368-4f5f-bf88-80b8ee80faad">
</details>

**Between Tablet Size and Desktop Size 999px (Role Dropdown):** 
<details>
<summary>Visuals before changes are applied:</summary>
<img width="834" alt="desktop-wrap" src="https://github.com/hackforla/website/assets/110444314/1a30efca-7cd0-45a0-9aa7-9559971ce984">
</details>

<details>
<summary>Visuals after changes are applied:</summary>
<img width="1116" alt="desktop-nowrap" src="https://github.com/hackforla/website/assets/110444314/5bea730d-001f-479b-91c6-20a11fd2ac5b">
</details>

