### PR TITLE
Fix Capitalization of "Slack" in CONTRIBUTING.MD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The following is a set of guidelines for contributing to the website repository,
 
 **If you need a text editor to work on code, [VS Code](https://code.visualstudio.com/download) is recommended by the team, but feel free to use a text editor of your choice.**
 
-**If you have any other questions about your contributing process, feel free to reach out to the team in the [#hfla-site](https://hackforla.slack.com/archives/C4UM52W93) slack channel.**
+**If you have any other questions about your contributing process, feel free to reach out to the team in the [#hfla-site](https://hackforla.slack.com/archives/C4UM52W93) Slack channel.**
 <br><br>
 
 ## **Table of Contents**


### PR DESCRIPTION
Fixes #6918

### What changes did you make?
  - capitalize slack to Slack on line 11 of CONTRIBUTING.md

### Why did you make the changes (we will use this info to test)?
  - For Reviewers: Do not review changes locally, rather, review changes at https://github.com/dcotelessa/website-hackforla/blob/fix-capitalization-slack-6918/CONTRIBUTING.md

No visuals on websites changed.