### PR TITLE
7078 post pbb migration refactor schedule friday workflow

### DIFF
--- a/.github/workflows/schedule-fri-0700.yml
+++ b/.github/workflows/schedule-fri-0700.yml
@@ -15,6 +15,7 @@ jobs:
         env:
           HACKFORLA_ADMIN_TOKEN: ${{ secrets.HACKFORLA_ADMIN_TOKEN }}
         with:
+          github-token: ${{ secrets.HACKFORLA_GRAPHQL_TOKEN }}  
           script: |
             const HACKFORLA_ADMIN_TOKEN = process.env.HACKFORLA_ADMIN_TOKEN;
             const script = require('./github-actions/trigger-schedule/add-update-label-weekly/add-label.js');

--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -84,7 +84,7 @@ async function main({ g, c }, pbt) {
  * Finds issue numbers for all open & assigned issues, excluding issues labeled `Draft`, `ER`, `Epic`,
  * or `Dependency`, and returning issue numbers only if their status === "In progess (actively working"
  *
- * @Returns{Array} issueNums   - an array of open, assigned, and statused issue numbers
+ * @returns {Promise<Array>} issueNums     - an array of open, assigned, and statused issue numbers
  */
 async function getIssueNumsFromRepo() {
   const labelsToExclude = ['Draft', 'ER', 'Epic', 'Dependency'];

--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -1,7 +1,6 @@
 /// Import modules
 const fs = require("fs");
 const https = require("https");
-const statusFieldIds = require("../../utils/_data/status-field-ids");
 const queryIssueInfo = require("../../utils/query-issue-info");
 const findLinkedIssue = require('../../utils/find-linked-issue');
 const getTimeline = require('../../utils/get-timeline');

--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -1,6 +1,8 @@
 /// Import modules
 const fs = require("fs");
 const https = require("https");
+const statusFieldIds = require("../../utils/_data/status-field-ids");
+const queryIssueInfo = require("../../utils/query-issue-info");
 const findLinkedIssue = require('../../utils/find-linked-issue');
 const getTimeline = require('../../utils/get-timeline');
 
@@ -33,7 +35,7 @@ var projectBoardToken;
  * last update was not between 7 to 14 days ago, apply the appropriate label and request an update. However, if the assignee has submitted 
  * a PR that will fix the issue regardless of when, all update-related labels should be removed.
 
- * @param {Object} g                   - github object from actions/github-script
+ * @param {Object} g                   - GitHub object from actions/github-script
  * @param {Object} c                   - context object from actions/github-script
  * @param {String} projectBoardToken   - the Personal Access Token for the action
  */
@@ -80,12 +82,13 @@ async function main({ g, c }, pbt) {
 
 
 /**
- * Function that returns issue numbers of all issues in a repo
+ * Finds issue numbers for all open & assigned issues, excluding issues labeled `Draft`, `ER`, `Epic`,
+ * or `Dependency`, and returning issue numbers only if their status === "In progess (actively working"
  *
- * @returns an Array of issue numbers
+ * @Returns{Array} issueNums   - an array of open, assigned, and statused issue numbers
  */
 async function getIssueNumsFromRepo() {
-  const labelsToExclude = ['Draft', 'ER', 'Epic'];
+  const labelsToExclude = ['Draft', 'ER', 'Epic', 'Dependency'];
   let issueNums = [];
   let pageNum = 1;
   let result = [];
@@ -94,6 +97,7 @@ async function getIssueNumsFromRepo() {
     const issueData = await github.request('GET /repos/{owner}/{repo}/issues', {
       owner: context.repo.owner,
       repo: context.repo.repo,
+      assignee: '*',
       per_page: 100,
       page: pageNum,
     });
@@ -106,17 +110,17 @@ async function getIssueNumsFromRepo() {
     }
   }
   
-  for (let issueNum of result) {
-    if (issueNum.number) {
-      let issueLabels = [];
-      for (let label of issueNum.labels) {
-        issueLabels.push(label.name);
-      }
-      if (!issueLabels.some(item => labelsToExclude.includes(item))) {
-        issueNums.push(issueNum.number);
-      } else {
-        console.log(`Excluding Issue #${issueNum.number} because of label`);
-      }
+  for (let { number, labels } of result) {
+    if (!number) continue;
+
+    // Exclude any issues that have excluded labels
+    const issueLabels = labels.map((label) => label.name);
+    if (issueLabels.some((item) => labelsToExclude.includes(item))) continue;
+
+    // For remaining issues, check if status === "In progress (actively working)"
+    const { statusName } = await queryIssueInfo(github, context, number);
+    if (statusName === "In progress (actively working)") {
+      issueNums.push(number);
     }
   }
   return issueNums;


### PR DESCRIPTION
Fixes #7078 

### What changes did you make?
  - Inserts `github-token` from repository secrets at `secrets.HACKFORLA_GRAPHQL_TOKEN` to `.github\workflows\schedule-fri-0700.yml` [here](https://github.com/mrodz/hfla-website/blob/fab4dfa9d7cc21f41a413e2c7ba05a58d11a9ffe/.github/workflows/schedule-fri-0700.yml#L18)
  - Updated filtering of issues [here](https://github.com/mrodz/hfla-website/blob/fab4dfa9d7cc21f41a413e2c7ba05a58d11a9ffe/github-actions/trigger-schedule/add-update-label-weekly/add-label.js#L112) following the issue's directions, and audited the fix for bugs
  - Updated fetch parameters to only include assigned users [here](https://github.com/mrodz/hfla-website/blob/fab4dfa9d7cc21f41a413e2c7ba05a58d11a9ffe/github-actions/trigger-schedule/add-update-label-weekly/add-label.js#L99)
  - Added `Dependency` to the list of labels to exclude from the inactivity check [here](https://github.com/mrodz/hfla-website/blob/fab4dfa9d7cc21f41a413e2c7ba05a58d11a9ffe/github-actions/trigger-schedule/add-update-label-weekly/add-label.js#L90)
  - Updated JSDoc [here](https://github.com/mrodz/hfla-website/blob/fab4dfa9d7cc21f41a413e2c7ba05a58d11a9ffe/github-actions/trigger-schedule/add-update-label-weekly/add-label.js#L83)
    - **I changed the return type details because it did not follow the JSDoc specification and also should have been `Promise<Array>` instead of `Array`**
  - Capitalized "GitHub" [here](https://github.com/mrodz/hfla-website/blob/fab4dfa9d7cc21f41a413e2c7ba05a58d11a9ffe/github-actions/trigger-schedule/add-update-label-weekly/add-label.js#L37)
  - Imported module used in this patch [here](https://github.com/mrodz/hfla-website/blob/fab4dfa9d7cc21f41a413e2c7ba05a58d11a9ffe/github-actions/trigger-schedule/add-update-label-weekly/add-label.js#L4)
### Why did you make the changes (we will use this info to test)?
  - Migrating to Project Boards (new) changed the API for how data for issues is laid out. We take advantage of the GraphQL API exposed through `Octokit` to ensure our CI/CD workflow can operate without hiccups.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screenshot code changes)
No Visual Changes

### Information for reviewers:
I replicated Hack4LA's project board in my own repo and created four issues to test some use cases:
- https://github.com/mrodz/hfla-website/issues/5
- https://github.com/mrodz/hfla-website/issues/4
- https://github.com/mrodz/hfla-website/issues/3
- https://github.com/mrodz/hfla-website/issues/2

A manual run of [`.github/workflows/schedule-fri-0700.yml`](https://github.com/mrodz/hfla-website/blob/2b297f7af84d2c60e27c7b91b93c30e6dda52d71/.github/workflows/schedule-fri-0700.yml) gave the following output, only checking the age of https://github.com/mrodz/hfla-website/issues/5, which is expected behavior.

<details>
<summary>Expand</summary>
<img src="https://github.com/user-attachments/assets/731c3268-cc9c-4b40-8e6d-c0a6650240b5" alt="" />
</details>