### PR TITLE
7183: Add github-handle for Raji Pradheap in home-unite-us.md

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -53,6 +53,7 @@ leadership:
       github: "https://github.com/sanya301"
     picture: https://avatars.githubusercontent.com/sanya301
   - name: Raji Pradheap
+    github-handle:
     role: Product Manager
     links:
       slack: "https://hackforla.slack.com/team/U02R9MKA6KH"


### PR DESCRIPTION
 Fixes #7183 

### What changes did you make?
Replaced:
```
- name: Raji Pradheap
```
with
```
- name: Raji Pradheap
  github-handle:
```

### Why did you make the changes (we will use this info to test)?
- To create a single variable `github-handle` to hold the github handle for each member of the leadership team
- Eventually `github-handle` will replace the `github` and `picture` variables, reducing redundancy in the project file

- ### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
No visual changes to the website.