### PR TITLE
Replace all instances of `Peer Led` to `Community Led` in .yml files

### DIFF
--- a/_data/internal/communities/engineering.yml
+++ b/_data/internal/communities/engineering.yml
@@ -11,7 +11,7 @@ alt: 'A computer screen shows a diagram used to manage code development'
 
 meeting-times: Thursdays 6:00-7:00 pm PT
 
-leadership-type: Peer Led
+leadership-type: Community Led
 leadership:
   - name: Micah Elm
     role: Co-lead

--- a/_data/internal/communities/ui-ux.yml
+++ b/_data/internal/communities/ui-ux.yml
@@ -11,7 +11,7 @@ alt: 'A board full of Post-it notes is used as a communication tool'
 
 meeting-times: Wednesdays 6:00-7:00 PM PT
 
-leadership-type: Peer Led
+leadership-type: Community Led
 leadership:
   - name: Aparna Gopal
     role: Co-lead


### PR DESCRIPTION
Fixes #6861

### What changes did you make?
  - Replaced "Peer Led" to "Community Led" in `_data/internal/communities/ui-ux.yml` and `_data/internal/communities/engineering.yml`.

### Why did you make the changes (we will use this info to test)?
  - To make the leadership types of the CoP's more coherent; picked "Community Led" to describe this leadership structure.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<ol>
<li>
<img width="707" alt="image" src="https://github.com/hackforla/website/assets/79176075/61a1bdff-ccad-4972-a7d4-ff459a7619e9">
</li>
<li>
<img width="683" alt="image" src="https://github.com/hackforla/website/assets/79176075/d5ba3abe-3b6a-4172-81c5-212490e321e8">
</li>
</ol>

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<ol>
<li>
<img width="701" alt="image" src="https://github.com/hackforla/website/assets/79176075/66585516-4af1-4413-a1e9-5059775d53b9">
</li>
<li>
<img width="698" alt="image" src="https://github.com/hackforla/website/assets/79176075/07b0532e-65cf-40d3-9e2a-7570245bbcee">
</li>
</ol>

</details>
