### PR TITLE
Truncate contributor's name in filter tag with ellipsis on Toolkit page

### DIFF
--- a/_sass/components/_toolkit.scss
+++ b/_sass/components/_toolkit.scss
@@ -61,8 +61,11 @@
     flex-direction: column;
     
     .filter-tag {
-        overflow-x: auto;
+        overflow-x: hidden;
         overflow-y: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 300px;
     }
     
     a {

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -197,9 +197,10 @@ border-radius: 2.5px;
   font-size: 15px;
   text-transform: capitalize;
 
-  &::after {
+  &::before {
     content: "\00d7";
-    padding-left: 0.5em;
+    padding-left: 0.75em;
+    float: right;
   }
 
   &:hover,


### PR DESCRIPTION
Fixes #6787
### What changes did you make?
  - Added "text-overflow: ellipsis" and "white-space: nowrap" styles to .filter-tag element in _toolkit.scss to truncate a contributor's name with ellipsis
  - Changed "max-width" value from "fit-content" to "300px" to make sure truncation of longer names occurs
  - Made the "::after" cross element into a "::before" element that floats right so that it shows up when the contributor's name is truncated

### Why did you make the changes (we will use this info to test)?
  - To provide a visual cue when a contributor's name is truncated

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-06-22 at 20-46-27 Toolkit - Hack for LA](https://github.com/hackforla/website/assets/15069166/e801b3d8-cf8e-4c7b-9ae6-3b5d165c4e1c)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-06-22 at 20-46-17 Toolkit - Hack for LA](https://github.com/hackforla/website/assets/15069166/a4410f87-7517-41f0-8c87-e90e17ae3980)

</details>
