### PR TITLE
Added github-handle for  Natalie Aguilar in tech-work-experience

### DIFF
--- a/_projects/tech-work-experience.md
+++ b/_projects/tech-work-experience.md
@@ -83,6 +83,7 @@ leadership:
       github: 'https://github.com/meetminji'
     picture: https://avatars.githubusercontent.com/meetminji
   - name: Natalie Aguilar
+    github-handle:
     role: UX/UI Designer
     links:
       slack: 'https://hackforla.slack.com/team/U04P6N186P9'


### PR DESCRIPTION
Fixes #7252 

added githib-handle under Natalie Aguilar name

We need to create a single variable github-handle to hold the github handle for each member of the leadership team. Eventually github-handle will replace the github and picture variables, reducing redundancy in the project file. 

 No visual changes to the website
