### PR TITLE
Updated "Schedule Monthly" to Account for July Break

### DIFF
--- a/.github/workflows/schedule-monthly.yml
+++ b/.github/workflows/schedule-monthly.yml
@@ -1,9 +1,9 @@
 name: Schedule Monthly
 
-# This action runs at 11:00 UTC/ 4:00 PDT on the first day of every month except January.
+# This action runs at 11:00 UTC/ 4:00 PDT on the first day of every month except January and August.
 on:
   schedule:
-    - cron:  0 11 1 2-12 *
+    - cron:  0 11 1 2-7,9-12 *
 
 jobs:
   Trim_Contributors:

--- a/github-actions/trigger-schedule/list-inactive-members/get-contributors-data.js
+++ b/github-actions/trigger-schedule/list-inactive-members/get-contributors-data.js
@@ -9,12 +9,12 @@ var context;
 const maintTeam = 'website-maintain';
 const botMembers = ['elizabethhonest', 'hfla-website-checklist', 'HackforLABot'];
 
-// Set date limits: we are sorting inactive members into groups to warn after 1 month and remove after 2 months.
-// Since the website team takes off the month of December, the January 1st run is skipped (via `schedule-monthly.yml`). 
-// The February 1st run keeps the 1 month inactive warning, but changes removal to 3 months inactive (skipping December).
+// Set date limits: we are sorting inactive members into groups to notify after 1 month and remove after 2 months.  
+// Since the teams take off December and July, the Jan. 1st and Aug. 1st runs are skipped (via `schedule-monthly.yml`). 
+// The Feb. 1st and Sept. 1st runs account for skipped months: 'oneMonth' & 'twoMonths' = 2 & 3 months respectively
 let today = new Date();
-let oneMonth = (today.getMonth() == 1) ? 2 : 1;            // If month is "February" == 1, then oneMonth = 2 months ago
-let twoMonths = (today.getMonth() == 1) ? 3 : 2;           // If month is "February" == 1, then twoMonths = 3 months ago
+let oneMonth = (today.getMonth() === 1 || today.getMonth() === 8) ? 2 : 1;
+let twoMonths = (today.getMonth() === 1 || today.getMonth() === 8) ? 3 : 2;
 
 let oneMonthAgo = new Date();                              // oneMonthAgo instantiated with date of "today"
 oneMonthAgo.setMonth(oneMonthAgo.getMonth() - oneMonth);   // then set oneMonthAgo from "today"


### PR DESCRIPTION
Fixes #7083 

### What changes did you make?
  - Updated the cron job in schedule-monthly.yml to skip August 1st
  - Updated oneMonth and twoMonths variables in get-contributors-data.js for September run

### Why did you make the changes (we will use this info to test)?
  - To account for break in July so that members are not removed for inactivity during the break

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No visual changes to the website.
