### PR TITLE
Changed reference to the admin Slack channel in the join us file

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -40,7 +40,7 @@ permalink: /join
         <ol>
           <li>Follow the steps on our <a href="/getting-started" target="_blank">Getting Started</a> page</li>
           <li>
-            Connect with our leadership team on the <strong>#admin</strong> <a href="https://hackforla.slack.com/messages/admin"
+            Connect with our leadership team on the <strong>#admin</strong> <a href="https://hackforla.slack.com/archives/C01Q24YF56J"
               target="_blank">channel</a>
           </li>
         </ol>


### PR DESCRIPTION
Fixes #6847

### What changes did you make?
  - Fixed our reference to the admin Slack channel in the join us file to use the channel ID instead of the channel name in the file pages/join-us.html

### Why did you make the changes (we will use this info to test)?
  - So that if the name of the channel gets changed, the link will still work

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes to the website.