### PR TITLE
Refactor img Tag in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -447,7 +447,7 @@ Once you find an issue you want to work on, you need to self-assign to claim it 
 <details>
   <summary><strong>Click here</strong> to see how you assign & unassign yourself to an issue</summary>
   <p><strong>Assign/Unassign demo</strong></p>
-  <img src="https://user-images.githubusercontent.com/21162229/137636320-e96ef70d-3c85-405e-90d2-ee7b3bba071f.gif" />
+  <img src="https://user-images.githubusercontent.com/21162229/137636320-e96ef70d-3c85-405e-90d2-ee7b3bba071f.gif">
 </details>
 
 ##### **i. If you want to to self assign an issue:**


### PR DESCRIPTION
Fixes #7096 

### What changes did you make?
  - Removed a closing slash from the img tag on line 450

### Why did you make the changes (we will use this info to test)?
  - This change makes the tag more consistent with HackForLA's preferred style

For Reviewers: Do not test changes locally, rather test changes at https://github.com/TheManTheMythTheGameDev/website/blob/img-tag-refactor-7096/CONTRIBUTING.md

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

Stylistic change. No visual changes to the website.
