### PR TITLE
Update spell-check-audit.md label and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/spell-check-audit.md
+++ b/.github/ISSUE_TEMPLATE/spell-check-audit.md
@@ -18,7 +18,7 @@ We need to audit HfLA codebase files for spelling errors using the Code Spell Ch
 - [ ] Locate the file in column A ("File") of the "Page Audit" sheet. In the column labeled "Result Summary", select the appropriate option: `No errors` or `At least one error`.
 - [ ] If at least one error was reported, copy/paste each cSpell message into a separate row in the `Results` sheet
 - [ ] In each new row, select the appropriate value: `misspelling` or `false positive` from the "Result type" column. A false positive is a term that is not a misspelling but is not recognized by the spell checker because it is a technical term, abbreviation, acronym, URL or proper noun (name of a person, place or organization).
-- [ ] Move this issue to the Questions/In Review column and apply the label `ready for dev lead`
+- [ ] Move this issue to the Questions/In Review column and apply the label `ready for merge team`
 
 ### Merge Team
 - [ ] After this issue is closed, release the dependency on this issue in #5248

--- a/.github/ISSUE_TEMPLATE/spell-check-audit.md
+++ b/.github/ISSUE_TEMPLATE/spell-check-audit.md
@@ -2,7 +2,7 @@
 name: Spell check audit web page
 about: For checking spelling on a code file that contains text displayed on the website
 title: Run VS Code Spell Checker on [INSERT FILE HERE]
-labels: 'Complexity: Small, feature: spelling, ready for dev lead, role: back end/devOps,
+labels: 'Complexity: Small, feature: spelling, ready for merge team, role: back end/devOps,
   role: front end, size: 0.5pt'
 assignees: ''
 


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7601

### What changes did you make?
<!--  Note: add lines if needed, and remove any unused lines  -->  
  - ln 5 and 21 in spell-check-audit.md changed "ready for dev lead" to "ready for merge team"

### Why did you make the changes (we will use this info to test)?
<!--  Note: add lines if needed, and remove any unused lines  -->  
  - language changed to address merge team instead of dev leads
  
 ### For Reviewers
- Use this URL to check the updated issue template: https://github.com/aswutmaxcy/website/issues/new?assignees=&labels=Complexity%3A+Small%2C+feature%3A+spelling%2C+ready+for+merge+team%2C+role%3A+back+end%2FdevOps%2C+role%3A+front+end%2C+size%3A+0.5pt&projects=&template=spell-check-audit.md&title=Run+VS+Code+Spell+Checker+on+%5BINSERT+FILE+HERE%5D

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
  ![image](https://github.com/user-attachments/assets/1a028e12-ff99-4d8e-b673-e51fbdba0b8b)