### PR TITLE
added gh handle for wataru inoue

### DIFF
--- a/_projects/design-systems.md
+++ b/_projects/design-systems.md
@@ -46,6 +46,7 @@ leadership:
       github: 'https://github.com/kangina-tech'
     picture: 'https://avatars.githubusercontent.com/kangina-tech'
   - name: Wataru Inoue
+    github-handle:
     role: UX Consultant
     links:
       slack: 'https://hackforla.slack.com/team/U02SMT4H4LR'


### PR DESCRIPTION
Fixes #6703 

### What changes did you make?
  - Added "github-handle" for Wataru Inoue

### Why did you make the changes (we will use this info to test)?
  -  To hold the github handle for each member of the leadership team

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->
 - No visual changes


