### PR TITLE
Add GH token / permissions to `stefanzweifel/git-auto-commit-action`,  sch-monthly.yml

### DIFF
--- a/.github/workflows/schedule-monthly.yml
+++ b/.github/workflows/schedule-monthly.yml
@@ -1,10 +1,9 @@
 name: Schedule Monthly
 
-# This action runs at 11:00 UTC/ 3:00 PDT on the first day of every month except January.
+# This action runs at 11:00 UTC/ 4:00 PDT on the first day of every month except January.
 on:
   schedule:
     - cron:  0 11 1 2-12 * 
-  workflow_dispatch:
 
 jobs:
   Trim_Contributors:
@@ -12,9 +11,11 @@ jobs:
     if: github.repository == 'hackforla/website'      
 
     steps:
-    # Checkout repo
+    # Checkout repo, and provide authorization token for `stefanzweifel/git-auto-commit-action` below
     - name: Checkout repository
       uses: actions/checkout@v4
+      with: 
+        token: ${{ secrets.HACKFORLA_ADMIN_TOKEN }}
  
     # Checks member activity logs for recent and previous contributors 
     - name: Get Contributors


### PR DESCRIPTION
Fixes #6843

### What changes did you make?
In `schedule-monthly-1100.yml`:
  - Corrected time for 11:00 UTC --> 4:00 PDT
  - Removed `workflow_dispatch:`
  - Provided token at `actions/checkout@v4` to give permissions to `stefanzweizel/git-auto-commit-action`

### Why did you make the changes (we will use this info to test)?
  - To correct a minor error in the comments so that we know when to expect workflow to run locally
  - This workflow should not be triggered manually
  - Previously, this workflow has failed due to branch protection rule exceptions due to a lack of permissions. Adding the token authorizes the workflow to write data logs to our repo

### Note to PR Reviewers
- Although this involves a GHA, this workflow has been previously tested- this review does not require testing
- [Log of successful run](https://github.com/t-will-gillis/website/actions/runs/9279714980) from personal repo- See "Update Inactive Members JSON" step in workflow for confirmation that the Branch Protection Rules are temporarily bypassed to save data file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

- No visual changes
