### PR TITLE
Removed liquid statement for calendar.html in pages/index.html

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -4,7 +4,6 @@ permalink: /
 {% assign remote-only = 'true' %}
 {% if remote-only == 'false' %}
     {%- include hero.html -%}
-    {%- include calendar.html -%}
     {%- include current-projects.html -%}
     {%- include press.html -%}
     {%- include about.html -%}


### PR DESCRIPTION
Fixes #7281

### What changes did you make?
Removed the liquid statement that includes the calendar.html file inside pages/index.html

### Why did you make the changes (we will use this info to test)?
The calendar component is no longer being used so it needed to be removed in the liquid template for the homepage per the issue.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No Visual Changes Made. The liquid conditional is set to true so the calendar was already not rendering before the removal of the code.