### PR TITLE
Replace Github with GitHub in project-managment.yml

### DIFF
--- a/_data/internal/communities/project-management.yml
+++ b/_data/internal/communities/project-management.yml
@@ -23,7 +23,7 @@ leadership:
 links:
   - name: Slack
     url: https://app.slack.com/client/T04502KQX/C010LNXH2JY/details/
-  - name: Github
+  - name: GitHub
     url: https://github.com/hackforla/product-management
 
 recruiting-message:


### PR DESCRIPTION
Fixes #7117

### What changes did you make?
  - Replaced `- name: Github` with `- name: GitHub` in `_data/internal/communities/project-management.yml`
 

### Why did you make the changes (we will use this info to test)?
  - To display the company name correctly throughout the website.

### Screenshots of Proposed Changes to the Website
- No visual changes

### Test
- Since the element `- name: GitHub` is not directly referenced in any files, there should be no visual changes.

1. Follow the steps from [How to review Pulll requests](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests#Step3) section to view the changes locally.
2. Compare the `Project/Product Management` card on the local website at [http://localhost:4000/communities-of-practice](http://localhost:4000/communities-of-practice) to the live website at [http://www.hackforla.org/communities-of-practice](http://www.hackforla.org/communities-of-practice) and verify that there are no differences.
