### PR TITLE
Revert lint-scss.yml to github/super-linter@4.8.1

### DIFF
--- a/.github/workflows/lint-scss.yml
+++ b/.github/workflows/lint-scss.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint SCSS
-        uses: github/super-linter@v5.0.0
+        uses: github/super-linter@v4.8.1
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: gh-pages


### PR DESCRIPTION
Fixes #6868 

### What changes did you make?
  - In `lint-scss.yml` file, reverted linter to previous version `github/super-linter@4.8.1`

### Why did you make the changes (we will use this info to test)?
  - When we updated the linter to 5.0.0, the "Lint Scss" workflow broke (long story, see #5048). We are reverting to a previous version as a temporary fix.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
n/a

### Additional
- [Successful issue creation](https://github.com/t-will-gillis/website/pull/753)
- [Successful issue creation](https://github.com/t-will-gillis/website/pull/752)



</details>
