### PR TITLE
Updates the profiles in the civic tech jobs project page

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -20,27 +20,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U02E7ATACAV
       github: https://github.com/kchotani
     picture: https://avatars.githubusercontent.com/kchotani
-  - name: Jen Chung 
-    github-handle: 
-    role: UX/UI Design Lead
-    links:
-      slack: https://hackforla.slack.com/team/U02A6H5PVAA
-      github: https://github.com/jenchuu
-    picture: https://avatars.githubusercontent.com/jenchuu
-  - name: Melinda Sukosd
-    github-handle: 
-    role: UX Research Lead
-    links:
-      slack: https://hackforla.slack.com/team/U03T1G9F46P
-      github: https://github.com/melkosm
-    picture: https://avatars.githubusercontent.com/melkosm
-  - name: Jenn Wu
-    github-handle:
-    role: UX Researcher Lead
-    links:
-      slack: https://hackforla.slack.com/team/U05JS3V38TV
-      github: https://github.com/jayywu
-    picture: https://avatars.githubusercontent.com/jayywu 
   - name: Jimmy Juarez
     github-handle: JimmyJuarez10
     role: Developer Lead
@@ -49,8 +28,8 @@ leadership:
       github: https://github.com/JimmyJuarez10
     picture: https://avatars.githubusercontent.com/JimmyJuarez10
   - name: Lu Feng
-    github-handle:
-    role: UX/UI Designer
+    github-handle: fenglugithub
+    role: UI/UX Lead
     links:
       slack: https://hackforla.slack.com/team/U03NV47TG4X
       github: https://github.com/fenglugithub


### PR DESCRIPTION
Fixes #6638 

### What changes did you make?
  - Removed Jen Chung, Melinda Sukosd, and Jenn Wu's profiles
  - Updated Lu Feng's profile and is after the other Product Managers' and Leads' profiles

### Why did you make the changes (we will use this info to test)?
  - Keeps civic tech jobs project profiles and information up to date
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-05-03 at 11 50 45 PM](https://github.com/hackforla/website/assets/67129178/a643da59-7f9c-407a-a53b-000869996502)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-05-03 at 11 49 54 PM](https://github.com/hackforla/website/assets/67129178/7e9cd9a0-c038-4829-adc9-f6e47ef5c698)

</details>
