### PR TITLE
Standardize Slack channels using ID and archives: CONTRIBUTING.md Section 1.5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,7 +216,7 @@ git remote add upstream https://github.com/hackforla/website.git
 
 Docker is the recommended approach to quickly getting started with local development. Docker helps create a local/offline version of the hackforla.org website on your computer so you can test out your code before submitting a pull request.
 
-The recommended installation method for your operating system can be found [here](https://docs.docker.com/install/). <strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/messages/hfla-site/) if you have trouble installing docker on your system</em></strong>
+The recommended installation method for your operating system can be found [here](https://docs.docker.com/install/). <strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/archives/C4UM52W93/) if you have trouble installing docker on your system</em></strong>
 
 More on using Docker and the concepts of containerization:
 


### PR DESCRIPTION
Fixes #6848

### What changes did you make?
  - Change https://hackforla.slack.com/messages/hfla-site/ to https://hackforla.slack.com/archives/C4UM52W93/
  - Only in Section 1.5 on CONTRIBUTING.md
  - Tested on branch link

### Why did you make the changes (we will use this info to test)?
  - Change ONLY in Section 1.5 to link to Slack channel correctly
  - For Reviewers: Do not review changes locally, rather, review changes at https://github.com/dcotelessa/website-hackforla/blob/slack-channel-contributing-section-1.5-6848/CONTRIBUTING.md
 