### PR TITLE
Add github-handle for Jessie Liu in _projects/tech-work-experience.md

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -62,6 +62,7 @@ leadership:
       github: 'https://github.com/dialectic51'
     picture: https://avatars.githubusercontent.com/dialectic51
   - name: Jessie Liu
+    github-handle:
     role: UX Researcher
     links:
       slack: 'https://hackforla.slack.com/team/U045YQFSGMB'


### PR DESCRIPTION
Fixes #7250 

### What changes did you make?
  - Added the variable github-handle for Jessie Liu in _projects/tech-work-experience.md

### Why did you make the changes (we will use this info to test)?
  - This is to reduce redundancy within the file, as `github-handle` can replace both `github` and `picture` variables.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes.
