### PR TITLE
Add github-handle for Michael Morgan in design-systems.md #7291

### DIFF
--- a/_projects/design-systems.md
+++ b/_projects/design-systems.md
@@ -101,6 +101,7 @@ leadership:
       github: 'https://github.com/liz-zheng'
     picture: 'https://avatars.githubusercontent.com/liz-zheng'
   - name: Michael Morgan
+    github-handle:
     role: UX/UI Designer
     links:
       slack: 'https://hackforla.slack.com/team/U01SPJCC26A'


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7291

### What changes did you make?
  - Added "github-handle" under "-name: Michael Morgan" 
 
### Why did you make the changes (we will use this info to test)?
  - We need to create a single variable github-handle to hold the github handle for each member of the leadership team. Eventually github-handle will replace the github and picture variables, reducing redundancy in the project file.

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
No visual changes to the website.