### PR TITLE
Removing instances of "test" as a substring in the events page - #6369

### DIFF
--- a/assets/js/utility/vrms-events.js
+++ b/assets/js/utility/vrms-events.js
@@ -4,16 +4,13 @@
 {% assign vrmsData = site.data.external.vrms_data %}
 const vrmsData = JSON.parse(decodeURIComponent("{{ vrmsData | jsonify | uri_escape }}"));
 
-/* vrmsDataFilter is a function that filters the vrmsData array to remove the instances of "test" from the events page.
-We need to add logic for removing any event that contain "test"(case-insensitive) from the events page.
+/* vrmsDataFilter is a function that filters the vrmsData array to remove the instances of "test" or "testing" from the events page.
+We need to add logic for removing any event that contain "test" or "testing" (case-insensitive) from the events page.
 */
-export const vrmsDataFilter = (vrmsData) => {
-  return vrmsData.filter(event => event.name.toLowerCase().indexOf("test") === -1);
-}
-
+const vrmsDataFilter = (vrmsData) => vrmsData.filter(data => data.name.match(/(?<=\W|^)(test(ing)?)(?=\W|$)/i) === null);
 const filteredVrmsData = vrmsDataFilter(vrmsData);
 
-/* vrmsDataFetch calls sortByDate function and passes vrmsData variable, current page which can either be "events" for the right-col-content.html page or 
+/* vrmsDataFetch calls sortByDate function and passes filteredVrmsData variable, current page which can either be "events" for the right-col-content.html page or 
 "project" from the project.html page, and passes the appendMeetingTimes function from projects.js that appends the sorted vrmsData 
 returned by sortByDate to project.html. AppendMeetingTimes is only called if vrmsDataFetch is being called from project.js for the project.html page 
 */

--- a/assets/js/utility/vrms-events.js
+++ b/assets/js/utility/vrms-events.js
@@ -7,7 +7,7 @@ const vrmsData = JSON.parse(decodeURIComponent("{{ vrmsData | jsonify | uri_esca
 /* vrmsDataFilter is a function that filters the vrmsData array to remove the instances of "test" or "testing" from the events page.
 We need to add logic for removing any event that contain "test" or "testing" (case-insensitive) from the events page.
 */
-const vrmsDataFilter = (vrmsData) => vrmsData.filter(data => data.name.match(/(?<=\W|^)(test(ing)?)(?=\W|$)/i) === null);
+const vrmsDataFilter = (vrmsData) => vrmsData.filter(data => data.name.match(/\btest(ing)?\b/i) === null);
 const filteredVrmsData = vrmsDataFilter(vrmsData);
 
 /* vrmsDataFetch calls sortByDate function and passes filteredVrmsData variable, current page which can either be "events" for the right-col-content.html page or 

--- a/assets/js/utility/vrms-events.js
+++ b/assets/js/utility/vrms-events.js
@@ -4,12 +4,21 @@
 {% assign vrmsData = site.data.external.vrms_data %}
 const vrmsData = JSON.parse(decodeURIComponent("{{ vrmsData | jsonify | uri_escape }}"));
 
+/* vrmsDataFilter is a function that filters the vrmsData array to remove the instances of "test" from the events page.
+We need to add logic for removing any event that contain "test"(case-insensitive) from the events page.
+*/
+export const vrmsDataFilter = (vrmsData) => {
+  return vrmsData.filter(event => event.name.toLowerCase().indexOf("test") === -1);
+}
+
+const filteredVrmsData = vrmsDataFilter(vrmsData);
+
 /* vrmsDataFetch calls sortByDate function and passes vrmsData variable, current page which can either be "events" for the right-col-content.html page or 
 "project" from the project.html page, and passes the appendMeetingTimes function from projects.js that appends the sorted vrmsData 
 returned by sortByDate to project.html. AppendMeetingTimes is only called if vrmsDataFetch is being called from project.js for the project.html page 
 */
 export const vrmsDataFetch = (currentPage, appendMeetingTimes) => {
-    return sortByDate(vrmsData, currentPage, appendMeetingTimes)
+    return sortByDate(filteredVrmsData, currentPage, appendMeetingTimes)
 }
 
  // Helper function used for project.html and right-col-content.html to sort VRMS data by day of the week from "date" key and meeting time from "startTime" key


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #6369

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Created new function to filter VRMS data based on "test" found in the entry name (case-insensitive)
  - Applied the function to the VRMS data
  - Checked the events page to see test entried removed

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - On `/assets/js/utility/vrms-events.js`, the code-block rendering events from the VRMS to the website contain "test" events
  - These test events are idenitified by "test" found in the entry name (case-insensitive)
  - On Docker, the filtering of "test" events can be seen on http://localhost:4000/events/

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/65b3e01e-ab56-47f4-810e-203d9535d1fc)


</details>

<details>
<summary>Visuals after changes are applied</summary>


![image](https://github.com/user-attachments/assets/1f3a6c65-02a1-4686-b888-2f50cc66fbc9)

</details>
