### PR TITLE
Updated alt text for Sitemap Header Hero image

### DIFF
--- a/pages/sitemap.html
+++ b/pages/sitemap.html
@@ -15,7 +15,7 @@ permalink: /sitemap/
         </p>
     </div>
     <img class="header-hero-image" src="/assets/images/sitemap/sitemap-planning.svg"
-        alt="image of a person using a computer and mapping out a website">
+        alt="">
 </div>
 
 <!-- Page body -->


### PR DESCRIPTION
Fixes #6798 

### What changes did you make?
  - Removed alt text for header hero image on sitemap.html

### Why did you make the changes (we will use this info to test)?
  - Removed to create space for more clear and descriptive alt text

### Visual Changes
  - No visual changes were made in this code change
