### PR TITLE
Add GitHub handle Ryan Mayott

### DIFF
--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -13,6 +13,7 @@ leadership:
       github: 'https://github.com/ExperimentsInHonesty'
     picture: 'https://avatars.githubusercontent.com/ExperimentsInHonesty'
   - name: Ryan Mayott
+    github-handle:
     role: UI/UX Designer
     links:
       slack: 'https://hackforla.slack.com/team/U01L3BJ3QSW'


### PR DESCRIPTION
Fixes #6732

### What changes did you make?
  - Under "- name: Ryan Mayott" I added "github-handle:"

### Why did you make the changes (we will use this info to test)?
  - To create a single variable <code>github-handle</code> to hold the github handle for Ryan Mayott

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes
