### PR TITLE
Add github-handle for Tyler Thome in home-unite-us.md 

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -7,6 +7,7 @@ alt: 'Home Unite Us'
 image-hero: /assets/images/projects/home-unite-us-hero.png
 leadership:
   - name: Tyler Thome
+    github-handle: 
     role: HUU Tech Lead
     links:
       slack: "https://hackforla.slack.com/team/ULN1M6UAH"


### PR DESCRIPTION
Fixes #7175 

### What changes did you make?
- Added the `github-handle:` field under `name: Tyler Thome` in the `_projects/home-unite-us.md` file. This field was added without a value as per the issue's instructions.

### Why did you make the changes?
- The change was made to prepare the project file for future enhancements, reducing redundancy by standardizing the GitHub handle field.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to the website.