### PR TITLE
Add Github Handle for Nino Dzotsenidze in tech-work-experience.md

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -81,6 +81,7 @@ leadership:
       github: 'https://github.com/Natalie-Aguilar'
     picture: https://avatars.githubusercontent.com/Natalie-Aguilar
   - name: Nino Dzotsenidze
+    github-handle:
     role: UX Researcher
     links:
       slack: 'https://hackforla.slack.com/team/U04MUEYTECR'


### PR DESCRIPTION
Fixes #7253 

### What changes did you make?
  - Using spaces, I added a variable to hold the github-handle for Nino Dzotsenidze 

### Why did you make the changes (we will use this info to test)?
  - The reason why I need to add a single variable holding the github-handle is because eventually this variable will replace the github and picture variables. This is being done for every member of the leadership team to ensure that we are writing efficient code and reducing redundancy. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to the website
