### PR TITLE
Removed backlash / in img tag (<img.../>) in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -616,7 +616,7 @@ git commit -m “insert message here”
 
 <details>
   <summary><strong>Click here</strong> to see how to sync the fork on GitHub</summary>
-  <img src="https://raw.githubusercontent.com/wiki/hackforla/website/images/how-to-review-pull-requests/step3-sync-demo.gif" />
+  <img src="https://raw.githubusercontent.com/wiki/hackforla/website/images/how-to-review-pull-requests/step3-sync-demo.gif">
 </details>
 
 Next, bring upstream changes into your topic branch. With your topic branch checked out, run: 


### PR DESCRIPTION
Fixes #7098 

### What changes did you make?
  - In section 2.7.d of CONTRIBUTING.md removed the backlash / in the img tag (<img.../>) to an img tag without an ending backslash (<img...>).

### Why did you make the changes (we will use this info to test)?
  - So that the codebase is consistent with how we use img HTML tags.

For Reviewers: Do not test changes locally, rather test changes at https://github.com/santisecco/website/blob/img-tag-refactor-contributing-7098/CONTRIBUTING.md

### Screenshots of Proposed Changes Of The Website
- No visual changes were made to the website.