### PR TITLE
GHA add comments to prework issue 4820

### DIFF
--- a/.github/workflows/issue-comment-trigger.yaml
+++ b/.github/workflows/issue-comment-trigger.yaml
@@ -1,0 +1,13 @@
+name: Issue Comment Trigger
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  Add-Comment-To-Prework-Issue:
+    if: ${{ github.event_name == 'issue_comment' && github.event.action == 'created'}}
+    permissions:
+      issues: write
+    uses: partapparam/website/.github/workflows/prework-issue-comment-reusable-workflow.yaml@gh-pages
+    secrets: inherit

--- a/.github/workflows/issue-comment-trigger.yaml
+++ b/.github/workflows/issue-comment-trigger.yaml
@@ -9,5 +9,4 @@ jobs:
     if: ${{ github.event_name == 'issue_comment' && github.event.action == 'created'}}
     permissions:
       issues: write
-    uses: partapparam/website/.github/workflows/prework-issue-comment-reusable-workflow.yaml@gh-pages
-    secrets: inherit
+    uses: ./.github/workflows/prework-issue-comment-reusable-workflow.yaml    secrets: inherit

--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -117,5 +117,5 @@ jobs:
     if: "${{ github.event.action == 'opened' || github.event.action == 'closed' || github.event.action == 'assigned' || github.event.action == 'unassigned'}}"
     permissions:
       issues: write
-    uses: partapparam/website/.github/workflows/prework-issue-comment-reusable-workflow.yaml@gh-pages
+    uses: ./.github/workflows/prework-issue-comment-reusable-workflow.yaml
     secrets: inherit

--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -1,7 +1,7 @@
 name: Issue Trigger
 on:
   issues:
-    types: [opened, transferred, assigned, labeled, unlabeled]
+    types: [opened, closed, transferred, assigned, unassigned, labeled, unlabeled]
 
 jobs:
   # Adds newly created issues onto project board in the default column 'New Issue Approval' 
@@ -111,3 +111,11 @@ jobs:
           script: |
             const script = require('./github-actions/trigger-issue/feature-branch-comment/hide-feature-branch-comment.js')
             script({g: github, c: context})
+
+# Adds a comment to actor's prework issue              
+  Add-Comment-To-Prework-Issue:
+    if: "${{ github.event.action == 'opened' || github.event.action == 'closed' || github.event.action == 'assigned' || github.event.action == 'unassigned'}}"
+    permissions:
+      issues: write
+    uses: partapparam/website/.github/workflows/prework-issue-comment-reusable-workflow.yaml@gh-pages
+    secrets: inherit

--- a/.github/workflows/prework-issue-comment-reusable-workflow.yaml
+++ b/.github/workflows/prework-issue-comment-reusable-workflow.yaml
@@ -1,0 +1,76 @@
+name: Find Prework Issue and Comment User Activity
+
+on:
+  workflow_call:
+
+jobs:
+  Add-Comment-To-Prework-Issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get activity detail
+        id: get-activity-detail
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./github-actions/prework-issue-reusable-workflow/get-activity-detail.js')
+            const contributor = script({g: github, c: context})
+            return contributor
+
+      - name: Get prework issue
+        id: get-prework-issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./github-actions/prework-issue-reusable-workflow/get-prework-issue.js')
+            const activityDetail = ${{steps.get-activity-detail.outputs.result}}
+            return script({g: github, c: context}, activityDetail)
+
+      - name: Update prework issue status
+        id: update-prework-issue-status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.HFLA_PROJECT_BOARD_TOKEN }}
+          script: |
+            const script = require('./github-actions/prework-issue-reusable-workflow/update-prework-issue-status.js')
+            const issue = ${{steps.get-prework-issue.outputs.result}}
+            return script({g: github, c: context}, issue)
+
+      # Only move issue if issue was closed and is reopened
+      - name: Move issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.HFLA_PROJECT_BOARD_TOKEN }}
+          script: |
+            const projectColumnId = "PC_lATOJyGIJc4A4juVzgEvcLk"
+            let mutation = `
+              mutation ($cardId: ID! $columnId: ID!) {
+                moveProjectCard (input: {cardId: $cardId columnId: $columnId}) {
+                  cardEdge {
+                    node {
+                      resourcePath
+                    }
+                  }
+                }
+              }
+              `
+            let issue = ${{steps.update-prework-issue-status.outputs.result}}
+            if (issue != false) {
+              let cardId = issue.projectCards.nodes[0].id
+              return await github.graphql(mutation, {
+                cardId: cardId,
+                columnId: projectColumnId,
+              })
+            }
+
+      - name: Leave comment on issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./github-actions/prework_issue_comment/add-prework-comment.js')
+            const issue = ${{steps.get-prework-issue.outputs.result}}
+            const activityDetail = ${{steps.get-activity-detail.outputs.result}}
+            return script({ g: github, c: context}, issue.number, activityDetail)

