### PR TITLE
Replace Github with GitHub in pages/getting-started.html

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -98,7 +98,7 @@ permalink: /getting-started
                 </br>
                     <div class="list-container">
                         <img class="step-img-icon-git" src="assets/images/getting-started/join-2.png" alt="" />
-                        <li class="g-s-list">Receive access to the Google Drive and Github repository by sending a Slack message of your Github username and Gmail address to a CoP lead. <img class="info-icon" src="assets/images/getting-started/information.png" alt="">
+                        <li class="g-s-list">Receive access to the Google Drive and GitHub repository by sending a Slack message of your GitHub username and Gmail address to a CoP lead. <img class="info-icon" src="assets/images/getting-started/information.png" alt="">
                         </li>
                     </div>
                     </br>


### PR DESCRIPTION
Fixes #7118

### What changes did you make?
  - Change:
  `<li class="g-s-list">Receive access to the Google Drive and Github repository by sending a Slack message of your Github username and Gmail address to a CoP lead. <img class="info-icon" src="assets/images/getting-started/information.png" alt="">`
  - To:
  `<li class="g-s-list">Receive access to the Google Drive and GitHub repository by sending a Slack message of your GitHub username and Gmail address to a CoP lead. <img class="info-icon" src="assets/images/getting-started/information.png" alt="">`

### Why did you make the changes (we will use this info to test)?
  - Make sure company name GitHub displays with proper capitalization throughout the website

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<details>
<summary>Visuals before changes are applied</summary>

![before](https://github.com/user-attachments/assets/0d0c49cf-8dd8-40f9-a577-478fd4f6e629)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after](https://github.com/user-attachments/assets/886587b5-c8d0-4d00-a1f5-8cc98cb3652c)

</details>

### Connected files
- The `getting-started.html` is used to populate the [HackforLA Getting Started](https://www.hackforla.org/getting-started) page
- The visual change can be observed in _Step 2: Join Your Community of Practice_ (as shown in pictures attached above)

### Test
- Compare the [http://localhost:4000/getting-started](http://localhost:4000/getting-started) to the live page on the HfLA website [https://www.hackforla.org/getting-started](https://www.hackforla.org/getting-started)
- Noticed the change from **Github** to **GitHub** in _Step 2: Join Your Community of Practice_ 
- Click on all the link attached in the section to make sure it redirects correctly 