### PR TITLE
Update schedule-monthly.yml

### DIFF
--- a/.github/workflows/schedule-monthly.yml
+++ b/.github/workflows/schedule-monthly.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
       with: 
         token: ${{ secrets.HACKFORLA_ADMIN_TOKEN }}
-      
+  
     # Checks member activity logs for recent and previous contributors 
     - name: Get Contributors
       id: get-contributors

--- a/.github/workflows/schedule-monthly.yml
+++ b/.github/workflows/schedule-monthly.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
       with: 
         token: ${{ secrets.HACKFORLA_ADMIN_TOKEN }}
-  
+
     # Checks member activity logs for recent and previous contributors 
     - name: Get Contributors
       id: get-contributors

--- a/.github/workflows/schedule-monthly.yml
+++ b/.github/workflows/schedule-monthly.yml
@@ -4,7 +4,7 @@ name: Schedule Monthly
 on:
   schedule:
     - cron:  0 11 1 2-12 * 
-
+  workflow_dispatch:
 jobs:
   Trim_Contributors:
     runs-on: ubuntu-latest
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
       with: 
         token: ${{ secrets.HACKFORLA_ADMIN_TOKEN }}
- 
+      
     # Checks member activity logs for recent and previous contributors 
     - name: Get Contributors
       id: get-contributors
@@ -38,7 +38,11 @@ jobs:
           const results = ${{ steps.get-contributors.outputs.result }}
           const script = require('./github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js')
           script({ g: github, c: context }, results)
-    
+
+    # Run `git pull` so that branch is current prior to next step
+    - name: Pull latest changes from gh-pages
+      run: git pull
+      
     # Commits list of inactive members to repo for using in next step, and in one month
     - name: Update Inactive Members JSON
       id: update-inactive-members-json

--- a/.github/workflows/schedule-monthly.yml
+++ b/.github/workflows/schedule-monthly.yml
@@ -27,7 +27,7 @@ jobs:
           const script = require('./github-actions/trigger-schedule/list-inactive-members/get-contributors-data.js')
           const results = script({ g: github, c: context })
           return results
-    
+
     # Trims inactive members from team and notifies idle members
     - name: Trim and Notify Members
       id: trim-and-notify-members
@@ -42,7 +42,7 @@ jobs:
     # Run `git pull` so that branch is current prior to next step
     - name: Pull latest changes from gh-pages
       run: git pull
-      
+
     # Commits list of inactive members to repo for using in next step, and in one month
     - name: Update Inactive Members JSON
       id: update-inactive-members-json


### PR DESCRIPTION
Adding `git pull` to address runtime error re: divergent branches in `stefanzweifel/git-auto-commit-action` logs. Hopefully

Fixes #6922

### What changes did you make?
  - Added step to run `git pull` prior to `stefanzweifel/git-auto-commit-action` step in the [schedule-monthly.yml](https://github.com/hackforla/website/blob/gh-pages/.github/workflows/schedule-monthly.yml) workflow
  - Added `workflow_dispatch:` trigger to the same

### Why did you make the changes (we will use this info to test)?
  - Adding `git pull` step to address the bug the caused the latest workflow to fail, per the recommendation of the author of the `stefanzweifel` action
  - Adding the trigger so that the workflow can be live-tested immediately

Note that if this PR addresses the problem, then immediately after a.) the `workflow_dispatch:` trigger will be removed, and b.) [inactive-members.json](https://github.com/hackforla/website/blob/gh-pages/github-actions/utils/_data/inactive-members.json) will be updated with the names of members removed during the first part of the failed Schedule Monthly run.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes
