### PR TITLE
Updated Project Profile for Will Gillis

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -19,18 +19,18 @@ leadership:
       slack: https://hackforla.slack.com/team/U06REBB5K4M
       github: https://github.com/kellyc9
     picture: https://avatars.githubusercontent.com/kellyc9
-  - name: Roslyn Wythe
-    role: Developer Co-Lead
-    links:
-      slack: 'https://hackforla.slack.com/team/U046PD8UT55'
-      github: 'https://github.com/roslynwythe'
-    picture: https://avatars.githubusercontent.com/roslynwythe
   - name: Will Gillis
     role: Developer Co-Lead
     links:
       slack: 'https://hackforla.slack.com/team/U043LGHSZFT'
       github: 'https://github.com/t-will-gillis'
     picture: https://avatars.githubusercontent.com/t-will-gillis
+  - name: Roslyn Wythe
+    role: Developer Co-Lead
+    links:
+      slack: 'https://hackforla.slack.com/team/U046PD8UT55'
+      github: 'https://github.com/roslynwythe'
+    picture: https://avatars.githubusercontent.com/roslynwythe
   - name: Ren Demeis-Ortiz
     role: Merge Team
     links:


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7283 

### What changes did you make?
- Moved Will Gillis' entry from the current location in the markdown file to the line after Bonnie's entry and any "Role: Product Manager" and/or "Role: Product Team", but before any "Role: Merge Team"

### Why did you make the changes (we will use this info to test)?
- To correctly order the entries for the Hack for LA Website project page.

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/741df0c3-de14-40b9-888f-6448149c5d04)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/93b7f4ac-8798-4233-be52-5af6d26c32f0)

</details>
