### PR TITLE
Added github-handle for Brian #7249

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -55,6 +55,7 @@ leadership:
       github: 'https://github.com/bryannalim'
     picture: https://avatars.githubusercontent.com/bryannalim
   - name: Brian Dick
+    github-handle:
     role: UX Researcher
     links:
       slack: 'https://hackforla.slack.com/team/U046AAZD309'


### PR DESCRIPTION
Fixes #7249

### What changes did you make?
  - Added `github-handle` variable for Brian
  

### Why did you make the changes (we will use this info to test)?
  - This variable is to replace the `github` and `picture` in the future


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- (N/A)
