### PR TITLE
Add github-handle for Natalie Aguilar in tech-work-experience.md #7252

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -75,6 +75,7 @@ leadership:
       github: 'https://github.com/meetminji'
     picture: https://avatars.githubusercontent.com/meetminji
   - name: Natalie Aguilar
+    github-handle:
     role: UX/UI Designer
     links:
       slack: 'https://hackforla.slack.com/team/U04P6N186P9'
@@ -93,8 +94,8 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U03AUUZT3E3'
       github: 'https://github.com/ericvennemeyer'
     picture: https://avatars.githubusercontent.com/ericvennemeyer
-  
-links: 
+
+links:
   - name: Github
     url: 'https://github.com/hackforla/internship'
   - name: Slack
@@ -104,12 +105,12 @@ links:
   - name: Overview
     url: '../assets/pdfs/Tech-Work-Experience-One-Sheet.pdf'
 looking:
-technologies: 
+technologies:
   - GitHub Pages
-location: 
+location:
   - Remote
 partner:
-tools: 
+tools:
   - Figma
   - Miro
   - Otter.ai


### PR DESCRIPTION
Fixes #7252

### What changes did you make?

replaced 
- name: Natalie Aguilar
with

- name: Natalie Aguilar
  github-handle:
  

### Why did you make the changes (we will use this info to test)?

 We need to create a single variable github-handle to hold the github handle for each member of the leadership team. Eventually github-handle will replace the github and picture variables, reducing redundancy in the project file.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- No visual changes to the website