### PR TITLE
Add github-handle to Richa Srivastava

### DIFF
--- a/_projects/ems-triage-tracker.md
+++ b/_projects/ems-triage-tracker.md
@@ -50,6 +50,7 @@ leadership:
       github: 'https://github.com/ysjiang18'
     picture: https://avatars.githubusercontent.com/ysjiang18
   - name: Richa Srivastava
+    github-handle: 
     role: UX Research
     links:
       slack: 'https://hackforla.slack.com/team/UJ8M64E5V'


### PR DESCRIPTION
Fixes #6724 

### What changes did you make?
  - Opened the file _projects/ems-triage-tracker.md in my IDE
  - Replaced:
     `- name: Richa Srivastava`
  - With:
     `- name: Richa Srivastava`
     `   github-handle: `
  - Ensured no other changes were made (a.k.a. no Prettier automatic reformatting)
  - Used spaces to indent, not tabs.

### Why did you make the changes (we will use this info to test)?
  - to create a single variable `github-handle` to hold the GitHub handle for each member of the leadership team eventually reducing redundancy in the project file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - No visual changes to the website.
