### PR TITLE
Update cspell.json to ignore members' github handles

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -33,6 +33,7 @@
       "google-apps-scripts/"
   ],
   "ignoreRegExpList": [
-      "\\- name:.*$"
+      "\\- name:.*$",
+      "github-handle:.*$"
   ]
 }


### PR DESCRIPTION
Fixes #7099

### What changes did you make?
  - Updated spell check `cspell.json` to ignore members' GitHub handles.

### Why did you make the changes (we will use this info to test)?
  - To ignore members' GitHub handles, which will reduce the number of false positives like: *Unkown word*

### Screenshots of Proposed Changes of The Website

<details>
<summary>Visuals before changes are applied</summary>

- No visual changes.

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
- No visual changes.

</details>
