### PR TITLE
Update Github to GitHub in `_data/internal/communities/ops.yml`

### DIFF
--- a/_data/internal/communities/ops.yml
+++ b/_data/internal/communities/ops.yml
@@ -45,7 +45,7 @@ leadership:
 links:
   - name: Slack
     url: https://app.slack.com/client/T04502KQX/CV7QGL66B
-  - name: Github
+  - name: GitHub
     url: https://github.com/hackforla/ops
   
 recruiting-message:


### PR DESCRIPTION
Fixes #7415

### What changes did you make?
  - Replaced `- name: Github` with `- name: GitHub` in `_data/internal/communities/ops.yml`
 

### Why did you make the changes (we will use this info to test)?
  - To display the company name correctly throughout the website.

### Screenshots of Proposed Changes to the Website
- No visual changes

### Test
- Since the link `- name: GitHub` is not directly referenced in any files, there should be no visual changes.

1. Follow the steps from [How to review Pulll requests](https://github.com/hackforla/website/wiki/How-to-Review-Pull-Requests#Step3) section to view the changes locally.
2. Compare the `Ops` card on the local website at [http://localhost:4000/communities-of-practice](http://localhost:4000/communities-of-practice) to the live website at [http://www.hackforla.org/communities-of-practice](http://www.hackforla.org/communities-of-practice) and verify that there are no differences.
