### PR TITLE
Fix capitalization of slack in pre-work-template--dev.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/pre-work-template--dev.md
+++ b/.github/ISSUE_TEMPLATE/pre-work-template--dev.md
@@ -82,7 +82,7 @@ Progress through issues in the [prioritized backlog](https://github.com/hackforl
 ### What should I do if I have a question about an issue I'm working on, and I haven't gotten a response yet?
 - First, you should post the question or blocker as a comment on your assigned issue, so it can be easily referred to in the next bullet points.
 - Then, add the label "Status: Help Wanted" so other developers can see it and potentially help answer your question. In addition, you will still need to post a Slack message or bring it up in meeting so we know you need help; see below for how to do that.
-- Also, you can post your question on the hfla-site slack channel and link the issue you're working on, so other developers can see and respond.
+- Also, you can post your question on the hfla-site Slack channel and link the issue you're working on, so other developers can see and respond.
 - Lastly, you can add the issue to the "Development team meeting discussion items" column of the Project Board so that it can be addressed in the next development meeting. Please bring it during the meeting that you need help.
 
 ### Resources/Instructions


### PR DESCRIPTION
Fixes #7192

### What changes did you make?
  - Capitalized `Slack` in the issue template `pre-work-template--dev.md`.

### Why did you make the changes?
  - To maintain consistency throughout the codebase
  
 ### For Reviewers
- Use this URL to check the updated issue template: https://github.com/buneeIsSlo/website/issues/new?assignees=&labels=Complexity%3A+Prework%2C+Feature%3A+Onboarding%2FContributing.md%2C+role+missing%2C+size%3A+1pt&projects=&template=pre-work-template--dev.md&title=Pre-work+Checklist%3A+Developer%3A+%5Breplace+brackets+with+your+name%5D

### Screenshots of Proposed Changes Of The Website
- No visual changes were made to the website.
