### PR TITLE
Changed QA Validation URL in add-github-handle issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-github-handle.md
+++ b/.github/ISSUE_TEMPLATE/add-github-handle.md
@@ -11,7 +11,7 @@ assignees: ''
 ### Prerequisite
 1. Be a member of Hack for LA. (There are no fees to join.) If you have not joined yet, please follow the steps on our [Getting Started Page](https://www.hackforla.org/getting-started).
 2. Before you claim or start working on an issue, please make sure you have read our [How to Contribute to Hack for LA Guide](https://github.com/hackforla/website/blob/7f0c132c96f71230b8935759e1f8711ccb340c0f/CONTRIBUTING.md).
-   
+
 ### Overview
 We need to create a single variable `github-handle` to hold the github handle for each member of the leadership team. Eventually `github-handle` will replace the `github` and `picture` variables, reducing redundancy in the project file.
 
@@ -24,7 +24,7 @@ We need to create a single variable `github-handle` to hold the github handle fo
 with
 ```
 - name: [INSERT MEMBER NAME]
-  github-handle: 
+  github-handle:
 ```
 - [ ] Do not use a tab to indent `github-handle`. YAML doesn't allow tabs; it requires spaces.
 - [ ] Using docker, confirm that the appearance of the project webpage is unchanged at all screen sizes. The project webpage URL can be found below under Resources.
@@ -33,9 +33,9 @@ with
 - [ ] Release the dependency for this issue in #5441. If all the dependencies have been completed, close that issue.
 
 ### Resources/Instructions
-https://github.com/hackforla/website/wiki/project.md-file-template  
-https://jekyllrb.com/  
-For QA to validate change: https://github.com/hackforla/website/blob/gh-pages/[INSERT-PATH-TO-PROJECT-FILE]  
+https://github.com/hackforla/website/wiki/project.md-file-template
+https://jekyllrb.com/
+For QA to validate change: https://github.com/hackforla/website/blob/gh-pages/_projects/[INSERT_PROJECT_FILE]?plain=1
 Project Webpage: https://www.hackforla.org/projects/[INSERT-PROJECT-FILENAME-WITHOUT-.MD-EXTENSION]
 
 - This issue is part of #5441.


### PR DESCRIPTION
Fixes #6850 

### What changes did you make?
  - In VScode, located file `.github/ISSUE_TEMPLATE/add-github-handle.md`
 
Replaced 
```
For QA to validate change: https://github.com/hackforla/website/blob/gh-pages/[INSERT-PATH-TO-PROJECT-FILE]  
```
with
```
For QA to validate change: https://github.com/hackforla/website/blob/gh-pages/_projects/[INSERT_PROJECT_FILE]?plain=1
```
### Why did you make the changes (we will use this info to test)?
  - Changing the URL for QA validation in add-github-handle issue template allows it to default to code instead of preview
 ### For Reviewers
- Use this URL to check the updated issue template:[ URL of issue creation page for reviewer to check the URL change](https://github.com/ino-iosdev/website/issues/new?assignees=&labels=good+first+issue%2C+P-Feature%3A+Project+Info+and+Page%2C+ready+for+dev+lead%2C+role%3A+back+end%2FdevOps%2C+role%3A+front+end%2C+size%3A+0.25pt&projects=&template=add-github-handle.md&title=Add+github-handle+for+%5BINSERT+NAME%5D+in+%5BINSERT+PROJECT+FILE%5D)
### Screenshots of Proposed Changes Of The Website  (if any, please do not screenshot code changes)
- No visual change to the website