### PR TITLE
add github handle #7254

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -86,6 +86,7 @@ leadership:
       github: 'https://github.com/Dzotsen'
     picture: https://avatars.githubusercontent.com/Dzotsen
   - name: Eric Vennemeyer
+    github-handle:
     role: Developer
     links:
       slack: 'https://hackforla.slack.com/team/U03AUUZT3E3'


### PR DESCRIPTION
Fixes #7254

### What changes did you make?
  - added 'github-handle' under Eric  Vennemeyer's name, located under the "Tech Work Expereince" project.

### Why did you make the changes (we will use this info to test)?
  - To reduce redundancy in the project file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->
 No visual changes were made. 

