### PR TITLE
Update "Schedule Friday" workflow to account for July, Dec. breaks

### DIFF
--- a/.github/workflows/schedule-fri-0700.yml
+++ b/.github/workflows/schedule-fri-0700.yml
@@ -1,8 +1,9 @@
 name: Schedule Friday 0700
 
+# This action runs at 7:00 UTC/ 0:00 PDT (midnight) every Friday, except during July and December.
 on:
   schedule:
-    - cron:  '0 7 * * 5'
+    - cron:  '0 7 * 1-6,8-11 5'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Fixes #7101

### What changes did you make?
  - In schedule-fri-0700.yml, changed 
```
    - cron:  '0 7 * * 5'
```
to
```
    - cron:  '0 7 * 1-6,8-11 5'
```
  - In same file, added comment on line 3:
```
# This action runs at 7:00 UTC/ 0:00 PDT (midnight) every Friday, except during July and December.
```

### Why did you make the changes (we will use this info to test)?
  - Prevent workflow from sending reminders to website devs during July and December breaks

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes
