### PR TITLE
Remove unused import from post-comment.js

### DIFF
--- a/github-actions/pr-instructions/post-comment.js
+++ b/github-actions/pr-instructions/post-comment.js
@@ -1,5 +1,4 @@
 // Import modules
-var fs = require("fs");
 const postComment = require('../utils/post-issue-comment')
 
 // Global variables


### PR DESCRIPTION
Fixes #6665

### What changes did you make?
  - Removed the import of "fs" from the top of the file.

### Why did you make the changes (we will use this info to test)?
  - It is an unused import in this file.
  - This line did not follow CodeQL rules.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual change
