### PR TITLE
Configure Dependabot to ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: "daily"
     ignore:
+      - dependency-name: "*"
       - update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
@@ -15,6 +16,7 @@ updates:
     schedule:
       interval: "daily"
     ignore:
+      - dependency-name: "*"
       - update-types: ["version-update:semver-patch"]
 
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/github-actions/trigger-schedule/github-data"
     schedule:
       interval: "daily"
+    ignore:
+      - update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
@@ -12,3 +14,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - update-types: ["version-update:semver-patch"]
+
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "*"
-      - update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
@@ -17,6 +17,6 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "*"
-      - update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch"]
 
 


### PR DESCRIPTION
Fixes #6849

### What changes did you make?
  - Modified the Dependabot configuration to ignore semver patch updates.

### Why did you make the changes (we will use this info to test)?
  - We are ignoring patch updates in dependencies to reduce noise from minor updates and focus on more significant changes to dependencies. Security patches are not ignored.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
 - Not applicable.
