### PR TITLE
added github handle for Nicole Doan-6721

### DIFF
--- a/_projects/ems-triage-tracker.md
+++ b/_projects/ems-triage-tracker.md
@@ -32,6 +32,7 @@ leadership:
       github: 'https://github.com/designsimone'
     picture: https://avatars.githubusercontent.com/designsimone
   - name: Nicole Doan
+    github-handle:
     role: Lead UX/UI Design and UX Research
     links:
       slack: 'https://hackforla.slack.com/team/UBPKHJJVC'


### PR DESCRIPTION
Fixes #6721
https://github.com/hackforla/website/issues/6721

### What changes did you make?
 I replaced:  

`-name: Nicole Doan`

with

```
-name: Nicole Doan
  github-handle:
```

### Why did you make the changes (we will use this info to test)?
  -To create a single variable  to hold the github handle for each member of the leadership team.


<details>
<summary>Visuals before changes are applied</summary>
<img width="353" alt="before-nicole-doan" src="https://github.com/hackforla/website/assets/79864764/3c7439c5-6be4-487b-943f-25f101154a51">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="349" alt="after-nicole-doan" src="https://github.com/hackforla/website/assets/79864764/d32dfc37-4b5d-4ed0-b97a-90b04aba9ea1">


</details>
