### PR TITLE
Add Lola Sarumi to Home Unite Us leadership

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -118,6 +118,13 @@ leadership:
       slack: "https://hackforla.slack.com/team/U04BEDM1B2L"
       github: "https://github.com/emeldar"
     picture: https://avatars.githubusercontent.com/emeldar
+  - name: Lola Sarumi
+    github-handle: lola3736
+    role: Lead Product / Project
+    links:
+      slack: https://hackforla.slack.com/team/U06TAL88YUV
+      github: https://github.com/lola3736
+    picture: https://avatars.githubusercontent.com/lola3736    
 links:
   - name: GitHub
     url: "https://github.com/hackforla/homeuniteus"


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7488

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Added Lola Sarumi's profile to Home Unite Us leadership (home-unite-us.md frontmatter).

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - So current team members can be properly displayed on the Hack for LA website.

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-09-23 at 16-54-21 Home Unite Us - Hack for LA](https://github.com/user-attachments/assets/8a4aa99d-f6be-4eb3-91d4-4ac36cbe7662)
</details>

<details>
<summary>Visuals after changes are applied</summary>

![Screenshot 2024-09-23 at 16-54-49 Home Unite Us - Hack for LA](https://github.com/user-attachments/assets/69bbd790-4590-4403-8012-819a03475a6d)
</details>
