### PR TITLE
Fixed slack capitalization

### DIFF
--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -130,7 +130,7 @@
 }
 
 
-//styling for join slack and view github buttons
+//styling for join Slack and view github buttons
 .page-card-content{
   .link-buttons{
     display: flex;

--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -136,7 +136,6 @@
     display: flex;
     justify-content: space-around;
     flex-wrap: wrap;
-
   }
 
   .button-icon{


### PR DESCRIPTION
Fixes #6845 
### What changes did you make?
 - Fixed the capitalization of slack from line 133 of file website/_sass/components/_communities-of-practice.scss.
### Why did you make the changes (we will use this info to test)?
  - We need to fix the following line of code to correctly capitalize "Slack" when it's used to refer to the app or the company in our code and content.
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - No visual changes. 