### PR TITLE
Updated spell checker to ignore member's names

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -31,5 +31,8 @@
       "redirections/",
       "surveys/",
       "google-apps-scripts/"
+  ],
+  "ignoreRegExpList": [
+      "\\- name:.*$"
   ]
 }


### PR DESCRIPTION
Fixes #7010

### What changes did you make?
  - Updated the code spell check configuration file so the spell checker excludes lines matching "- name:".

### Why did you make the changes (we will use this info to test)?
  - So that the spell checker can avoid checking lines with " - name:" to reduce the number of false positives ("unknown word") in the spell check.
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>No visual changes to website</summary>

</details>


