### PR TITLE
Fix `Our Events` Card Glitch After Toggling and Resizing Window 

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -27,7 +27,7 @@
       }
     }
   }
-  document.querySelector('.flex-page-card').addEventListener('resize',handleScreenResize)
+  window.addEventListener('resize',handleScreenResize) 
   function handleScreenResize(){
     if(document.body.clientWidth>767){
       const columns = document.querySelectorAll('.mobile-dropdown');

--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -27,19 +27,24 @@
       }
     }
   }
-  window.addEventListener('resize',handleScreenResize) 
-  function handleScreenResize(){
-    if(document.body.clientWidth>767){
-      const columns = document.querySelectorAll('.mobile-dropdown');
-      for(let column of columns){
+  window.addEventListener('resize', handleScreenResize); 
+
+  /**
+   * Handles the screen resize event for event cards
+   * When the screen width is greater than 767 pixels (tablet/desktop), disables mobile dropdown, removes the arrow and display card content
+   * When the screen width is less than or equal to 767 pixels (mobile), enables cards mobile dropdown and fold the cards, unless already unfolded ('active').
+   */
+  function handleScreenResize() {
+    const columns = document.querySelectorAll('.mobile-dropdown');
+
+    if (document.body.clientWidth > 767) {
+      for(let column of columns) {
         column.style.display='block';
         column.previousElementSibling.classList.remove('active');
       }
-    }
-    else{
-      const columns = document.querySelectorAll('.mobile-dropdown');
-      for(let column of columns){
-        if (column.previousElementSibling.classList.contains('active')){
+    } else {
+      for (let column of columns) {
+        if (column.previousElementSibling.classList.contains('active')) {
           // when collapsing cards, skip the ones unfolded manually
           continue;
         }

--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -39,6 +39,10 @@
     else{
       const columns = document.querySelectorAll('.mobile-dropdown');
       for(let column of columns){
+        if (column.previousElementSibling.classList.contains('active')){
+          // when collapsing cards, skip the ones unfolded manually
+          continue;
+        }
         column.style.display='none';
     }
   }


### PR DESCRIPTION
Fixes #6775 

### What changes did you make?
  1. (7e94b92) changed where `eventListener` is registered from `.flex-page-card'` to `window`
  2. (4262f25) added a condition before `handleScreenResize()` collapse cards to check if they have been manually unfolded, and if so, leave them unfolded

### Why did you make the changes (we will use this info to test)?
  - change No.1 was made to address the main issue in [#6775](https://github.com/hackforla/website/issues/6775), making the eventListener properly registered (with the current way of registration it won't be triggered) so it can function as intended to reset the cards after resizing
  - change No.2 was made to address a issue that existed in the code before but [was only exposed after change No.1 is made](https://github.com/hackforla/website/issues/6775#issuecomment-2081630841) now that the function can be triggered: `handleScreenResize()` will reset (collapse) all cards every time the window size is `#bp-below-tablet` after `resize`. The problem is it cannot tell whether the **previous state before `resize` event is also `#bp-below-tablet`**. If the resize happens from a `#bp-below-tablet` width to another `#bp-below-tablet` width, the expected behavior is to leave the card as is, rather than resetting/collapsing it. By adding a condition to check if card was manually unfolded (by checking existence of `active` in class list), the unfolded cards will not be unexpectedly collapsed, therefore fixing the problem.
 

### Screen Recordings of Proposed Changes Of The Website


<details>
<summary>Visuals before change 1 is applied</summary>

notice how the card will be empty after resizing from width 750 to width 800

![b1](https://github.com/hackforla/website/assets/16524851/d4e4982f-fc03-4d49-95f4-a4140763ee72)


</details>

<details>
<summary>Visuals after change 1 is applied</summary>

notice how the card content **remains** after resizing from width 750 to width 800
  
![a1](https://github.com/hackforla/website/assets/16524851/b8348efa-c010-4028-a93e-e6c5eeb29cf0)

</details>

<details>
<summary>Visuals after change 1 is applied but before change 2 is applied</summary>

notice the card collapse unexpectedly while adjusting the width (<=767 the entire duration)

![b2](https://github.com/hackforla/website/assets/16524851/2bfe6742-5240-4b91-bb4b-fb5fd30edaef)

</details>

<details>
<summary>Visuals after both change 1 and change 2 are applied</summary>

expected behavior: the unfolded card remains unfolded while adjusting the width (<=767 the entire duration)
  
![a2](https://github.com/hackforla/website/assets/16524851/407fefe8-b99b-4cc7-b3cf-ae20ca78e4e8)

</details>
