### PR TITLE
Bug fix `find-linked-issue.js` for "Schedule Friday"

### DIFF
--- a/github-actions/utils/find-linked-issue.js
+++ b/github-actions/utils/find-linked-issue.js
@@ -1,3 +1,8 @@
+/**
+ * Function that returns the number of a linked issue (if exists)
+ * @param {String} text       - the text to search for keywords
+ * @returns                   - issueNumber, or false
+ */
 function findLinkedIssue(text) {
     // Create RegEx for capturing KEYWORD #ISSUE-NUMBER syntax (i.e. resolves #1234)
     const KEYWORDS = ['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved'];
@@ -8,10 +13,17 @@ function findLinkedIssue(text) {
 
     // Receive and unpack matches into an Array of Array objs
     let re = new RegExp(reArr.join('|'), 'gi');
-    let matches = text.matchAll(re);
-    matches = [...matches];
-
-    // If only one match is found, return the issue number. Else return false. Also console.log results.
+    let matches = [];
+    
+    // Find matches or throw error
+    try {
+        matches = text.matchAll(re);
+        matches = [...matches]; 
+    } catch (err) {
+        console.error(err);
+    }
+    
+    // If only one match is found, return the issue number
     if (matches.length == 1) {
         const issueNumber = matches[0][0].match(/\d+/);
         return issueNumber[0];


### PR DESCRIPTION
Fixes #7080 

### What changes did you make?
  - Added error catching to [find-linked-issue.js](https://github.com/hackforla/website/blob/gh-pages/github-actions/utils/find-linked-issue.js) at line 11 `let matches = text.matchAll(re)`
  - Same file, added function comments


### Why did you make the changes (we will use this info to test)?
  - Error catching was added because for the last several weeks, the "Schedule Friday" workflow has stopped running while reviewing the timeline for issue 6882. Specific details are on #7080.
  - The error catching does not change any evaluation, its purpose is to catch the TypeError raised when issue 6882 is evaluated so that the workflow can run to completion.
  - Comments help others to understand the intended actions of the function.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- No visual changes to website

#### Testing results and explanation:
- Schedule Friday [workflow log](https://github.com/t-will-gillis/website/actions/runs/9914349582/job/27393251406). 
  - The workflow is scanning all flagged issues. Line 4891 (see below) shows that the same `TypeError` is caught for issue 6882. In the current HfLA ["Schedule Friday" workflows](https://github.com/hackforla/website/actions/runs/9903883772), this causes a fatal error, however with the code edits this workflow run (see below) continues to completion as as intended. 
  - (Note that line 4906 shows a `RequestError`. This is due to a token error/ lack of permissions because this workflow is running from a personal repo against issues in the HfLA repo. This is not a concern because the `RequestError` will not occur when the workflow runs from the HfLA repo.)
  
  <details>
  <img width="1165" alt="Screenshot 2024-07-14 141727" src="https://github.com/user-attachments/assets/0ae1a9c8-ee74-4565-86d5-a45bdc0cd250">

  </details>