### PR TITLE
Removed Unused Variable in check-labels Action

### DIFF
--- a/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
@@ -110,7 +110,7 @@ async function addLabels(labelsToAdd, currentLabels) {
   ])]
 
   try {
-    const results = await github.rest.issues.setLabels({
+    await github.rest.issues.setLabels({
       owner: owner,
       repo: repo,
       issue_number: issueNum,


### PR DESCRIPTION
Fixes #6662

### What changes did you make?
- Removed unused variable `results`

### Why did you make the changes (we will use this info to test)?
- The variable was unused. Per the CodeQL alert:

>  unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.

 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- Not applicable as this was a change related to a GitHub Action. As a confirmation though, I did screenshot the successful running of the action in my fork of the repository: 
<img width="306" alt="image" src="https://github.com/hackforla/website/assets/76270077/ba3b7fe6-f3e9-4341-a1b8-9b28f80dc223">
