### PR TITLE
Add github handle for Angela Darosh on tech-work-experience.md

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -43,6 +43,7 @@ leadership:
       github: 'https://github.com/AndrewSalvatore'
     picture: https://avatars.githubusercontent.com/AndrewSalvatore
   - name: Angela Darosh
+    github-handle:
     role: UX Researcher
     links:
       slack: 'https://hackforla.slack.com/team/U03J4ENS09F'


### PR DESCRIPTION
Fixes #7247

### What changes did you make?
  - Using spaces, added the variable `github-handle` under Angela Darosh

### Why did you make the changes (we will use this info to test)?
  - We need to create a single variable github-handle to hold the github handle for each member of the leadership team. 


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to the website.

