### PR TITLE
Ignore `google-apps-scripts/` in spell checker

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -29,6 +29,7 @@
       "_site/",
       "github-actions/",
       "redirections/",
-      "surveys/"
+      "surveys/",
+      "google-apps-scripts/"
   ]
 }


### PR DESCRIPTION
Fixes #5845

### What changes did you make?
  - Add `google-apps-scripts/` directory to `ignorePaths` array in `cspell.json`

### Why did you make the changes (we will use this info to test)?
  - To exclude `google-apps-scripts/` from spell check

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes