### PR TITLE
Added GitHub Handle for Liz Zheng in design-systems.md

### DIFF
--- a/_projects/design-systems.md
+++ b/_projects/design-systems.md
@@ -94,6 +94,7 @@ leadership:
       github: 'https://github.com/TobyShanti'
     picture: 'https://avatars.githubusercontent.com/TobyShanti'
   - name: Liz Zheng
+    github-handle:
     role: UX/UI Designer
     links:
       slack: 'https://hackforla.slack.com/team/U04GYRW4DAT'


### PR DESCRIPTION
Fixes #7290 

### What changes did you make?
  - Added github-handle field under the name field for Liz Zheng in design-systems.md

### Why did you make the changes (we will use this info to test)?
  - To hold the GitHub handle for each member of the leadership team

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
No visual changes made.