### PR TITLE
Fixing footer overlapping the content div #6637

### DIFF
--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -1,15 +1,8 @@
 .main-footer {
-  position: sticky;
   width: 100%;
   background: $color-darkblue;
   color: $color-white;
   padding: 42px 25px 20px;
-  bottom: 0;
-  margin-top: -205px;
-
-  @media #{$bp-mobile-up} {
-    margin-top: -165px;
-  }
 
   @media #{$bp-desktop-up} {
     padding: 48px 69px;

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -1,4 +1,9 @@
 .main-footer {
+  /**
+   * Removing position, top and margin-top attributes 
+   * because the footer is now a child of a flex element
+   * and no need to modify the positioning attributes 
+   */
   width: 100%;
   background: $color-darkblue;
   color: $color-white;

--- a/_sass/layouts/_main.scss
+++ b/_sass/layouts/_main.scss
@@ -3,18 +3,11 @@
  * when the content is short.
  */
 
- #app {
-   position: relative;
-   min-height: 100vh;
- }
-
- #content {
-  padding-bottom: 160px;
-
-  @media #{$bp-below-mobile} {
-    padding-bottom: 200px;
-  }
- }
+#app {
+  min-height: 100vh;
+  display: flex; 
+  flex-direction: column;
+}
 
 .page-wrapper {
   display: flex;

--- a/_sass/layouts/_main.scss
+++ b/_sass/layouts/_main.scss
@@ -4,6 +4,10 @@
  */
 
 #app {
+  /**
+   * Modifying #app to be flex will establish a stack (vertical layout) 
+   * for its child elements so the footer will always be pushed to the bottom.
+   */
   min-height: 100vh;
   display: flex; 
   flex-direction: column;


### PR DESCRIPTION
Fixes #6637

### What changes did you make?
  - Modifying `_sass\layouts\_main.scss` & `_sass\components\_footer.scss` files.
  - First, I tried to change the position of the footer to absolute or static as mentioned in the issue but neither of them worked so I had to look for another approach.
  - The approach I took was using **[Flexbox](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox)**:
    1. In `_main.scss` I converted the `#app` element (footer's parent element) to a flex container using `display: flex;` `flex-direction: column;`. This establishes a stack (vertical layout) for its child elements and the footer will be pushed to the bottom since it's the last element.
    2. In `_footer.scss` I removed the previously used `position: sticky` and `margin-top` styles on the `.main-footer` element. With the flexbox layout in place, these styles are no longer necessary for positioning the footer.

### Why did you make the changes (we will use this info to test)?
  - Fix Footer overlapping the content div.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/32923319/3ea9142c-a019-42df-8eec-936a2366c58a)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/32923319/30b53733-300c-4d75-9814-c56bcadb9de9)

</details>
