### PR TITLE
Added 'github-handle' key below name for Flora Osmond

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -73,6 +73,7 @@ leadership:
       github: "https://github.com/edela0015"
     picture: https://avatars.githubusercontent.com/edela0015
   - name: Flora Osmond
+    github-handle:
     role: UX/UI Designer
     links:
       slack: "https://hackforla.slack.com/team/U047ZT4GP5E"


### PR DESCRIPTION
Fixes #7187

### What changes did you make?
  - I modified `_projects/home-unite-us.md` by adding 'github-handle' key below the 'name: Flora Osmond' key/value pair.

### Why did you make the changes (we will use this info to test)?
  - This change is intended to reduce redundancy in the project file by replacing, in the near future, 'github' and 'picture' key/value pairs.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to the website. The new key is not part of a display card.
