### PR TITLE
Removed api-actionnetwork.js script in default template

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,6 @@
    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.js"
      integrity="sha384-5eDs4qg7Mm6lRIqLmB5k7P/GV+iEWdlzONR7lOdXJ/hquF3S4n4Z2u0rbhx8OYXs" crossorigin="anonymous">
    </script>
-    <script src="{{ '/assets/js/api-actionnetwork.js' | absolute_url }}"></script>
   </div>
 </body>
 </html>


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7092

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Removed the script tag that references assets/js/api-actionnetwork.js from default template

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - The script is no longer required.

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: -->
  - No visual changes to the website

