### PR TITLE
Added Mira Kinebuchi's github handle variable in home-unite-us.md

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -19,6 +19,7 @@ leadership:
       github: "https://github.com/jed-stewart"
     picture: https://avatars.githubusercontent.com/jed-stewart
   - name: Mira Kinebuchi
+    github-handle:
     role: Developer
     links:
       slack: "https://hackforla.slack.com/team/U0411CAL13N"


### PR DESCRIPTION
Fixes #7177 

### What changes did you make?
  -    Added github-handle for Mira Kinebuchi
  

### Why did you make the changes (we will use this info to test)?
  -    The change was made to prepare the project file for the future inclusion of GitHub handles in a standardized way, reducing redundancy.
 
### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
 -    No visual changes to the website

