### PR TITLE
Replace 'Github' with 'GitHub' in engineering.yml

### DIFF
--- a/_data/internal/communities/engineering.yml
+++ b/_data/internal/communities/engineering.yml
@@ -41,7 +41,7 @@ leadership:
 links:
   - name: Slack
     url: https://app.slack.com/client/T04502KQX/C01CU709SER
-  - name: Github
+  - name: GitHub
     url: https://github.com/hackforla/engineering
   
 recruiting-message: 


### PR DESCRIPTION
Fixes #7115

### What changes did you make?
  - In `_data/internal/communities/engineering.yml`, replaced `- name: Github` with `- name: GitHub` on line 44

### Why did you make the changes (we will use this info to test)?
  - Make sure company name GitHub displays with proper capitalization throughout the website

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

No visual changes

### Testing
The engineering.yml file is used to populate the Engineering card template on the Communities of Practice page (\pages\communities-of-practice.html). However, the template never references the `- name: GitHub` element that has been edited. Therefore, there should be no visual changes to the page.

**To test:**

- Follow Step 3 in [How to Review Pull Requests](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests#Step3) to run the updated website

- Compare the Communities of Practice page "http://localhost:4000/communities-of-practice" to the live page on the HfLA website "http://www.hackforla.org/communities-of-practice"

  - Check the Engineering card and verify there are no visual differences
  
  - View the page source for both versions and verify that the contents of the div containing the Slack and GitHub link buttons in the Engineering card are the same, specifically the titles of the button elements and the link addresses
