### PR TITLE
Added github-handle for Thad Kerosky in civic-tech-structure.md

### DIFF
--- a/_projects/civic-tech-structure.md
+++ b/_projects/civic-tech-structure.md
@@ -29,6 +29,7 @@ leadership:
       github: "https://github.com/MasSamH"
     picture: https://avatars.githubusercontent.com/MasSamH
   - name: Thad Kerosky
+    github-handle:
     role: Co-Product Manager
     links:
       slack: "https://cfa.slack.com/archives/C019RCM15FE"


### PR DESCRIPTION
Fixes #6762 

### What changes did you make?
  - Added github-handle for Thad Kerosky in civic-tech-structure.md.

### Why did you make the changes (we will use this info to test)?
  - To Reduce redundancy in the project data.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- Adding a line of code. No visual changes to the website.
