### PR TITLE
Added github-handle property for Andrew Salvatore

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -37,6 +37,7 @@ leadership:
       github: 'https://github.com/bradyse'
     picture: https://avatars.githubusercontent.com/bradyse
   - name: Andrew Salvatore
+    github-handle:
     role: UX Researcher
     links:
       slack: 'https://hackforla.slack.com/team/U04K5R2A7L2'


### PR DESCRIPTION
Fixes #7246

### What changes did you make?
  - I modified `_projects/tech-work-experience.md` by adding 'github-handle' key below the 'name: Andrew Salvatore' key/value pair.

### Why did you make the changes (we will use this info to test)?
  - This change is intended to reduce redundancy in the project file by replacing 'github' and 'picture' key/value pairs.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - No visual changes to the website. The new key is not part of a display card.