### PR TITLE
Section 2.4.b img change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -463,7 +463,7 @@ Once you find an issue you want to work on, you need to self-assign to claim it 
 <details>
   <summary><strong>Click here</strong> to see how to move an issue from the ‘Prioritized Backlog’ to the ‘In progress (actively working)’ & back</summary>
   <p><strong>Project Board column demo</strong></p>
-  <img src="https://user-images.githubusercontent.com/21162229/137693338-97fe5f6c-820d-41c9-8e93-57b70827e0cf.gif" />
+  <img src="https://user-images.githubusercontent.com/21162229/137693338-97fe5f6c-820d-41c9-8e93-57b70827e0cf.gif">
 </details>
 
 ##### **i. After you claim an issue:**


### PR DESCRIPTION
Fixes #7097

### What changes did you make?
  - In Section 2.4.b change  to <img src="https://user-images.githubusercontent.com/21162229/137045294-3d46b28c-edbb-410c-98f1-13940ecc5c5f.jpg">   

### Why did you make the changes (we will use this info to test)?
  - <img src="https://user-images.githubusercontent.com/21162229/137045294-3d46b28c-edbb-410c-98f1-13940ecc5c5f.jpg" />  is not formatted correct.

For Reviewers: Do not test changes locally, rather test changes at [https://github.com/dcotelessa/website-hackforla/blob/dcotelessa-img-tag-refactor-7097/CONTRIBUTING.md]