### PR TITLE
Added github-handle variable for Stephen Barkley-Yeung

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -25,6 +25,7 @@ leadership:
       github: "https://github.com/mira-kine"
     picture: https://avatars.githubusercontent.com/mira-kine
   - name: Stephen Barkley-Yeung
+    github-handle:
     role: Developer
     links:
       slack: "https://hackforla.slack.com/team/U041403GHEC"


### PR DESCRIPTION
Fixes #7178 

### What changes did you make?
  - Added github: as a variable under Stephen Barkley-Yeung's name: variable

### Why did you make the changes (we will use this info to test)?
  - Per issue request to create a single variable github-handle to hold the handle for this leadership team member, which will eventually replace the github and picture variable.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

No visual changes to the website made.
