### PR TITLE
img tag refactor in CONTRIBUTING.md Sec 1.3 - second instance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ You can fork the hackforla/website repository by clicking <a href="https://githu
   <p><strong>First, you find the `fork` button on the top right hand side of the [Hack for LA website repo](https://github.com/hackforla/website)</strong></h4>
   <img src="https://user-images.githubusercontent.com/21162229/137044762-c80f18e8-b785-48fb-a286-81c1117c0178.jpg" />
   <p><strong>Next, a modal may open and request where you want to fork this website repo. Please click on your avatar or your GitHub username</strong></p>
-  <img src="https://user-images.githubusercontent.com/21162229/137045294-3d46b28c-edbb-410c-98f1-13940ecc5c5f.jpg" />
+  <img src="https://user-images.githubusercontent.com/21162229/137045294-3d46b28c-edbb-410c-98f1-13940ecc5c5f.jpg">
 </details><br>
 
 **Note:** It should create a URL that looks like the following -> `https://github.com/<your_GitHub_user_name>/website`.


### PR DESCRIPTION
Fixes #7097

### What changes did you make?
  - In Section 2.4.b change  to <img src="https://user-images.githubusercontent.com/21162229/137045294-3d46b28c-edbb-410c-98f1-13940ecc5c5f.jpg">   

### Why did you make the changes (we will use this info to test)?
  - <img src="https://user-images.githubusercontent.com/21162229/137045294-3d46b28c-edbb-410c-98f1-13940ecc5c5f.jpg" />  is not formatted correct.

For Reviewers: Do not test changes locally, rather test changes at [https://github.com/dcotelessa/website-hackforla/blob/dcotelessa-img-tag-refactor-7097/CONTRIBUTING.md]