### PR TITLE
Updated Current Project Team Contributors in Civic Tech Jobs Profile Page

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -83,6 +83,20 @@ leadership:
       slack: https://hackforla.slack.com/team/U05JP90EHMK
       github: https://github.com/bennyv8
     picture: https://avatars.githubusercontent.com/bennyv8
+  - name: Ida Valenzuela
+    github-handle: irais-valenzuela
+    role: Developer
+    links:
+      slack: https://hackforla.slack.com/team/U062NBBNFA7
+      github: https://github.com/irais-valenzuela
+    picture: https://avatars.githubusercontent.com/u/93952027
+  - name: Kevin Yu
+    github-handle: kevin31yu
+    role: Developer
+    links:
+      slack: https://hackforla.slack.com/team/U061GQQ56Q4
+      github: https://github.com/kevin31yu
+    picture: https://avatars.githubusercontent.com/u/118224034
 links: 
   - name: GitHub
     url: https://github.com/hackforla/civictechjobs


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7521

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Added Ida Valenzuela and Kevin Yu to the Current Project Team section of the Civic Tech Jobs project page
  - Please note the Issue also requested the removal of Peter Olorunsola and Anahis Valenzuela but these members were already removed

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Updated so that the current team members can be properly displayed on the Civic Tech Jobs project page

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-09-29 150355](https://github.com/user-attachments/assets/c6afe60b-2f28-4850-b157-78914e2e7c9e)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-09-29 154146](https://github.com/user-attachments/assets/6465dfd1-f01a-4621-bf4d-b6d7ab106845)

</details>
