### PR TITLE
Added info and link to VRMS guide for updating meeting details

### DIFF
--- a/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
+++ b/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml
@@ -73,9 +73,8 @@ body:
         Slack Member ID:
   - type: markdown
     attributes:
-      value: "### Resources"
-  - type: markdown
-    attributes:
       value: |
-        folder where files are in the repo: https://github.com/hackforla/website/tree/gh-pages/_data/internal/communities
-        where you can see the live page: https://www.hackforla.org/communities-of-practice
+        ### Resources
+        * Folder where files are in the repo: https://github.com/hackforla/website/tree/gh-pages/_data/internal/communities
+        * Where you can see the live page: https://www.hackforla.org/communities-of-practice
+        * If you need to update your meeting times, names, dates, or frequency, please see the [VRMS User Guide](https://github.com/hackforla/VRMS/wiki/User-Guide). The HackforLA.org website gets the meeting times from the updates made to each Community of Practice's meeting data in vrms.io


### PR DESCRIPTION
Fixes #7273

### What changes did you make?
1.  I added a note/entry under the _Resources_  section regarding updates to meeting details in the file: `.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml`
    - Link to file in my repo: [LINK](https://github.com/8alpreet/website/blob/update-cop-issue-tempalte-7273/.github/ISSUE_TEMPLATE/communities-of-practice-information-updates.yml).
    
2. I added numbers to the notes/elements under the _Resources_ section.
    - replaced with bullet points
3. I added `### Resources` at the beginning of the block of text which contains the notes/entries. Consequently, I removed an entry from the `body` array which was dedicated to the _Resources_ section heading.

### Why did you make the changes (we will use this info to test)?
1. The new note/entry under the _Resources_ section was added to help users of the "communities of practice information updates" template. The note informs users how and where they can make updates to meeting details.
2. The numbers were added to increase readability. Without the numbers it was difficult to distinguish one note/entry from another.
    > numbers were replaced with bullet points after feedback from a reviewer (see @t-will-gillis's comment). Bullet points are consistent with other templates.
    <details>
      <summary><strong>Click here</strong> to see image of the original format</summary>
      
      <img width="959" alt="original-format" src="https://github.com/user-attachments/assets/1dbc5c70-2469-4717-b0b5-d8ec123de584">
    </details>
    <details>
      <summary><strong>Click here</strong> to see image with bullet points</summary>
     <img width="955" alt="bullet points result" src="https://github.com/user-attachments/assets/c313eb1c-4c51-4ceb-894c-dc3f0f9c40a2">
    </details>
   Note: using numbers or bullet points seems to break the formatting on Github. The list does not get indented as it should. I think the weird spacing is more acceptable than a lack of numbers or bullet points. I chose numbers over bullet points because I think the numbers look better.

5. I added the `### Resources` heading and removed the separate entry because having the separate entry is not necessary. Having the heading and the list of resources in the same block produces the same result.
    <details>
      <summary><strong>Click here</strong> to see the original and new side by side.</summary>
     
    <img width="927" alt="original + new heading result" src="https://github.com/user-attachments/assets/cd430543-297d-4782-b7ee-b9a17b37cf00">

    </details>

6. Additional notes:
    * I tried adding numbers while keeping the `### Resources` in it's own section, like the original code, but that did not fix the indenting issue.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- No visual changes to website.
