### PR TITLE
Fix capitalization of "Slack" in  `pre-work-template---design.md` issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/pre-work-template---design.md
+++ b/.github/ISSUE_TEMPLATE/pre-work-template---design.md
@@ -63,7 +63,7 @@ Progress through issues with increasing complexity in the following order:
 - First, you should post the question as a comment on your assigned issue, so it can be easily referred to in the next bullet points
 - Then, add the issue to the "Design Weekly Meeting Agenda" column of the Project Board so that it can be addressed in the next design meeting
 - You may also add the label "Status: Help Wanted" so other designers can see it and potentially help answer your question
-- Lastly, you can post your question in the hfla slack channel and link the issue you're working on, so other volunteers can see and respond
+- Lastly, you can post your question in the hfla Slack channel and link the issue you're working on, so other volunteers can see and respond
 
 ### Resources/Instructions
 - [GitHub Project Board - Hack for LA ](https://github.com/hackforla/website/projects/7)


### PR DESCRIPTION
Fixes #7194

### What changes did you make?
  - Capitalized "Slack" in `pre-work-template---design.md` when used as a proper noun

### Why did you make the changes (we will use this info to test)?  
  - Correctly capitalize "Slack" when it's used to refer to the app or the company in our code and content.

 ### For Reviewers
- Use this URL to check the updated issue template: https://github.com/jchue/hackforla-website/issues/new?assignees=&labels=Complexity%3A+Prework%2C+Feature%3A+Onboarding%2FContributing.md%2C+role%3A+design%2C+size%3A+1pt&projects=&template=pre-work-template---design.md&title=Pre-work+Checklist%3A+Designer%3A+%5Breplace+brackets+with+your+name%5D

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes to the website