### PR TITLE
Added GitHub handle option for Eva Kwock in design-systems.md

### DIFF
--- a/_projects/design-systems.md
+++ b/_projects/design-systems.md
@@ -53,6 +53,7 @@ leadership:
       github: 'https://github.com/fuzjan81'
     picture: 'https://avatars.githubusercontent.com/fuzjan81'
   - name: Eva Kwock
+    github-handle: 
     role: UX Researcher
     links:
       slack: 'https://hackforla.slack.com/team/U049PSE3ZMZ'


### PR DESCRIPTION
Fixes #6706


### What changes did you make?

  - Added empty github-handle variable under Eva Kwock's name variable.

### Why did you make the changes (we will use this info to test)?

  - Eventually the added github-handle will replace the github and picture variables, reducing redundancy in the project file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

 - Added an empty variable. No visual changes to the website.
