### PR TITLE
Add 'Leadership Option' to Issue Template for CoP Information Update

### DIFF
--- a/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
+++ b/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
@@ -34,7 +34,7 @@ body:
         - "N/A"
         - "Mentor Led"
         - "Community Led"
-      default: "N/A"
+      default: 0
       description: "Select the type of leadership if applicable."
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
+++ b/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
@@ -20,9 +20,22 @@ body:
   - type: markdown
     attributes:
       value: "Change Description: NO"
-  - type: markdown
+  - type: dropdown
     attributes:
-      value: "Change Leadership Type: NO"
+      label: "Change Leadership Type"
+      options:
+          - "YES"
+          - "NO"
+      description: "If YES on Change Leadership Type, choose the Leadership Type; if NO, leave the field with the NA value:"
+  - type: dropdown
+    attributes:
+      label: "Leadership Type"
+      options:
+        - "N/A"
+        - "Mentor Led"
+        - "Community Led"
+      default: "N/A"
+      description: "Select the type of leadership if applicable."
   - type: markdown
     attributes:
       value: "Change Slack Link: NO"

--- a/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
+++ b/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
@@ -22,8 +22,8 @@ body:
     attributes:
       label: "Change Leadership Type"
       options:
-          - "YES"
-          - "NO"
+        - "YES"
+        - "NO"
       description: "If YES on Change Leadership Type, choose the Leadership Type; if NO, leave the field with the NA value:"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
+++ b/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
@@ -1,7 +1,6 @@
 name: Communities of Practice information updates
 description: CoP leads use this issue to make changes to Leadership members and contact info
-title: 'Communities of Practice information updates: [INSERT NAME OF Community of
-  Practice]'
+title: 'Communities of Practice information updates: [INSERT NAME OF Community of Practice]'
 labels: ['role: product', 'P-Feature: Communities of Practice', 'time sensitive', 'Complexity: Missing', 'size: missing']
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
+++ b/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
@@ -3,7 +3,6 @@ description: CoP leads use this issue to make changes to Leadership members and 
 title: 'Communities of Practice information updates: [INSERT NAME OF Community of
   Practice]'
 labels: ['role: product', 'P-Feature: Communities of Practice', 'time sensitive', 'Complexity: Missing', 'size: missing']
-
 body:
   - type: markdown
     attributes:
@@ -27,6 +26,8 @@ body:
           - "YES"
           - "NO"
       description: "If YES on Change Leadership Type, choose the Leadership Type; if NO, leave the field with the NA value:"
+    validations:
+      required: true
   - type: dropdown
     attributes:
       label: "Leadership Type"


### PR DESCRIPTION
Fixes #6862 

### What changes did you make?
  - Changed `Leadership Type: NO` to have a YES/NO dropdown
  - Added the following text under the dropdown:
    - `If YES on Change Leadership Type, choose the Leadership Type; if NO, leave the field with the NA value:`
  - Added a dropdown directly below the `Leadership Type` dropdown with the following values:
    - `N/A`
    - `Mentor Led`
    - `Community Led`
  - Set `N/A` as the default value

### Why did you make the changes (we will use this info to test)?
  - To allow CoP co-leads to make issues to update their CoP's details

### For Reviewers
- Use this URL to check the updated issue template: [CoP Issue Template](https://github.com/DrAcula27/website/issues/new?assignees=&labels=role%3A+product%2CP-Feature%3A+Communities+of+Practice%2Ctime+sensitive%2CComplexity%3A+Missing%2Csize%3A+missing&projects=&template=communities-of-practice-information-updates.yml&title=Communities+of+Practice+information+updates%3A+%5BINSERT+NAME+OF+Community+of+Practice%5D)

### Screenshots of Proposed Changes Of The Website  (if any, please do not screenshot code changes)
- No visual changes to the website

### Resources
- [testing issue templates](https://github.com/hackforla/website/issues/4786#issuecomment-1670584024)
  - _Note_: The following steps were skipped per @roslynwythe 
    - Browse to the Issues page, then click Labels
    - Create labels corresponding to each label that was listed in the updated issue template. The color of the labels don't have to match those on the hackforla/website repository, but the text of the labels must match exactly.
