### PR TITLE
Update CONTRIBUTING.md Section 2.7.d with correct stream branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -634,10 +634,10 @@ git commit -m “insert message here”
 
 #### **2.7.d Working on an issue (4): Pulling from upstream before you push**
 
-**IMPORTANT:** Before you push your local commits to your repository, sync your fork to the main Hack For LA website repository. `git pull upstream` will ensure that your local repository is up-to-date with the main site:
+**IMPORTANT:** Before you push your local commits to your repository, sync your fork to the main Hack For LA website repository. `git pull upstream gh-pages` will ensure that your local repository is up-to-date with the main site:
 
 ```bash
-git pull upstream
+git pull upstream gh-pages
 ```
 You can also sync your fork directly on GitHub by clicking "Sync Fork" at the right of the screen and then clicking "Update Branch"
 


### PR DESCRIPTION
Fixes #6581

### What changes did you make?
  - Replace `git pull upstream` with `git pull upstream gh-pages` within Section 2.7.d of CONTRIBUTING.md where the branch was not properly specified.
  - Once pushed to a branch, tested to ensure changes are visible.

### Why did you make the changes (we will use this info to test)?
  - The current documentation in Section 2.7d does not provide an upstream branch for the user to pull from prior to pushing their code, and results in an error because a branch was not specified.
  - We needed to update this code to include the correct upstream branch.
  - For Reviewers: Do not review changes locally, rather, review changes at https://github.com/dcotelessa/website-hackforla/blob/update-contibuting-section-2-7-d-6581/CONTRIBUTING.md

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/website/assets/5404705/e0c06fa3-bbe3-4cf3-9d58-f26a649615db)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/website/assets/5404705/bf80a0ed-5d64-4dc1-8546-a2ca26a91777)

</details>
