### PR TITLE
Fix mail link for Children's privacy section in privacy-policy.yml  

### DIFF
--- a/_data/internal/privacy-policy.yml
+++ b/_data/internal/privacy-policy.yml
@@ -67,7 +67,7 @@ privacy-policy: |
 
   We do not knowingly collect, maintain, or use personal information from children under 13 years of age, and no part of our Site is directed to children.
 
-  If you learn that a child has provided us with personal information in violation of this Privacy Policy, then you may alert us at [privacy@hackforla.org](privacy@hackforla.org) and reference “Child Privacy Report” in the subject line.
+  If you learn that a child has provided us with personal information in violation of this Privacy Policy, then you may alert us at [privacy@hackforla.org](mailto: privacy@hackforla.org) and reference “Child Privacy Report” in the subject line.
 
   ## Security
 


### PR DESCRIPTION
Fixes #7410 

### What changes did you make?
In the Children's privacy section I changed 
```
[privacy@hackforla.org](privacy@hackforla.org)
```
to
```
[privacy@hackforla.org](mailto: privacy@hackforla.org)
```

### Why did you make the changes (we will use this info to test)?
This change was done to properly link the email address privacy@hackforla.org, allowing readers to send emails directly from the link.

### Screenshots of Proposed Changes To The Website 


<details>
<summary>Visuals before changes are applied</summary>

<img width="1506" alt="hfla" src="https://github.com/user-attachments/assets/b5d5f591-4e58-445c-8f45-df57d17f06b7">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
https://github.com/user-attachments/assets/304d2a48-2729-4c64-b085-22a63f33176e

</details>
