### PR TITLE
Replace 'Github' with 'GitHub' in `assets/js/wins.js` makecards

### DIFF
--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -331,7 +331,7 @@
 		if (card[github_url].length > 0){
 			cloneCardTemplate.querySelector('.wins-card-github-icon').href = card[github_url];
 			cloneCardTemplate.querySelector('.github-icon').src = GITHUB_ICON ;
-			cloneCardTemplate.querySelector('.github-icon').alt = `Github profile for ${card[name]}`;
+			cloneCardTemplate.querySelector('.github-icon').alt = `GitHub profile for ${card[name]}`;
 		} else {
 			cloneCardTemplate.querySelector('.wins-card-github-icon').setAttribute('hidden', 'true')
 		}


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7494

### What changes did you make?
- On line 334 in `assets/js/wins.js`, I replaced `Github profile for ${card[name]}` with `GitHub profile for ${card[name]}`. This changes the alt text of the Github icon.

### Why did you make the changes (we will use this info to test)?
- This change was made as part of a larger effort to accurately display the name "GitHub" on the website. In this context, the name will not be displayed publicly so it is for internal consistency.

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- There are no visual changes to the website.


### Details requested in issue
1. Find all the files that are connected to this change
    * This changes was made in a JS file so other files are not affected
2. Define where you expect the change to show up on the website
    * The change is not visible on the website. It's alt text for an icon so only screen readers will access the text in which case capitalization should not make a difference. Lastly, developers will see the text during code changes.
3. Test Procedure
    > This procedure is for chrome, but should be similar in other browsers.

    1. Run the website locally using docker
    2. Navigate to the wins page
    3. Right click a GitHub icon on a card in the wins page
    4. Click "inspect"
    5. Dev tools will open up to the related DOM element
    6. The `alt` attribute should have the value "GitHub profile for firstName lastName"

4. Link to test procedure comment in issue: [LINK](https://github.com/hackforla/website/issues/7494#issuecomment-2374790629)
