### PR TITLE
Add github handle for bryce lednar in home-unite-us.md

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -55,6 +55,7 @@ leadership:
       github: "https://github.com/rpradheap"
     picture: https://avatars.githubusercontent.com/rpradheap
   - name: Bryce Lednar
+    github-handle:
     role: Product Manager
     links:
       slack: "https://hackforla.slack.com/team/U049TSDG2SX"


### PR DESCRIPTION
Fixes #7184 

### What changes did you make?
Added github handle to `_projects/home-unite-us.md` for Bryce Lednar.

### Why did you make the changes (we will use this info to test)?
We need to create a single variable `github-handle` to hold the github handle for each member of the leadership team. Eventually `github-handle` will replace the github and picture variables, reducing redundancy in the project file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to the website.
