### PR TITLE
Updated Role for Will Gillis on Website Project Profile

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -26,7 +26,7 @@ leadership:
       github: 'https://github.com/roslynwythe'
     picture: https://avatars.githubusercontent.com/roslynwythe
   - name: Will Gillis
-    role: Merge Team
+    role: Developer Co-Lead
     links:
       slack: 'https://hackforla.slack.com/team/U043LGHSZFT'
       github: 'https://github.com/t-will-gillis'


### PR DESCRIPTION
Fixes #7060 

### What changes did you make?
  - changed role for Will Gillis from Merge Team to Developer Co-Lead in _projects/website.md

### Why did you make the changes (we will use this info to test)?
  - to update project information on website project page

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/157540251/3de91f8a-fa24-4108-b70c-b7a55db8e4ec)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/157540251/6adff66a-4f1d-4bb3-a167-746f7914dd4d)

</details>
