### PR TITLE
add github handle for Jed Stewart

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -13,6 +13,7 @@ leadership:
       github: "https://github.com/tylerthome"
     picture: https://avatars.githubusercontent.com/tylerthome
   - name: Jed Stewart
+    github-handle: 
     role: Developer
     links:
       slack: "https://hackforla.slack.com/team/U04A3J6V0HY"


### PR DESCRIPTION
Fixes #7176 

### What changes did you make?
Added "github-handle:" under Jed Stewart's name in home-unite-us.md 

### Why did you make the changes (we will use this info to test)?
This variable will eventually replace github and picture variables to reduce redundancy in the project file.

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
No visual changes to the website"

