### PR TITLE
Replace 'Github' with 'GitHub' in data-science.yml

### DIFF
--- a/_data/internal/communities/data-science.yml
+++ b/_data/internal/communities/data-science.yml
@@ -28,7 +28,7 @@ leadership:
 links:
   - name: Slack
     url: https://app.slack.com/client/T04502KQX/CGRATJCCF
-  - name: Github
+  - name: GitHub
     url: https://github.com/hackforla/data-science/
   
 recruiting-message:


### PR DESCRIPTION
Fixes #7416

### What changes did you make?  
  - Changed `Github` to `GitHub` on `_data/internal/communities/data-science.yml`


### Why did you make the changes (we will use this info to test)?
  -  The website should display proper capitalization for GitHub to match the company's branding.
 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)


### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes to the website

### Connected file
The `_data/internal/communities/data-science.yml` file is used to display the Data Science community on `https://www.hackforla.org/communities-of-practice`. The template for the community of practice page, `pages\communities-of-practice.html`, does not reference the `GitHub` text that I have changed in this PR. The "GitHub" text that does display on this page has been hard-coded in the html template. There should be no visible changes to the page. However, if this variable is referenced in the template in future, it will have the correct capitalization.

### Test
- Compare http://localhost:4000/communities-of-practice to the live page on HfLA website https://www.hackforla.org/communities-of-practice. Specifically the area with the title "Data Science".
-  Check for visual changes. There should be none.
- GitHub button redirects correctly to https://github.com/hackforla/data-science/