### PR TITLE
 Add github-handle for Erik Guntner in home-unite-us.md

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -33,6 +33,7 @@ leadership:
       github: "https://github.com/stevbark"
     picture: https://avatars.githubusercontent.com/stevbark
   - name: Erik Guntner
+    github-handle:
     role: Front End Developer
     links:
       slack: "https://hackforla.slack.com/team/U0103MJB0AZ"


### PR DESCRIPTION

Fixes #7179

### What changes did you make?
  - Added github-handle: field under name: Erik Guntner in the _projects/home-unite-us.md file.

### Why did you make the changes (we will use this info to test)?
  - The change was made to prepare the project file for future enhancements by standardizing the GitHub handle field.

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes to the website


