### PR TITLE
Improved Accessible Naming for Resource Icons in Project Pages

### DIFF
--- a/_includes/resource-card.html
+++ b/_includes/resource-card.html
@@ -2,9 +2,9 @@
 {% assign image = include.image %}
 {% assign name = include.name %}
 {% assign lowercaseName = include.name | downcase %}
+{% assign hyphenatedName = lowercaseName | replace: ' ', '-' %}
 
-
-<a href="{{ url }}" class='resource-link' target="_blank" rel="noopener noreferrer">
+<a href="{{ url }}" class='resource-link' target="_blank" rel="noopener noreferrer" aria-labelledby="resource-title-{{hyphenatedName}}">
     <li class='resource-card'>
         <!--Where the images will be-->
         <div {% if image %} class='resource-img resource-img-provided' {% else %} role="img" aria-label="{{name}}" class='resource-img' {% endif %}>
@@ -22,11 +22,11 @@
         </div>
         <div class='resource-body'>
             {% if lowercaseName == 'github' %}
-                <h4 class='resource-title'>
+                <h4 id="resource-title-{{hyphenatedName}}" class='resource-title'>
                     GitHub
                 </h4>
             {% else %}
-                <h4 class='resource-title'>
+                <h4 id="resource-title-{{hyphenatedName}}" class='resource-title'>
                     {{ name }}
                 </h4>
             {% endif %}


### PR DESCRIPTION
Fixes #6655 

### What changes did you make?
1. Added a `hyphenatedName` variable to correctly format the IDs used with `aria-labelledby`. 
2. Used `aria-labelledby` on the `<a>` tag to specify that its accessible name will be that of the `<h4>` tag. 
3. Added `id="resource-title-{{ hyphenatedName }}"` to the `<h4>` tags so that its accessible name is being referenced by the `<a>` tag. 

### Why did you make the changes (we will use this info to test)?
1. If I used `lowercaseName` instead, the aria-label on the `<h4>` tags remove the white spaces, making the ID specified by `aria-labelledby` and the ID on the `<h4>` tags unequal. 
2. To use `<h4>`'s accessible name rather than `<a>`'s child nodes, leading to duplicate accessible names.
3. To act as an accessible name reference to the `<a>` tag.

### Screenshots of Proposed Changes Of The Website
No visual changes.
