### PR TITLE
Fix Capitalization of "Slack" in CONTRIBUTING.MD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -579,7 +579,7 @@ If you do not see the changes you applied when you run `docker-compose up`, **do
 <br><br>
 
 - If the above steps did not resolve your issue, run through the first three steps again, but try resetting your browser's cache before restarting docker (you can also try running http://localhost:4000 in another browser).
-- If you still do not see your changes after trying these steps, please feel free to reach out to the team in the [#hfla-site](https://hackforla.slack.com/archives/C4UM52W93) slack channel, or bring up your issue in a dev meeting.
+- If you still do not see your changes after trying these steps, please feel free to reach out to the team in the [#hfla-site](https://hackforla.slack.com/archives/C4UM52W93) Slack channel, or bring up your issue in a dev meeting.
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 


### PR DESCRIPTION
Fixes #6932

### What changes did you make?
  - capitalize slack to Slack on line 582 of CONTRIBUTING.md
  - Do not change any other lines in the file.
  - Reviewed changes on URL below

### Why did you make the changes (we will use this info to test)?
  - For Reviewers: Do not review changes locally, rather, review changes at https://github.com/dcotelessa/website-hackforla/blob/fix-capitalization-slack-6932/CONTRIBUTING.md

### Screenshots of Proposed Changes Of The Website
- No visual changes on the website
