### PR TITLE
PR Added github-handle for Sarah Edwards in projects file

### DIFF
--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -9,6 +9,7 @@ alt: 'Guides Team'
 image-hero: /assets/images/projects/guides-team-hero.jpg
 leadership:
   - name: Bonnie Wolfe
+    github-handle:
     role: Agile Coach
     links:
       slack: 'https://hackforla.slack.com/team/UE1UG1YFP'

--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -9,7 +9,6 @@ alt: 'Guides Team'
 image-hero: /assets/images/projects/guides-team-hero.jpg
 leadership:
   - name: Bonnie Wolfe
-    github-handle:
     role: Agile Coach
     links:
       slack: 'https://hackforla.slack.com/team/UE1UG1YFP'

--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -9,13 +9,13 @@ alt: 'Guides Team'
 image-hero: /assets/images/projects/guides-team-hero.jpg
 leadership:
   - name: Bonnie Wolfe
-    github-handle:
     role: Agile Coach
     links:
       slack: 'https://hackforla.slack.com/team/UE1UG1YFP'
       github: 'https://github.com/ExperimentsInHonesty'
     picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
   - name: Sarah Edwards
+    github-handle:
     role: Product Manager
     links:
       slack: 'https://hackforla.slack.com/team/U03KBU16APN'


### PR DESCRIPTION
Fixes #7103 

This PR adds the github-handle variable for each member of the leadership team in the guides-team file, addressing issue https://github.com/hackforla/website/issues/7103.

### What changes did you make?
  - Added github-handle variable for leadership team member Sarah Edwards.
  
  

### Why did you make the changes (we will use this info to test)?
  - To reduce redundancy in project file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - No visual changes. 