### PR TITLE
Updated the leadership variable with the current team in communities/ops.yml

### DIFF
--- a/_data/internal/communities/ops.yml
+++ b/_data/internal/communities/ops.yml
@@ -12,35 +12,40 @@ alt: 'A dramatic closeup of a screen filled with code'
 leadership-type: Community Led
 leadership:
   - name: Chelsey Beck
+    github-handle: chelseybeck
     role: Co-lead
     links:
       slack: https://hackforla.slack.com/team/U01J93AQKSS
       github: https://github.com/chelseybeck
     picture: https://avatars.githubusercontent.com/chelseybeck
-  - name: Ernie Pelayo
+  - name: Alex English
+    github-handle: ale210
     role: Co-lead
     links:
-      slack: https://hackforla.slack.com/team/U046MDSM3PA
-      github: https://github.com/erniep278
-    picture: https://avatars.githubusercontent.com/erniep278
+      slack: U078B1S0XDM
+      github: https://github.com/ale210
+    picture: https://avatars.githubusercontent.com/ale210
+  - name: Ryan Sakuma
+    github-handle: RSkuma
+    role: Co-lead
+    links:
+      slack: U078U294XB6
+      github: https://github.com/RSkuma
+    picture: https://avatars.githubusercontent.com/RSkuma
+  - name: Sudha Raamakrishnan
+    github-handle: sudhara
+    role: Ops PM
+    links:
+      slack: https://hackforla.slack.com/team/U07FJRNN9MK
+      github: https://github.com/sudhara
+    picture: https://avatars.githubusercontent.com/sudhara
   - name: Dean Church
+    github-handle: Rankazze
     role: Co-lead
     links:
       slack: https://hackforla.slack.com/team/UJR0UKBN1
       github: https://github.com/Rankazze
     picture: https://avatars.githubusercontent.com/Rankazze
-  - name: Nayan Bhatt
-    role: Co-lead
-    links:
-      slack: https://hackforla.slack.com/team/U05TZLLJAUV
-      github: https://github.com/freaky4wrld
-    picture: https://avatars.githubusercontent.com/freaky4wrld
-  - name: Zoey Zhang
-    role: Co-lead
-    links:
-      slack: https://hackforla.slack.com/team/U06DT2CA92T
-      github: https://github.com/abbyz123
-    picture: https://avatars.githubusercontent.com/abbyz123
 
 links:
   - name: Slack


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7497 

### What changes did you make?
  - Removed the original "leadership" variable in website\_data\internal\communities\ops.yml
  - Replaced it with the new "leadership" variable as specified in the original Issue.

### Why did you make the changes (we will use this info to test)?
  - We need to keep project information up to date so that visitors to the website can find accurate information. These changes will help visitors find the most updated DevOps team on the [Communities of Practice](https://www.hackforla.org/communities-of-practice) page.

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-09-19 142506](https://github.com/user-attachments/assets/90082bbc-c48d-44af-8c7f-4222e8f2b6eb)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-09-19 142751](https://github.com/user-attachments/assets/06778143-fa87-4515-8998-4689743dbfa5)

</details>
