### PR TITLE
Fix email link in privacy-policy.yml for Questions section

### DIFF
--- a/_data/internal/privacy-policy.yml
+++ b/_data/internal/privacy-policy.yml
@@ -89,7 +89,7 @@ privacy-policy: |
 
   ## Questions
 
-  If you have any questions, comments, concerns, or complaints related to our websites, please contact us by email at [privacy@hackforla.org](privacy@hackforla.org), or by mail at:
+  If you have any questions, comments, concerns, or complaints related to our websites, please contact us by email at [privacy@hackforla.org](mailto: privacy@hackforla.org), or by mail at:
 
   Civic Tech Structure, Inc.\
   Ref: Hack for LA, HackforLA.org\


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7412

### What changes did you make?
Under the `Questions` section of the privacy-policy.yml file, I have added `mailto:` to the email link.

### Why did you make the changes (we will use this info to test)?
Adding `mailto:` will allow users to easily send an email when they click this link instead of going to a 404 page.


### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
There were no style changes affecting the website, but I have attached screen shots of the behavior changes when clicking the link.

<details>
<summary>Visuals before changes are applied</summary>

<img src="https://github.com/user-attachments/assets/f9fb7813-9f84-402b-a0b6-97da675f4e8d" width="400px" height="auto">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)
<img src="https://github.com/user-attachments/assets/68a843d2-d50a-45ae-9dea-5b98086cef8f" width="400px" height="auto">

</details>
