### PR TITLE
Fix email link for Right to be forgotten and rectification in privacy-policy.yml

### DIFF
--- a/_data/internal/privacy-policy.yml
+++ b/_data/internal/privacy-policy.yml
@@ -77,7 +77,7 @@ privacy-policy: |
 
   ## Right to be forgotten and rectification
 
-  You may request that we make corrections to any personal data that is stored on our internal databases at any time. You may request that incomplete data be completed or that incorrect data be corrected. Requests can be submitted to [privacy@hackforla.org](privacy@hackforla.org) and reference “Hack for LA Public Website” in the subject line.
+  You may request that we make corrections to any personal data that is stored on our internal databases at any time. You may request that incomplete data be completed or that incorrect data be corrected. Requests can be submitted to [privacy@hackforla.org](mailto: privacy@hackforla.org) and reference “Hack for LA Public Website” in the subject line.
 
   ## Changes
 


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7411 

### What changes did you make?
In the Right to be forgotten and rectification section, I replaced:
`[privacy@hackforla.org](privacy@hackforla.org)`
with:
`[privacy@hackforla.org](mailto: privacy@hackforla.org)`

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
This change was made to allow users to begin drafting an email to privacy@hackforla.org by clicking the link (the old link led to a 404 page)

### Screenshots of Proposed Changes To The Website
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 
These visual changes occur after you click the privacy@hackforla.org link.
<details>
<summary>Visuals before changes are applied</summary>

![hackforla before mailto link](https://github.com/user-attachments/assets/e4481a77-ed3e-4487-9bf0-1e2f25e2c7df)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![hackforla mailto link](https://github.com/user-attachments/assets/12dc5216-6883-4e1a-ac20-c3eab0481ff9)

</details>

### A note on testing this issue
If you're having trouble testing this in Chrome, you may need to check your browser settings to get Gmail to open: 
  - Go to chrome://settings/handlers
  - Ensure "Sites can ask to handle protocols" is selected
  - If "email" is listed on this page but the link on the Hack for LA website isn't opening, remove email from the list
  - Restart Chrome
  - Log into your Gmail account
  - Try testing the link again