### PR TITLE
Update Alt Text for Page Card Icon Image

### DIFF
--- a/pages/sitemap.html
+++ b/pages/sitemap.html
@@ -48,7 +48,7 @@ permalink: /sitemap/
 
   <div class="page-card card-primary page-card-lg page-card--large-icon-container">
     <h2 class="title4 page-card--large-icon-header">Help Us Add Sections to the Website</h2>  
-    <img src="/assets/images/sitemap/site.svg">
+    <img src="/assets/images/sitemap/site.svg" alt="">
     <div class="page-card--large-icon-body">
       <p>
           We are looking for volunteers across all


### PR DESCRIPTION
Fixes #6800 

### What changes did you make?
  - added alt text for page card icon image.

### Why did you make the changes (we will use this info to test)?
  - provide clear and descriptive alt text on the SiteMap page so that we adhere to the Web Content Accessibility Guidelines (WCAG).

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - added alt text. No visual changes to the website.