--- a/.github/workflows/prework-issue-comment-reusable-workflow.yaml
+++ b/.github/workflows/prework-issue-comment-reusable-workflow.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  Add-Comment-To-Prework-Issue:
+  Add-Comment-To-Prework-Issue-Reusable:
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -27,6 +27,9 @@ jobs:
           script: |
             const script = require('./github-actions/prework-issue-reusable-workflow/get-prework-issue.js')
             const activityDetail = ${{steps.get-activity-detail.outputs.result}}
+            if (!activityDetail) {
+              return false
+            } 
             return script({g: github, c: context}, activityDetail)
 
       - name: Update prework issue status
@@ -37,28 +40,22 @@ jobs:
           script: |
             const script = require('./github-actions/prework-issue-reusable-workflow/update-prework-issue-status.js')
             const issue = ${{steps.get-prework-issue.outputs.result}}
-            return script({g: github, c: context}, issue)
+            if (issue) {
+              return script({g: github, c: context}, issue)
+            }
+            return false
 
       # Only move issue if issue was closed and is reopened
       - name: Move issue
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.HFLA_PROJECT_BOARD_TOKEN }}
+          # NOTE: The projectColumnId is hard-coded
           script: |
-            const projectColumnId = "PC_lATOJyGIJc4A4juVzgEvcLk"
-            let mutation = `
-              mutation ($cardId: ID! $columnId: ID!) {
-                moveProjectCard (input: {cardId: $cardId columnId: $columnId}) {
-                  cardEdge {
-                    node {
-                      resourcePath
-                    }
-                  }
-                }
-              }
-              `
-            let issue = ${{steps.update-prework-issue-status.outputs.result}}
-            if (issue != false) {
+            const projectColumnId = "MDEzOlByb2plY3RDb2x1bW43MTk4MjI4"
+            const issue = ${{steps.update-prework-issue-status.outputs.result}}
+            const script = require('./github-actions/utils/update-issue-project-card.js')
+            if (issue) {
               let cardId = issue.projectCards.nodes[0].id
               return await github.graphql(mutation, {
                 cardId: cardId,
@@ -73,4 +70,6 @@ jobs:
             const script = require('./github-actions/prework_issue_comment/add-prework-comment.js')
             const issue = ${{steps.get-prework-issue.outputs.result}}
             const activityDetail = ${{steps.get-activity-detail.outputs.result}}
-            return script({ g: github, c: context}, issue.number, activityDetail)
+            if (issue && activityDetail) {
+              script({ g: github, c: context}, issue.number, activityDetail)
+            }

--- a/.github/workflows/prework-issue-comment-reusable-workflow.yaml
+++ b/.github/workflows/prework-issue-comment-reusable-workflow.yaml
@@ -36,7 +36,7 @@ jobs:
         id: update-prework-issue-status
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.HFLA_PROJECT_BOARD_TOKEN }}
+          github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
           script: |
             const script = require('./github-actions/prework-issue-reusable-workflow/update-prework-issue-status.js')
             const issue = ${{steps.get-prework-issue.outputs.result}}
@@ -49,18 +49,15 @@ jobs:
       - name: Move issue
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.HFLA_PROJECT_BOARD_TOKEN }}
+          github-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
           # NOTE: The projectColumnId is hard-coded
           script: |
             const projectColumnId = "MDEzOlByb2plY3RDb2x1bW43MTk4MjI4"
             const issue = ${{steps.update-prework-issue-status.outputs.result}}
             const script = require('./github-actions/utils/update-issue-project-card.js')
             if (issue) {
-              let cardId = issue.projectCards.nodes[0].id
-              return await github.graphql(mutation, {
-                cardId: cardId,
-                columnId: projectColumnId,
-              })
+              const issueCardId = issue.projectCards.nodes[0].id
+              script(issueCardId, projectColumnId, github)
             }
 
       - name: Leave comment on issue

