### PR TITLE
Add github-handle for Selena Jiang in ems-triage-tracker.md

### DIFF
--- a/_projects/ems-triage-tracker.md
+++ b/_projects/ems-triage-tracker.md
@@ -45,6 +45,7 @@ leadership:
       github: 'https://github.com/redmckiernan'
     picture: https://avatars.githubusercontent.com/redmckiernan
   - name: Selena Jiang
+    github-handle: 
     role: UI Design, Life Saving Measures screen
     links:
       slack: 'https://hackforla.slack.com/team/UMYN9DVSB'


### PR DESCRIPTION
Fixes #6723

### What changes did you make?
  - On _projects/ems-triage-tracker.md, 
    - added `github-handle:` under `- name: Selena Jiang`

### Why did you make the changes (we will use this info to test)?
  - We need to create a single variable github-handle to hold the github handle for Selena Jiang. 
  - No visual changes, but handle is now in the yaml.

No visual changes to website.