### PR TITLE
add github-handle for John Darragh

### DIFF
--- a/_projects/tdm-calculator.md
+++ b/_projects/tdm-calculator.md
@@ -14,6 +14,7 @@ leadership:
       github: 'https://github.com/ExperimentsInHonesty'
     picture: https://avatars.githubusercontent.com/ExperimentsInHonesty
   - name: John Darragh
+    github-handle:
     role: Architect
     links:
       slack: 'https://hackforla.slack.com/team/UFLDX9V19'


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7172 

### What changes did you make?
adds `github-handle:` beneath `name: John Darragh` on `tdm-calculator.md (Index)`

### Why did you make the changes (we will use this info to test)?
technical debt, required on issue 7172

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
No visual changes to the website