### PR TITLE
Added Github-handle for Byron Heart

### DIFF
--- a/_projects/engage.md
+++ b/_projects/engage.md
@@ -20,7 +20,7 @@ leadership:
       github: 'https://github.com/rmayott'
     picture: 'https://avatars.githubusercontent.com/rmayott'
   - name: Bryon Heart
-    role: Product Manager
+    github-handle: 
     links:
       slack: 'https://hackforla.slack.com/team/U01GHT3EMNZ'
       github: 'https://github.com/BryonPm'


### PR DESCRIPTION
Fixes #6730

### What changes did you make?

 - Replacement:

replaced
 
`- name: Bryon Heart` 

with
```
- name: Bryon Heart
  github-handle: 
```
  - maintained YAML front matter

### Why did you make the changes (we will use this info to test)?
  - Bryon Heart in engage.md is missing GitHub-handle

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - No website visual change
