### PR TITLE
Add GitHub handle #7186 for Eduardo De La Rosa in home-unite-us.md

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -67,6 +67,7 @@ leadership:
       github: "https://github.com/fourmatte"
     picture: https://avatars.githubusercontent.com/fourmatte
   - name: Eduardo De La Rosa
+    github-handle:
     role: UX/UI Designer
     links:
       slack: "https://hackforla.slack.com/team/U0430G2T4AC"


### PR DESCRIPTION
Fixes #7186 

### What changes did you make?
  - Added `github-handle` under Eduardo De La Rosa in `home-unite-us.md`

### Why did you make the changes (we will use this info to test)?
  - `github-handle` is a variable for each member of the leadership team and it will eventually replace the github and picture variables, reducing redundancy in the project file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->
- No screenshots since adding a variable does not affect the website visually
