### PR TITLE
Update wins.js so the Wins page uses icon-github.svg

### DIFF
--- a/_includes/svg/icon-github.svg
+++ b/_includes/svg/icon-github.svg
@@ -16,8 +16,8 @@
    viewBox="0 0 161.03333 157.05838"
    sodipodi:docname="icon-github.svg"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   width="161.03333"
-   height="157.05838"><metadata
+   width="33"
+   height="33"><metadata
      id="metadata8"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs

--- a/_includes/wins-page/wins-card-template.html
+++ b/_includes/wins-page/wins-card-template.html
@@ -7,7 +7,11 @@
           <span class="wins-card-name"> </span>
           <span class="wins-card-icons">
             <a target="_blank" class="wins-card-linkedin-icon"><img class="linkedin-icon" alt="" /></a>
-            <a target="_blank" class="wins-card-github-icon"><img class="github-icon" alt="" /></a>
+            <a target="_blank" class="wins-card-github-icon" style = "color:black">
+              <div role = "img" class = "github-icon">
+                  {% include svg/icon-github.svg %} 
+              </div>
+            </a>
           </span>
         </div>
         <div class="project-inner wins-card-team"></div>

--- a/_includes/wins-page/wins-card-template.html
+++ b/_includes/wins-page/wins-card-template.html
@@ -9,7 +9,7 @@
             <a target="_blank" class="wins-card-linkedin-icon"><img class="linkedin-icon" alt="" /></a>
             <a target="_blank" class="wins-card-github-icon" style = "color:black">
               <div role = "img" class = "github-icon">
-                  {% include svg/icon-github.svg %} 
+                  { % include svg/icon-github.svg % }  
               </div>
             </a>
           </span>

--- a/_includes/wins-page/wins-card-template.html
+++ b/_includes/wins-page/wins-card-template.html
@@ -9,7 +9,7 @@
             <a target="_blank" class="wins-card-linkedin-icon"><img class="linkedin-icon" alt="" /></a>
             <a target="_blank" class="wins-card-github-icon" style = "color:black">
               <div role = "img" class = "github-icon">
-                  { % include svg/icon-github.svg % }  
+                  {% include svg/icon-github.svg %}  
               </div>
             </a>
           </span>

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -291,6 +291,7 @@
 	const QUOTE_ICON_PATH = '/assets/images/wins-page/quote-icon.svg'
 	const AVATAR_DEFAULT_PATH = "/assets/images/wins-page/avatar-default.svg" 
 	const LINKEDIN_ICON = '/assets/images/wins-page/icon-linkedin-small.svg'
+	const GITHUB_ICON = '/assets/images/wins-page/icon-github-small.svg'
 	const winsCardContainer  = document.querySelector('#responses');
 
 	cards.forEach((card, index) => {

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -289,8 +289,7 @@
 	const cards = data.reverse();
 	const cardTemplate = document.getElementById("wins-card-template");
 	const QUOTE_ICON_PATH = '/assets/images/wins-page/quote-icon.svg'
-	const AVATAR_DEFAULT_PATH = "/assets/images/wins-page/avatar-default.svg"
-	const GITHUB_ICON = '/assets/images/wins-page/icon-github-small.svg';
+	const AVATAR_DEFAULT_PATH = "/assets/images/wins-page/avatar-default.svg" 
 	const LINKEDIN_ICON = '/assets/images/wins-page/icon-linkedin-small.svg'
 	const winsCardContainer  = document.querySelector('#responses');
 
@@ -331,7 +330,7 @@
 		if (card[github_url].length > 0){
 			cloneCardTemplate.querySelector('.wins-card-github-icon').href = card[github_url];
 			cloneCardTemplate.querySelector('.github-icon').src = GITHUB_ICON ;
-			cloneCardTemplate.querySelector('.github-icon').alt = `GitHub profile for ${card[name]}`;
+			cloneCardTemplate.querySelector('.github-icon').alt = `Github profile for ${card[name]}`;
 		} else {
 			cloneCardTemplate.querySelector('.wins-card-github-icon').setAttribute('hidden', 'true')
 		}


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #6911 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - In the wins.js page, I updated the makeCards function by replacing the image that was initially being used, with the image in the svg tag. This image has a name of "icon-github.svg". Since svgs files do not support the alt attribute, I had to update the html in _includes/wins-page/wins-card-template.html/wins-card-template.html to ensure the svg file was displaying on the webpage.

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - I had to change the image because using the original image was causing a redundancy in the number of images. By using an image with the svg tag, I am ensuring that there are no duplicate images. 

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 
- No visual changes made to the website 
