### PR TITLE
Update the meeting times on the CoP page

### DIFF
--- a/_data/internal/communities/data-science.yml
+++ b/_data/internal/communities/data-science.yml
@@ -9,8 +9,6 @@ location:
 image: /assets/images/communities-of-practice/data.jpg
 alt: 'A person uses a laptop to review a data dashboard'
 
-meeting-times: Mondays 7:00-8:00 pm PT
-
 leadership-type: Mentor Led
 leadership:
   - name: Sophia Alice

--- a/_data/internal/communities/engineering.yml
+++ b/_data/internal/communities/engineering.yml
@@ -9,8 +9,6 @@ location:
 image: /assets/images/communities-of-practice/engineering.jpg
 alt: 'A computer screen shows a diagram used to manage code development'
 
-meeting-times: Thursdays 6:00-7:00 pm PT
-
 leadership-type: Community Led
 leadership:
   - name: Micah Elm

--- a/_data/internal/communities/ops.yml
+++ b/_data/internal/communities/ops.yml
@@ -9,8 +9,6 @@ location:
 image: /assets/images/communities-of-practice/ops.jpg
 alt: 'A dramatic closeup of a screen filled with code'
 
-meeting-times: Wednesdays 6:00-7:00 pm PT
-
 leadership-type: Community Led
 leadership:
   - name: Chelsey Beck

--- a/_data/internal/communities/project-management.yml
+++ b/_data/internal/communities/project-management.yml
@@ -9,8 +9,6 @@ location:
 image: /assets/images/communities-of-practice/product.jpg
 alt: 'Several people around a small table listen intently as one person speaks.'
 
-meeting-times: Fridays 12:00-1:00 pm PT
-
 leadership-type: Mentor Led
 leadership:
   - name: Bonnie Wolfe

--- a/_data/internal/communities/ui-ux.yml
+++ b/_data/internal/communities/ui-ux.yml
@@ -9,8 +9,6 @@ location:
 image: /assets/images/communities-of-practice/uiux.jpg
 alt: 'A board full of Post-it notes is used as a communication tool'
 
-meeting-times: Wednesdays 6:00-7:00 PM PT
-
 leadership-type: Community Led
 leadership:
   - name: Aparna Gopal

--- a/assets/js/communities-of-practice.js
+++ b/assets/js/communities-of-practice.js
@@ -29,7 +29,7 @@ document.addEventListener("DOMContentLoaded", function() {
             // Make it plural form for the day
             const dayOfWeekPlural = dayOfWeek + 's';
 
-            return `${dayOfWeekPlural} ${formattedStartTime}-${formattedEndTime} PT`;
+            return `${dayOfWeekPlural} ${formattedStartTime} - ${formattedEndTime} PT`;
         } else {
             return "TBD";
         }

--- a/assets/js/communities-of-practice.js
+++ b/assets/js/communities-of-practice.js
@@ -1,0 +1,60 @@
+---
+---
+
+{% assign vrmsData = site.data.external.vrms_data %}
+const vrmsData = JSON.parse(decodeURIComponent("{{ vrmsData | jsonify | uri_escape }}"));
+
+document.addEventListener("DOMContentLoaded", function() {
+    // Function to retrieve and format meeting times
+    function getMeetingTimes(projectName) {
+        const project = vrmsData.find(event => 
+            event.project && event.project.name.startsWith("Community of Practice") && event.project.name.includes(projectName)
+        );
+
+        if (project) {
+            // Convert to Pacific Time
+            const options = { timeZone: "America/Los_Angeles", hour: 'numeric', minute: 'numeric', hour12: true };
+            const startTime = new Date(project.startTime);
+            const endTime = new Date(project.endTime);
+            
+            // Format in Pacific Time
+            const formatter = new Intl.DateTimeFormat('en-US', options);
+            const formattedStartTime = formatter.format(startTime);
+            const formattedEndTime = formatter.format(endTime);
+            
+            // Get the day of the week
+            const dayFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'long', timeZone: 'America/Los_Angeles' });
+            const dayOfWeek = dayFormatter.format(startTime);
+
+            // Make it plural form for the day
+            const dayOfWeekPlural = dayOfWeek + 's';
+
+            return `${dayOfWeekPlural} ${formattedStartTime}-${formattedEndTime} PT`;
+        } else {
+            return "TBD";
+        }
+    }
+
+    // sets the meeting times for each community
+    function setMeetingTimes() {
+        const communities = document.querySelectorAll('[id^="meeting-times-"]');
+
+        communities.forEach(element => {
+            const communityName = element.id.replace('meeting-times-', '').replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+            
+            // Map community names to their corresponding projectnames
+            let projectName = "";
+            if (communityName === "Project/Product Management") {
+                projectName = "Product Management";
+            } else if (communityName === "Ui/Ux") {
+                projectName = "UI/UX";
+            } else {
+                projectName = communityName;
+            }
+
+            element.innerHTML = getMeetingTimes(projectName);
+        });
+    }
+
+    setMeetingTimes();
+});

--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -37,8 +37,7 @@ permalink: /communities-of-practice
             <p>{{ community[1].description}}</p>
             <p>
                 <strong>Meeting Times:</strong> 
-                {% if community[1].meeting-times %}{{ community[1].meeting-times }}{% else %}TBD{% endif %}<br> 
-            </p>
+                <span id="meeting-times-{{ community[1].name | replace: ' ', '-' | downcase }}"></span><br>            </p>
             <p>
                 <strong>Leadership Type:</strong> 
                 {% if community[1].leadership-type %}{{ community[1].leadership-type }}{% else %}TBD{% endif %}
@@ -96,3 +95,4 @@ permalink: /communities-of-practice
     {% endif %}
     {% endfor %}
 </section>
+<script type="module" src="assets/js/communities-of-practice.js"></script>


### PR DESCRIPTION
Fixes #7072

### What changes did you make?
- Created `communities-of-practice.js` as there was no JavaScript file for the CoP page to handle dynamic content.
- Modified `communities-of-practice.html` to include a placeholder `<span id="meeting-times-..."></span>` for meeting times. This allows meeting times to be fetched from JSON data and displayed automatically, ensuring they are always up-to-date without manual updates. Included `communities-of-practice.js` at the end of the HTML file.
- Removed the meeting times key from `_data/internal/communities`.
- Pulled meeting times from the VRMS data similar to how project pages use VRMS data from `_data/external/vrms_data.json`.
- Created `getMeetingTimes` function to retrieve and format meeting times in Pacific Time (PT) using a 12-hour clock. It includes a formatter to get the full name of the day of the week and make it plural.
- Created `setMeetingTimes` function to set the meeting times for each community and update the HTML with the meeting times. It maps community names to their corresponding project names and formats the community name from the element ID.

### Why did you make the changes (we will use this info to test)?
- To move from using static YAML data to dynamic JSON data, making it easier to update and manage meeting times.
- To automate the process of displaying meeting times in a consistent and user-friendly format on the webpage.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-08-02 at 21 41 32](https://github.com/user-attachments/assets/081f1a56-8f47-4628-947e-557ab454bef3)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-08-08 at 11 53 13](https://github.com/user-attachments/assets/da539345-4dd3-4528-b00e-3328e7368250)


</details>
