### PR TITLE
Add comment to PR if there's no linked issue

### DIFF
--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, edited]
     branches:
-      - 'gh-pages'
+      - '*'
 
 jobs:
   Check-For-Linked-Issue:

--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   Check-For-Linked-Issue:
     runs-on: ubuntu-latest
-    if: ${{ github.event.action == 'opened' | github.event.action == 'edited' }}
+    if: ${{ github.event.action == 'opened' || github.event.action == 'edited' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, edited]
     branches:
-      - '*'
+      - 'gh-pages'
 
 jobs:
   Check-For-Linked-Issue:

--- a/.github/workflows/pull-request-trigger.yml
+++ b/.github/workflows/pull-request-trigger.yml
@@ -1,13 +1,22 @@
 name: Pull Request Trigger
 on:
-  pull_request_target:
-    types: [opened, closed]
+  pull_request:
+    types: [opened, edited]
     branches:
       - 'gh-pages'
 
 jobs:
-  # Placeholder action: Delete when new jobs added 
-  Hello-World:
+  Check-For-Linked-Issue:
     runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'opened' | github.event.action == 'edited' }}
     steps:
-     - run: echo "🍺 This job was automatically triggered by a ${{ github.event_name }} event."
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for keyword and issue number
+        id: check-for-keyword
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./github-actions/trigger-pr/check-linked-issue.js')
+            script({g: github, c: context})

