### PR TITLE
Fix bug in "Schedule Friday" workflow

### DIFF
--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -221,32 +221,22 @@ function isTimelineOutdated(timeline, issueNum, assignees) { // assignees is an 
  * @param {Array} labels       - an array containing the labels to remove (captures the rest of the parameters)
  */
 async function removeLabels(issueNum, ...labels) {
-  // Check if label exists on issue before attempting to remove it
-  let currLabels = [];
-  let labelData = await github.request('GET /repos/{owner}/{repo}/issues/{issue_number}/labels', {
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    issue_number: issueNum,
-  });
-  for (let currLabel in labelData.data) {
-    currLabels.push(currLabel.name);
-  }
-
   for (let label of labels) {
-    if (label in currLabels) {
-       try {
-        await github.request('DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}', {
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          issue_number: issueNum,
-          name: label,
-        });
-        console.log(`Issue #${issueNum}: removed "${label}" label`);
-      } catch (err) {
-        console.error(`Function failed to remove labels. Please refer to the error below: \n `, err);
+    try {
+      // https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue
+      await github.request('DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}', {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: issueNum,
+        name: label,
+      });
+      console.log(`  '${label}' label has been removed`);
+    } catch (err) {
+      if (err.status === 404) {
+        console.log(`  '${label}' label not found, no need to remove`);
+      } else {
+        console.error(`Function failed to remove labels. Please refer to the error below: \n `);
       }
-    } else {
-      console.log(`  '${label}' label not found, no need to remove`);
     }
   }
 }

--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -109,9 +109,12 @@ async function getIssueNumsFromRepo() {
     }
   }
   
-  for (let { number, labels } of result) {
+  for (let { number, labels, pull_request } of result) {
     if (!number) continue;
 
+    // Exclude any pull requests that were found
+    if (pull_request != undefined) continue;
+  
     // Exclude any issues that have excluded labels
     const issueLabels = labels.map((label) => label.name);
     if (issueLabels.some((item) => labelsToExclude.includes(item))) continue;

--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -260,7 +260,7 @@ async function addLabels(issueNum, ...labels) {
       issue_number: issueNum,
       labels: labels,
     });
-    console.log(`Issue #${issueNum}: Added these labels: '${labels}'`);
+    console.log(`  '${labels}' label has been added`);
     // If an error is found, the rest of the script does not stop.
   } catch (err) {
     console.error(`Function failed to add labels. Please refer to the error below: \n `, err);

--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -238,7 +238,7 @@ async function removeLabels(issueNum, ...labels) {
       if (err.status === 404) {
         console.log(`  '${label}' label not found, no need to remove`);
       } else {
-        console.error(`Function failed to remove labels. Please refer to the error below: \n `);
+        console.error(`Function failed to remove labels. Please refer to the error below: \n `, err);
       }
     }
   }


### PR DESCRIPTION
Fixes #7322

### What changes did you make?
  - In `add-label.js`, added a check to filter out self-assigned PRs from list of issues to analyze
  - In `add-label.js`, removed the section after "check if label exists on issue before attempting to remove it" from the `removeLabels()` function 
  - Changed the `try...catch` block by adding a check if `err.status === 404`


### Why did you make the changes (we will use this info to test)?
  - When a dev assigns themselves to a PR, the workflow includes the PR with other assigned issues and this causes an error, thus these PRs need to be excluded.
  - The section noted is extraneous, and more importantly has errors. The revised `github.request` will delete the label if it exists or return a "404" if it does not. The `try...catch` block can listen for the `err.status === 404` and log that the label does not exist, or post the full error for any other.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- Does not affect website visuals
- [Log from repo](https://github.com/t-will-gillis/website/actions/runs/10479730394/job/29025945744) showing successful run by removing the correct labels and posting a message if the label does not exist