### PR TITLE
added github handle for Nicole Doan

### DIFF
--- a/_projects/ems-triage-tracker.md
+++ b/_projects/ems-triage-tracker.md
@@ -32,6 +32,7 @@ leadership:
       github: 'https://github.com/designsimone'
     picture: https://avatars.githubusercontent.com/designsimone
   - name: Nicole Doan
+    github-handle:
     role: Lead UX/UI Design and UX Research
     links:
       slack: 'https://hackforla.slack.com/team/UBPKHJJVC'


### PR DESCRIPTION
Fixes #6721 

### What changes did you make?
  I replaced:
`
-name: Nicole Doan`

with

```
-name: Nicole Doan
  github-handle:
```

### Why did you make the changes (we will use this info to test)?
  --To create a single variable to hold the github handle for for Nicole Doan.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Created a single variable to hold the github handle for Nicole Doan.  No visual changes to the website.
