### PR TITLE
FIx capitalization of GitHub in ui-ux.yml

### DIFF
--- a/_data/internal/communities/ui-ux.yml
+++ b/_data/internal/communities/ui-ux.yml
@@ -46,7 +46,7 @@ leadership:
 links:
   - name: Slack
     url: https://app.slack.com/client/T04502KQX/C017ESHSMNG/
-  - name: Github
+  - name: GitHub
     url: https://github.com/hackforla/UI-UX
 
 recruiting-message:


### PR DESCRIPTION
Fixes #7113

### What changes did you make?
 - Corrected the capitalization of "GitHub" in _data/internal/communities/ui-ux.yml.
 - Ensured consistency of "GitHub" across the UI/UX community section.
 - Verified that no other aspects of the webpage are affected by this change.

### Why did you make the changes (we will use this info to test)?
  -To standardize the correct capitalization of the term "GitHub" across the project files.
 - To maintain a professional and consistent appearance in the documentation and website.
 - To address the issue reported in #7113, ensuring that "GitHub" is correctly capitalized throughout the website.

