### PR TITLE
Replace Github with GitHub in pages/communities-of-practice.html

### DIFF
--- a/pages/communities-of-practice.html
+++ b/pages/communities-of-practice.html
@@ -80,7 +80,7 @@ permalink: /communities-of-practice
                 {% if community[1].links[1].url %}
                     {% assign url_links = true %}
                     <a href="{{ community[1].links[1].url }}" class="btn btn-primary btn-md btn--default cop-btn" target="_blank" rel="noopener noreferrer"
-                        title="{{community[1].name}} Github Repo">
+                        title="{{community[1].name}} GitHub Repo">
                         <img class="button-icon" id="github-icon" src="/assets/images/communities-of-practice/icon-github-small.svg" alt="github icon" />
                         View GitHub
                     </a>


### PR DESCRIPTION
Fixes #7111

### What changes did you make?
  - Change 
  `title="{{community[1].name}} Github Repo">`
  - To
  `title="{{community[1].name}} GitHub Repo">`
  
### Why did you make the changes (we will use this info to test)?
  - Corrected the capitalization of "GitHub" in `pages/communities-of-practice.html`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
  - No visual changes
 
### Connected file
 - The `pages/communities-of-practice.html` is used to populate the [HackforLA Communities of Practice](https://www.hackforla.org/communities-of-practice) page
 - The element `title="{{community[1].name}} GitHub Repo"` is not directly referenced in any files, there should be no visual changes

### Test
 - Compare the  http://localhost:4000/communities-of-practice to the live page on the HfLA website https://www.hackforla.org/communities-of-practice
 - Check for visual changes, found none
 - `View GitHub` button as well as the `Join Slack Channel` button redirect correctly
 - Use `Inspect` to check for correct spelling in the title attribute for each community's GitHub anchor element in the HTML page source
