### PR TITLE
Update project profile: expunge assist(remove Curtis add Maria)

### DIFF
--- a/_projects/expunge-assist.md
+++ b/_projects/expunge-assist.md
@@ -7,6 +7,13 @@ image: /assets/images/projects/expunge-assist.png
 alt: 'Expunge Assist'
 image-hero: /assets/images/projects/expunge-assist-hero.png
 leadership:
+  - name: Maria Weissman
+    github-handle: mariaweissman
+    role: Product Manager, Project Manager
+    links:
+      slack: https://hackforla.slack.com/team/U06REA9H3FF
+      github: https://github.com/mariaweissman
+    picture: https://avatars.githubusercontent.com/mariaweissman
   - name: Analicia Mejia Mesinas
     github-handle: amejiamesinas
     role: Product Manager, UX Research
@@ -14,13 +21,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U04J34E73CG
       github: https://github.com/amejiamesinas
     picture: https://avatars.githubusercontent.com/amejiamesinas
-  - name: Curtis Barber
-    github-handle: CBx3000
-    role: Product Manager, Content
-    links:
-      slack: https://hackforla.slack.com/team/U05RZAETCQ4
-      github: https://github.com/CBx3000
-    picture: https://avatars.githubusercontent.com/CBx3000
   - name: Mireya V. Aviles
     github-handle: vanessaavviles
     role: Product Manager, Design


### PR DESCRIPTION
Fixes #6866 

### What changes did you make?
  - Removed Curts Barbers' profile and added Maria Weissmans' profile in Expunge Assist file.

### Why did you make the changes?
  - To keep project information up to date so that visitors to the website can find accurate information.

### Screenshots of Proposed Changes Of The Website 
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Before](https://github.com/hackforla/website/assets/79749200/b293f154-fb57-45a3-b935-832c1b572b85)



</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![After](https://github.com/hackforla/website/assets/79749200/893cd8fb-442e-46f3-8aa4-7001c572a94f)

</details>
