### PR TITLE
PR Added github-handle for Rachel Bracker in home-unite-us file

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -79,6 +79,7 @@ leadership:
       github: "https://github.com/itzflowa"
     picture: https://avatars.githubusercontent.com/itzflowa
   - name: Rachel Bracker
+    github-handle: 
     role: Design Lead
     links:
       slack: "https://hackforla.slack.com/team/U02JQLQ6YGY"


### PR DESCRIPTION
Fixes #7188

This PR adds the github-handle variable for each member of the leadership team in the home-unite-us file, addressing issue https://github.com/hackforla/website/issues/7188.

### What changes did you make?
  - Added github-handle variable for leadership team member Sarah Edwards.

### Why did you make the changes (we will use this info to test)?
  - To reduce redundancy in home-unite-us file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - No visual changes. 

