### PR TITLE
Add github-handle to leadership team in guides-team project

### DIFF
--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -15,6 +15,7 @@ leadership:
       github: 'https://github.com/ExperimentsInHonesty'
     picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
   - name: Sarah Edwards
+    github-handle:
     role: Product Manager
     links:
       slack: 'https://hackforla.slack.com/team/U03KBU16APN'


### PR DESCRIPTION
## Summary

This PR adds the `github-handle` variable for each member of the leadership team in the `_projects/guides-team.md` file, addressing issue #7103.

## Changes Made

- Added `github-handle` for each leadership team member.
- Verified that the appearance of the project webpage is unchanged.

## Verification Steps

1. Run Docker to ensure the project webpage appearance is unchanged at all screen sizes.
2. Visit the project webpage: [https://www.hackforla.org/projects/guides-team](https://www.hackforla.org/projects/guides-team).

## Related Issues

- Epic: Create issues to add `github-handle` to leadership teams #7103