--- a/.github/workflows/pull-request-review-comment-trigger.yaml
+++ b/.github/workflows/pull-request-review-comment-trigger.yaml
@@ -1,0 +1,12 @@
+name: Pull Request Review Comment Trigger
+on:
+  pull_request_review_comment:
+    types:
+      - created
+jobs:
+  Add-Comment-To-Prework-Issue:
+    if: ${{ github.event_name == 'pull_request_review_comment' && github.event.action == 'created'}}
+    permissions:
+      issues: write
+    uses: ./.github/workflows/prework-issue-comment-reusable-workflow.yaml    
+    secrets: inherit

--- a/.github/workflows/pull-request-review-trigger.yaml
+++ b/.github/workflows/pull-request-review-trigger.yaml
@@ -1,12 +1,11 @@
-name: Issue Comment Trigger
+name: Pull Request Review Trigger
 on:
-  issue_comment:
+  pull_request_review:
     types:
-    - created
-
+      - submitted
 jobs:
   Add-Comment-To-Prework-Issue:
-    if: ${{ github.event_name == 'issue_comment' && github.event.action == 'created'}}
+    if: ${{ github.event_name == 'pull_request_review' && github.event.action == 'submitted'}}
     permissions:
       issues: write
     uses: ./.github/workflows/prework-issue-comment-reusable-workflow.yaml    

--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -65,3 +65,10 @@ jobs:
           column: 'PR Needs review (Automated Column, do not place items here manually)'
           repo-token: ${{ secrets.HACKFORLA_BOT_PA_TOKEN }}
           action: delete
+
+  Add-Comment-To-Prework-Issue:
+    if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'closed')}}
+    permissions:
+      issues: write
+    uses: ./.github/workflows/prework-issue-comment-reusable-workflow.yaml@gh-pages
+    secrets: inherit

--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -70,5 +70,5 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'closed')}}
     permissions:
       issues: write
-    uses: ./.github/workflows/prework-issue-comment-reusable-workflow.yaml@gh-pages
+    uses: ./.github/workflows/prework-issue-comment-reusable-workflow.yaml
     secrets: inherit

--- a/github-actions/prework-issue-reusable-workflow/add-prework-issue-comment.js
+++ b/github-actions/prework-issue-reusable-workflow/add-prework-issue-comment.js
@@ -1,0 +1,36 @@
+// Import modules
+const postComment = require("../utils/post-issue-comment")
+
+// Global variables
+var github
+var context
+
+/**
+ * @description - This function is the entry point into the javascript file, it leaves a comment on the prework issue
+ * @param {Object} g - github object
+ * @param {Object} c - context object
+ * @param {Number} issueNumber - issue
+ * @param {Object} activityDetail - details of the activity performed
+ */
+async function main({ g, c }, issueNumber, activityDetail) {
+  github = g
+  context = c
+  const comment = await makeComment(activityDetail)
+  if (comment !== null) {
+    await postComment(issueNumber, comment, github, context)
+  }
+}
+
+/**
+ * @description  - This function makes the comment
+ * @param {Object} activityDetail  - details of the activity performed
+ * @returns {Promise<string>} - Comment to be posted with the issue label event actor's name
+ */
+
+async function makeComment(activityDetail) {
+  const comment = `${activityDetail.activityObject} has been ${activityDetail.action} by @${activityDetail.contributor}
+`
+  return comment
+}
+
+module.exports = main

