### PR TITLE
Added logic to check for the specified main HFLA website repository before commencing scheduling workflow.

### DIFF
--- a/.github/workflows/schedule-fri-0700.yml
+++ b/.github/workflows/schedule-fri-0700.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   Add-Update-Label-to-Issues-Weekly:
     runs-on: ubuntu-latest
+    if: github.repository == 'hackforla/website'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/github-script@v7


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7500

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Added an if-conditional statement to `schedule-fri-0700.yml` which commences the workflow after checking for the specified main hackforla/website repository.

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Previously the scheduling workflow could be run from any individual user's repository, which could be a nuisance or cause confusion.

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes to the website