### PR TITLE
Capitalize 'slack' on line 347 in CONTRIBUTING.MD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,7 +344,7 @@ All website team members are required to attend at least 1 team meeting in a wee
 
 All website team members are expected to devote a minimum of 6 hours per week while working on various assignments during their entire tenure at the website team (excluding week offs and vacations).
 
-Also, please let the tech leadership team know (through a slack message in the hfla-site channel as well as an @ mention in a comment of the issue that you would be working on) if you are planning to take a week off or a longer vacation.
+Also, please let the tech leadership team know (through a Slack message in the hfla-site channel as well as an @ mention in a comment of the issue that you would be working on) if you are planning to take a week off or a longer vacation.
 
 Prior to joining [another project within Hack for LA](https://www.hackforla.org/projects/), developers should gain the following experience:
 * Setting up your local environment from a CONTRIBUTING file


### PR DESCRIPTION
Fixes #6931 

**For Reviewers**: Do not review changes locally, rather, review changes at https://github.com/muninnhugin/hfla-website/blob/capitalize-slack-in-contributing-6931/CONTRIBUTING.md

### What changes did you make?
  - Capitalize the word 'slack' on line 347 in CONTRIBUTING.MD

### Why did you make the changes (we will use this info to test)?
  - To fix capitalization when referring to the app Slack

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/37560463/f25a68b6-51d2-4887-8fa6-6ca423cede93)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/37560463/c7a5d770-e64b-4064-a7e2-c3c79691ca7f)

</details>
