### PR TITLE
Refactor CONTRIBUTING.md: Removes slash at closure of Image Tag  in Section 2.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -441,7 +441,7 @@ Once you find an issue you want to work on, you need to self-assign to claim it 
 <details>
   <summary><strong>Click here</strong> to see how to move an issue from the ‘Prioritized Backlog’ to the ‘In progress (actively working)’ & back</summary>
   <p><strong>Project Board column demo</strong></p>
-  <img src="https://user-images.githubusercontent.com/21162229/137693338-97fe5f6c-820d-41c9-8e93-57b70827e0cf.gif" />
+  <img src="https://user-images.githubusercontent.com/21162229/137693338-97fe5f6c-820d-41c9-8e93-57b70827e0cf.gif">
 </details>
 
 ##### **i. After you claim an issue:**


### PR DESCRIPTION
Fixes #7097

### What changes did you make?
-Root Directory CONTRIBUTING.md file refactored  by removing slash at end of closure image tag on Section 2.4
make it better

For Reviewers: Do not test changes locally, rather test changes at https://github.com/mSharifHub/website/tree/img-tag-refactor-contributing.md-sec.2.4.b-%237097/CONTRIBUTING.md

### Why did you make the changes (we will use this info to test)?
-As requested in the Issue to meet the same syntax format of other tags


### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
-No visual changes to the website