--- a/github-actions/trigger-pr/check-linked-issue.js
+++ b/github-actions/trigger-pr/check-linked-issue.js
@@ -22,7 +22,7 @@ async function main({ g, c }) {
 
   if (!match) {
     console.log('PR does not have a properly linked issue. Posting comment...');
-    prComment = `@${prOwner}, this Pull Request is not linked to a valid issue. Above, on the first line of your PR, please link the number of the issue that you worked on using the format of 'Fixes #' + issue number, for example **_Fixes #9876_**.\n\nNote: Do **_not_** use the number of this PR.`;
+    prComment = `@${prOwner}, this Pull Request is not linked to a valid issue. Above, on the first line of your PR, please link the number of the issue that you worked on using the format of 'Fixes #' + issue number, for example:   **_Fixes #9876_**\n\nNote: Do **_not_** use the number of this PR.`;
   }
   
   else {

--- a/github-actions/trigger-pr/check-linked-issue.js
+++ b/github-actions/trigger-pr/check-linked-issue.js
@@ -22,7 +22,7 @@ async function main({ g, c }) {
 
   if (!match) {
     console.log('PR does not have a properly linked issue. Posting comment...');
-    prComment = `@${prOwner}, this Pull Request is not linked to a valid issue. Above, on the first line of your PR, please link a valid issue using the format of 'Fixes #' + issue number, for example 'Fixes #9876'. Note: Do _not_ use the number of this PR.`;
+    prComment = `@${prOwner}, this Pull Request is not linked to a valid issue. Above, on the first line of your PR, please link the number of the issue which you worked on using the format of 'Fixes #' + issue number, for example 'Fixes #9876'.\n\nNote: Do **_not_** use the number of this PR.`;
   }
   
   else {

--- a/github-actions/trigger-pr/check-linked-issue.js
+++ b/github-actions/trigger-pr/check-linked-issue.js
@@ -1,0 +1,54 @@
+// Import modules
+const fs = require('fs');
+const postIssueComment = require('../utils/post-issue-comment');
+
+// Global variables
+var github;
+var context;
+
+async function main({ g, c }) {
+  github = g;
+  context = c;
+
+  // Retrieve body of context.payload and search for GitHub keywords followed by 
+  // '#' + number. Exclude any matches that are in a comment within the PR body
+  const prBody = context.payload.pull_request.body;
+  const prNumber = context.payload.pull_request.number;
+  const prOwner = context.payload.pull_request.user.login;
+  const regex = /(?!<!--)(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*#(\d+)(?![^<]*-->)/gi;
+  const match = prBody.match(regex);
+  
+  let prComment;
+
+  if (!match) {
+    console.log('PR does not have a properly linked issue. Posting comment...');
+    prComment = `@${prOwner}, this Pull Request is not linked to a valid issue. Above, on the first line of your PR, please link a valid issue using the format of 'Fixes #' + issue number, for example 'Fixes #9876'. Note: Do _not_ use the number of this PR.`;
+  }
+  
+  else {
+    console.log(match[0]);
+    let [ keyword, linkNumber ] = match[0].replaceAll('#','').split(' ');
+    console.log(`Found a keyword: \'${keyword}\'. Checking for legitimate linked issue...`);
+
+    // Check if the linked issue exists in repo
+    try {
+      const response = await github.rest.issues.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: linkNumber,
+      });
+      console.log(`Found an issue: \'#${linkNumber}\' in repo. Reference is a legitimate linked issue.`);
+    }
+    catch (error) {
+      console.log(`Couldn\'t find issue: \'#${linkNumber}\' in repo. Posting comment...`);
+    prComment = `@${prOwner}, the issue number referenced above as "**${keyword}  #${linkNumber}**" is not found. Please replace with a valid issue number.`;
+    }
+  }
+
+  // If the prComment was given text, then post the comment to the PR
+  if (prComment) {
+    postIssueComment(prNumber, prComment, github, context);
+  }
+}
+
+module.exports = main;

--- a/github-actions/trigger-pr/check-linked-issue.js
+++ b/github-actions/trigger-pr/check-linked-issue.js
@@ -30,8 +30,9 @@ async function main({ g, c }) {
     console.log(`Found a keyword: \'${keyword}\'. Checking for legitimate linked issue...`);
 
     // Check if the linked issue exists in repo
+    // https://octokit.github.io/rest.js/v20#issues-get
     try {
-      const response = await github.rest.issues.get({
+      await github.rest.issues.get({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: linkNumber,

--- a/github-actions/trigger-pr/check-linked-issue.js
+++ b/github-actions/trigger-pr/check-linked-issue.js
@@ -22,7 +22,7 @@ async function main({ g, c }) {
 
   if (!match) {
     console.log('PR does not have a properly linked issue. Posting comment...');
-    prComment = `@${prOwner}, this Pull Request is not linked to a valid issue. Above, on the first line of your PR, please link the number of the issue which you worked on using the format of 'Fixes #' + issue number, for example 'Fixes #9876'.\n\nNote: Do **_not_** use the number of this PR.`;
+    prComment = `@${prOwner}, this Pull Request is not linked to a valid issue. Above, on the first line of your PR, please link the number of the issue that you worked on using the format of 'Fixes #' + issue number, for example **_Fixes #9876_**.\n\nNote: Do **_not_** use the number of this PR.`;
   }
   
   else {

--- a/github-actions/trigger-pr/check-linked-issue.js
+++ b/github-actions/trigger-pr/check-linked-issue.js
@@ -1,5 +1,4 @@
 // Import modules
-const fs = require('fs');
 const postIssueComment = require('../utils/post-issue-comment');
 
 // Global variables


### PR DESCRIPTION
Fixes #7140 

### What changes did you make?
  - In `pull-request-trigger.yml`, replaced existing with code reference to js
  - In `github-actions/trigger-pr/` folder created `check-linked-issue.js`


### Why did you make the changes (we will use this info to test)?
  - For both files, this was done to create a workflow to check whether a newly-created PR is correctly linked back to the originating issue.



### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- No visual changes

### Testing logs and test PRs
- [PR created without an issue](https://github.com/t-will-gillis/website/pull/920) and [log](https://github.com/t-will-gillis/website/actions/runs/10271937984)
- [PR with incorrect format ](https://github.com/t-will-gillis/website/pull/921) and [log](https://github.com/t-will-gillis/website/actions/runs/10272026585)
- [PR without issue, then add issue](https://github.com/t-will-gillis/website/pull/922) and [log](https://github.com/t-will-gillis/website/actions/runs/10272135809/job/28423643558)

## Notes for testing
This test involves GitHub actions. To review, you will need to have a testing environment set up in your repo. Suggestions:
- See [Updated Notes for HfLA's GitHub Actions](https://github.com/hackforla/website/issues/6537#issuecomment-2041147335)
- For this PR, make sure you have "Issues" enabled. You will need to create an issue so that you have a valid linked issue to reference, then you will need to create test PRs that either do or don't correctly reference the issue. (Don't reference existing HfLA issues or PR numbers while testing)
- In `pull-request-trigger.yml`, change line 6 to:
  ```  
  - '*'
  ```  
