### PR TITLE
Updates image instructions for pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -932,22 +932,25 @@ In bullet point form, explain the changes you made in order to complete the acti
 in the gif example [near the top  of this part within the gif of completing pull request #2131](#31-how-to-make-a-pull-request), you will see 2 images get dragged into the text box and added within the `<details>/<summary>` tags like so:
 
 ```
-### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
-<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
-<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->
+### Screenshots of Proposed Changes Of The Website (if any, please do not include screenshots of code changes)
+<!--  Notes: 
+  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
+  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
+  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
+  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
+ --> 
 
 <details>
-<summary>Visuals before changes are applied</summary>
+  <summary>Visuals before changes are applied</summary>
 
-![image](https://user-images.githubusercontent.com/77212035/130176122-aca18c1a-c883-48b3-987d-06342835017c.png)
-
+  ![image](https://user-images.githubusercontent.com/77212035/130176122-aca18c1a-c883-48b3-987d-06342835017c.png)
 
 </details>
 
 <details>
-<summary>Visuals after changes are applied</summary>
+  <summary>Visuals after changes are applied</summary>
 
-![image](https://user-images.githubusercontent.com/77212035/130176069-9c1cc306-f930-43a5-9f93-1249466c81dc.png)
+  ![image](https://user-images.githubusercontent.com/77212035/130176069-9c1cc306-f930-43a5-9f93-1249466c81dc.png)
 
 </details>
 ```


### PR DESCRIPTION
Fixes #7138

### What changes did you make?
  - I replaced the code block text located under 3.1.b.iv with new text specified in the issue.

### Why did you make the changes (we will use this info to test)?
  - The changes were made to reduce ambiguity of instructions regarding the inclusion of images when a PR leads to visual changes to the hackforLa website.

### For Reviewers
- Do not test changes locally, rather test changes at [LINK](https://github.com/8alpreet/website/blob/contributing-update-7138/CONTRIBUTING.md).

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
Changes were made in contributing.md; no visual changes to website.