--- a/github-actions/prework-issue-reusable-workflow/get-activity-detail.js
+++ b/github-actions/prework-issue-reusable-workflow/get-activity-detail.js
@@ -1,0 +1,136 @@
+// Import modules
+var fs = require("fs")
+
+// Global variables
+var github
+var context
+
+/**
+ * @description - This function is the entry point into the javascript file,
+ * It will determine the eventName and return the proper activity detail
+ * @param {Object} g - github object
+ * @param {Object} c - context object
+ */
+async function main({ g, c }) {
+  github = g
+  context = c
+
+  switch (context.eventName) {
+    case "issue_comment":
+      return await getIssueCommentEventType(context)
+    case "issues":
+      return await getIssueEventType(context)
+    case "pull_request":
+      return await getPullRequestEventType(context)
+    case "pull_request_review":
+      return await getPullRequestReviewEventType(context)
+    case "pull_request_review_comment":
+      return await getPullRequestReviewCommentEventType(context)
+    default:
+      // Handle cases where eventName doesn't match any known event type
+      console.log(`Unknown event name: ${context.eventName}`)
+  }
+}
+
+/**
+ * Retrieves detailed information about an issue event based on the action performed.
+ * @param {*} context
+ * @returns - An object containing the activity detail:
+ * - contributor
+ * - action
+ * - object the activity was performed on (issue, issue_comment, pr, pr_comment, pr_review)
+ *
+ */
+async function getIssueEventType(context) {
+  const activityDetail = {
+    contributor: "",
+    action: context.payload.action,
+    activityObject: `Issue #${context.payload.issue.number}`,
+  }
+  if (context.payload.action == "opened") {
+    activityDetail.contributor = context.payload.issue.user.login
+  } else if (context.payload.action == "closed") {
+    //   NOTE: context.payload.issue.assignee.login can be null if issue is not assigned and marked closed
+    activityDetail.contributor = context.payload.issue.assignee.login
+  } else {
+    //   on unassigned event, the `issue.assignee` is null.
+    activityDetail.contributor = context.payload.assignee.login
+  }
+  return activityDetail
+}
+
+/**
+ * Retrieves detailed information about an issue event based on the action performed.
+ * @param {*} context
+ * @returns - An object containing the activity detail:
+ * - contributor
+ * - action
+ * - object the activity was performed on (issue, issue_comment, pr, pr_comment, pr_review)
+ *
+ */
+async function getIssueCommentEventType(context) {
+  const activityDetail = {
+    contributor: context.payload.comment.user.login,
+    action: context.payload.action,
+    activityObject: context.payload.comment.url,
+  }
+  return activityDetail
+}
+
+/**
+ * Retrieves detailed information about an issue event based on the action performed.
+ * @param {*} context
+ * @returns - An object containing the activity detail:
+ * - contributor
+ * - action
+ * - object the activity was performed on (issue, issue_comment, pr, pr_comment, pr_review)
+ *
+ */
+async function getPullRequestEventType(context) {
+  const activityDetail = {
+    contributor: context.payload.pull_request.user.login,
+    action: context.payload.action,
+    activityObject: `PR #${context.payload.pull_request.number}`,
+  }
+  return activityDetail
+}
+
+/**
+ * Retrieves detailed information about an issue event based on the action performed.
+ * @param {*} context
+ * @returns - An object containing the activity detail:
+ * - contributor
+ * - action
+ * - object the activity was performed on (issue, issue_comment, pr, pr_comment, pr_review)
+ *
+ */
+async function getPullRequestReviewEventType(context) {
+  // also achievable by the context.sender - user who did this event
+  const activityDetail = {
+    contributor: context.payload.review.user.login,
+    action: context.payload.action,
+    activityObject: `PR #${context.payload.pull_request.number}`,
+  }
+  return activityDetail
+}
+
+/**
+ * Retrieves detailed information about an issue event based on the action performed.
+ * @param {*} context
+ * @returns - An object containing the activity detail:
+ * - contributor
+ * - action
+ * - object the activity was performed on (issue, issue_comment, pr, pr_comment, pr_review)
+ *
+ */
+async function getPullRequestReviewCommentEventType(context) {
+  // also achievable by the context.sender - user who did this event
+  const activityDetail = {
+    contributor: context.payload.comment.user.login,
+    action: context.payload.action,
+    activityObject: `${context.payload.comment.url}`,
+  }
+  return activityDetail
+}
+
+module.exports = main

--- a/github-actions/prework-issue-reusable-workflow/get-prework-issue.js
+++ b/github-actions/prework-issue-reusable-workflow/get-prework-issue.js
@@ -1,0 +1,29 @@
+// Import modules
+var getIssueByLabel = require("../utils/get-issue-by-label")
+
+// Global variables
+var github
+var context
+
+/**
+ * @description - This function is the entry point into the javascript file,
+ * it will find the prework issue
+ *
+ * @param {Object} g - github object
+ * @param {Object} c - context object
+ * @param {Object} activityDetail - person who triggered the workflow
+ */
+async function main({ g, c }, activityDetail) {
+  github = g
+  context = c
+  let labels = ["Complexity: Prework"]
+  const issue = await getIssueByLabel(
+    activityDetail.contributor,
+    labels,
+    github,
+    context
+  )
+  return issue
+}
+
+module.exports = main

