### PR TITLE
Replace 'Github' to 'GitHub' in github.md

### DIFF
--- a/redirections/github.md
+++ b/redirections/github.md
@@ -1,7 +1,7 @@
 ---
 # https://www.hackforla.org/github redirects to -> https://www.github.com/hackforla
 layout: redirect
-title: Github
+title: GitHub
 permalink: /github/
 redirect_to: https://www.github.com/hackforla
 ---


### PR DESCRIPTION
Fixes #7110

### What changes did you make?
  - Change 'Github' to 'GitHub' in `redirections/github.md`

### Why did you make the changes (we will use this info to test)?
  - Make sure company name GitHub displays with proper capitalization throughout the website
  
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - No visual changes

### Connected file
  - The github.md is used to redirect the link [https://www.hackforla.org/github](https://www.hackforla.org/github) to -> [https://www.github.com/hackforla](https://www.github.com/hackforla) in the `_layouts/redirect.html` page. However, the template never references the `title: Github` element that has been edited. Therefore, there should be no visual changes to the page, and it redirects correctly as intended. 

### Test
  - Compare the [http://localhost:4000/github](http://localhost:4000/github) to the live page on the HfLA website [https://www.hackforla.org/github](https://www.hackforla.org/github)
  - Check for visual changes, found none
  - Redirects correctly to the github link

