### PR TITLE
Replace `Github` with `GitHub`

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -98,7 +98,7 @@ permalink: /getting-started
                 </br>
                     <div class="list-container">
                         <img class="step-img-icon-git" src="assets/images/getting-started/join-2.png" alt="" />
-                        <li class="g-s-list">Receive access to the Google Drive and Github repository by sending a Slack message of your Github username and Gmail address to a CoP lead. <img class="info-icon" src="assets/images/getting-started/information.png" alt="">
+                        <li class="g-s-list">Receive access to the Google Drive and GitHub repository by sending a Slack message of your GitHub username and Gmail address to a CoP lead. <img class="info-icon" src="assets/images/getting-started/information.png" alt="">
                         </li>
                     </div>
                     </br>


### PR DESCRIPTION
### THIS PR WAS MISTAKENLY CREATED, PLEASE DISREGARD
---
Fixes #7118 

### What changes did you make?
  - Replaced instances of `Github` with `GitHub` in `pages/getting-started.html`

### Why did you make the changes (we will use this info to test)?
  - As GitHub is a company, we want to make sure that we spell out its name correctly consistently across the website to avoid confusion.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/e2457cab-3da4-4266-9dea-40b91d111620)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](https://github.com/user-attachments/assets/0fb1ee34-8b19-4863-a5dd-248ea62318a5)

</details>

### Additional Information:
> Per this issue's request:
> Write a test procedure, in a comment, and then use it to test the change. Include a link to this comment in your PR.  

 - https://github.com/hackforla/website/issues/7118#issuecomment-2229527848

