### PR TITLE
Standardize Slack channels using ID in CONTRIBUTING.md - 6858

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,7 +310,7 @@ The extension can also be installed via the VS Code Marketplace website [here](h
 
 For developers who do not use VS Code, use the corresponding npm package, cspell, and those instructions can be found [here](https://www.npmjs.com/package/cspell).
 
-<strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/messages/hfla-site/) if you have trouble installing the VS Code extension or the cspell npm package on your system.</em></strong>
+<strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/archives/C4UM52W93/) if you have trouble installing the VS Code extension or the cspell npm package on your system.</em></strong>
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 ***


### PR DESCRIPTION
Fixes #6858 

### What changes did you make?
  - Changed the link for the `hfla-site` slack channel link to channel ID. (Line 313 In Contributing.MD) (Section 1.7)
 **From**
`...<strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/messages/hfla-site/) if you have trouble installing ...`
**This**
`...<strong><em>Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/archives/C4UM52W93/) if you have trouble installing ...`


### Why did you make the changes (we will use this info to test)?
  - For Reviewers: Do not review changes locally, rather, review changes at https://github.com/patelbansi3009/website/blob/standarsize-slack-channel-id-in-CONTRIBUTING.md-6858/CONTRIBUTING.md
  - To fix the reference to the hfla-site Slack channel in Section 1.7 of the CONTRIBUTING.md file to use the channel ID instead of the channel name, so that if the name gets changed, the link will still work. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

- No Visual Changes