--- a/github-actions/prework-issue-reusable-workflow/update-prework-issue-status.js
+++ b/github-actions/prework-issue-reusable-workflow/update-prework-issue-status.js
@@ -1,0 +1,30 @@
+// Import modules
+var reopenIssue = require("../utils/reopen-issue")
+
+// Global variables
+var github
+var context
+
+/**
+ * @description - This function is the entry point into the javascript file, it will reopen the issue
+ * @param {Object} g - github object
+ * @param {Object} c - context object
+ * @param {Object} issue - the issue to update
+ */
+async function main({ g, c }, issue) {
+  github = g
+  context = c
+
+  // TODO value is hardcoded
+  // Project Number =1 , for HFLA project number = 7
+  const projectColumnId = "PC_lATOJyGIJc4A4juVzgEvcLk"
+  console.log(issue)
+  if (issue.closed == true) {
+    const result = await reopenIssue(issue.id, github)
+    console.log(result)
+    return result.reopenIssue.issue
+  }
+  return false
+}
+
+module.exports = main

--- a/github-actions/prework-issue-reusable-workflow/update-prework-issue-status.js
+++ b/github-actions/prework-issue-reusable-workflow/update-prework-issue-status.js
@@ -17,7 +17,6 @@ async function main({ g, c }, issue) {
 
   // TODO value is hardcoded
   // Project Number =1 , for HFLA project number = 7
-  const projectColumnId = "PC_lATOLVwEr84A4jIbzgEvVeo"
   console.log(issue)
   if (issue.closed == true) {
     const result = await reopenIssue(issue.id, github)

--- a/github-actions/prework-issue-reusable-workflow/update-prework-issue-status.js
+++ b/github-actions/prework-issue-reusable-workflow/update-prework-issue-status.js
@@ -17,7 +17,7 @@ async function main({ g, c }, issue) {
 
   // TODO value is hardcoded
   // Project Number =1 , for HFLA project number = 7
-  const projectColumnId = "PC_lATOJyGIJc4A4juVzgEvcLk"
+  const projectColumnId = "PC_lATOLVwEr84A4jIbzgEvVeo"
   console.log(issue)
   if (issue.closed == true) {
     const result = await reopenIssue(issue.id, github)

--- a/github-actions/utils/get-issue-by-label.js
+++ b/github-actions/utils/get-issue-by-label.js
@@ -12,6 +12,7 @@ async function getIssueByLabel(actor, labels, github, context) {
       owner: "partapparam",
       repository: "website",
     })
+    console.log(context)
 
     let issue = results.repository.issues.nodes[0]
     return issue

--- a/github-actions/utils/get-issue-by-label.js
+++ b/github-actions/utils/get-issue-by-label.js
@@ -5,15 +5,13 @@
  */
 async function getIssueByLabel(actor, labels, github, context) {
   try {
-    //   TODO - How to get owner and repo dynamically
+    const [owner, name] = context.payload.repository.full_name.split("/")
     let results = await github.graphql(query, {
       actor: actor,
       labels: labels,
-      owner: "partapparam",
-      repository: "website",
+      owner: owner,
+      repository: name,
     })
-    console.log(context)
-
     let issue = results.repository.issues.nodes[0]
     return issue
   } catch (err) {

--- a/github-actions/utils/get-issue-by-label.js
+++ b/github-actions/utils/get-issue-by-label.js
@@ -1,0 +1,51 @@
+/**
+ * Gets issue by label
+ * @param {String} actor - the creator of the issue
+ * @param {Array} labels - the labelS we want to filter by
+ */
+async function getIssueByLabel(actor, labels, github, context) {
+  try {
+    //   TODO - How to get owner and repo dynamically
+    let results = await github.graphql(query, {
+      actor: actor,
+      labels: labels,
+      owner: "partapparam",
+      repository: "website",
+    })
+
+    let issue = results.repository.issues.nodes[0]
+    return issue
+  } catch (err) {
+    console.error(err)
+    throw new Error(err)
+  }
+}
+
+/**
+ * GraphQL query template to use to execute the search.
+ */
+const query = `
+query ($actor: String!, $labels: [String!]!, $owner: String!, $repository: String!) {
+  repository (owner: $owner, name: $repository) {
+   issues (first: 10, filterBy: {createdBy: $actor labels: $labels}) {
+     nodes {
+       __typename
+       ... on Issue {
+         title
+         closed
+         number
+         url
+         id
+         projectCards {
+          nodes {
+            id
+          }
+        }
+      }
+    }
+  }
+}
+}
+`
+
+module.exports = getIssueByLabel

--- a/github-actions/utils/reopen-issue.js
+++ b/github-actions/utils/reopen-issue.js
@@ -1,0 +1,35 @@
+/**
+ * Reopen a closed issue
+ * @param {Number} issueId - the issue that should be reopened
+ */
+async function reopenIssue(issueId, github) {
+  try {
+    const response = await github.graphql(mutation, {
+      issueId: issueId,
+    })
+    return response
+  } catch (err) {
+    throw new Error(err)
+  }
+}
+
+/**
+ * GraphQL query template to use to execute the mutation.
+ */
+const mutation = `
+mutation ($issueId: ID!) {
+  reopenIssue (input: { issueId: $issueId}) {
+    issue {
+      title
+      state
+      projectCards {
+          nodes {
+            id
+          }
+        }
+    }
+  }
+}
+`
+
+module.exports = reopenIssue

--- a/github-actions/utils/update-issue-project-card.js
+++ b/github-actions/utils/update-issue-project-card.js
@@ -1,0 +1,32 @@
+/**
+ * Move Issue to In Progress Column
+ * @param {String} issueCardId - the issue card ID
+ * @param {String} projectColumnId - the project column ID
+ */
+async function updateIssueProjectCard(issueCardId, projectColumnId, github) {
+  try {
+    await github.graphql(mutation, {
+      cardId: issueCardId,
+      columnId: projectColumnId,
+    })
+  } catch (err) {
+    throw new Error(err)
+  }
+}
+
+/**
+ * GraphQL query template to use to move project card to In Progress Column
+ */
+const mutation = `
+mutation ($cardId: ID! $columnId: ID!) {
+  moveProjectCard (input: {cardId: $cardId columnId: $columnId}) {
+    cardEdge {
+      node {
+        resourcePath
+      }
+    }
+  }
+}
+`
+
+module.exports = updateIssueProjectCard


### PR DESCRIPTION
Fixes #4820

### What changes did you make?
- The following event/activity types are set up to trigger the workflow
   - issues: `opened`, `assigned`, `unassigned`, `closed as completed`, or `closed as not planned`
     - Updated `issue-trigger.yml` file with new job `Add-Comment-To-Prework-Issue`
   - issue_comment: `created`
     - Created `issue-comment-trigger.yaml` file and created new job ` Add-Comment-To-Prework-Issue`
   - pull_request: `opened`, `closed`
     - Updated `pull-request-trigger.yaml` file with new job `Add-Comment-To-Prework-Issue`
   - pull_request_review: `submitted`
     - Created `pull-request-review-trigger.yaml` file and created new job `Add-Comment-To-Prework-Issue`
   - pull_request_review_comment: `created`
     - Created `pull-request-review-comment-trigger.yaml` file and created new job ` Add-Comment-To-Prework-Issue`

- Created `prework-issue-reusable-workflow` folder in `github-actions`
- Added files to `github-actions/utils` folder

- Created `prework-issue-comment-reusable-workflow.yaml` with the following steps:
   - Determine the contributor generating the event/activity:
      - Created `get-activity-detail.js`
   - Search for an issue with a "prework" label that is assigned to the contributor 
     - Created `get-prework-issue.js` and `get-issue-by-label.js`
   - If the prework issue is closed, reopen it
     - Created `update-prework-issue-status.js` and `reopen-issue.js`
   - If the above issue is reopened, move it in the "In Progress" column
     - Created `update-issue-project-card.js`  
   - Add a comment to the prework issue describing the event/activity
     - Created `add-prework-issue-comment.js` 

### Why did you make the changes (we will use this info to test)?
  - To create a GitHub Action that will be triggered by GitHub issue, issue_comment, pull_request, pull_request_review and pull_request_review_comment events and will post comments to the developer's pre-work issue describing the developer's activities.


### Notes
- Folder structure
  - I tried to follow the [HFLA Github Actions](https://github.com/hackforla/website/wiki/Hack-for-LA's-GitHub-Actions) guide with creating the new folders
  - The new triggers call a [Reusable Workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows), all jobs to accomplish the required work are in this workflow. 
  - The files required by the `prework-issue-comment-reusable-workflow.yaml` are located in the `github-actions/prework-issue-reusable-workflow` folder
- For testing purposes, I added `permissions: issues: write` but I believe this is not required in this repo. I can remove once tested by the reviewer. 
- HFLA Project Board (number: 7) - In Progress Column value is hard coded.
  - I decided to provide the ProjectCardId rather than use an additional step to query the API.
  - For testing, you will need to update the ProjectCardId to your local project board and use the below query to fetch from the [GraphQL API.](https://docs.github.com/en/graphql/overview/explorer) 
 ```
query{
    repository(owner: "hackforla", name: "website") {
      projects(first: 10) {
        nodes {
          name
          number
          id
          columns(first: 10) {
            __typename
            nodes {
              name
              id
            }
          }
        }
      }
    }
  }
```
