### PR TITLE
Add github-handle for Sara Brady in tech-work-experience.md

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -31,6 +31,7 @@ leadership:
       github: 'https://github.com/doctorsandy'
     picture: https://avatars.githubusercontent.com/doctorsandy
   - name: Sara Brady
+    github-handle:
     role: UX Research Co-Lead
     links:
       slack: 'https://hackforla.slack.com/team/U0371AXAVUN'


### PR DESCRIPTION
Fixes #7245 

### What changes did you make?
 Changed variable `name:` in /website/_projects/tech-work-experience.md to include variable
`github-handle:` 
- `name: Sara Brady`

- `name: Sara Brady
   github-handle:`

### Why did you make the changes (we will use this info to test)?
  - to submit the second pull request. The issue was created to replace the github: and picture: variables with github-handle: to reduce redundancy. 
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

- No Visual changes made as only a variable name was added. 