### PR TITLE
Add GitHub Handle for Moji Jimoh

### DIFF
--- a/_projects/youthjusticenav.md
+++ b/_projects/youthjusticenav.md
@@ -31,6 +31,7 @@ leadership:
       github: 'https://github.com/doctorsandy'
     picture: 'https://avatars.githubusercontent.com/doctorsandy'
   - name: Moji Jimoh
+    github-handle:
     role: Product Manager
     links:
       slack: 'https://hackforla.slack.com/team/D04HDM7DM18'


### PR DESCRIPTION
Fixes #7336 

### What changes did you make?
  - Created a single variable `github-handle` to hold the github handle for Moji Jimoh

### Why did you make the changes (we will use this info to test)?
  - `github-handle` will replace the `github` and `picture` variables, reducing redundancy in the project file

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
No Visual Changes Made.