### PR TITLE
Refactor GHA 'sort-closed-issues.js'

### DIFF
--- a/github-actions/move-closed-issues/sort-closed-issues.js
+++ b/github-actions/move-closed-issues/sort-closed-issues.js
@@ -1,4 +1,5 @@
 const obtainLabels = require('../utils/obtain-labels');
+const retrieveLabelDirectory = require('../../utils/retrieve-label-directory');
 
 /**
  * Check the labels of an issue, and return the 'status' the issue should be sorted into when closed
@@ -10,16 +11,35 @@ function main({ context }) {
   const doneStatus = 'Done';
   const QAStatus = 'QA';
 
+  // Use labelKeys to retrieve current labelNames from directory
+  const [
+    featureRefactorCss,
+    featureRefactorHtml,
+    featureRefactorJsLiquid,
+    featureRefactorGha,
+    roleBackEndDevOps,
+    featureAnalytics,
+    roleFrontEnd
+  ] = [
+    "featureRefactorCss",
+    "featureRefactorHtml", 
+    "featureRefactorJsLiquid",
+    "featureRefactorGha",
+    "roleBackEndDevOps",
+    "featureAnalytics",
+    "roleFrontEnd"
+  ].map(retrieveLabelDirectory);
+
   const hardLabels = [
-    'Feature: Refactor CSS',
-    'Feature: Refactor HTML',
-    'Feature: Refactor JS / Liquid',
-    'Feature: Refactor GHA',
+    featureRefactorCss,
+    featureRefactorHtml,
+    featureRefactorJsLiquid,
+    featureRefactorGha,
   ];
 
-  const softLabels = ['role: back end/devOps', 'Feature: Analytics'];
+  const softLabels = [roleBackEndDevOps, featureAnalytics];
 
-  const overrideSoftLabels = ['role: front end'];
+  const overrideSoftLabels = [roleFrontEnd];
 
   const issueLabels = obtainLabels(context);
 

--- a/github-actions/move-closed-issues/sort-closed-issues.js
+++ b/github-actions/move-closed-issues/sort-closed-issues.js
@@ -1,5 +1,5 @@
 const obtainLabels = require('../utils/obtain-labels');
-const retrieveLabelDirectory = require('../../utils/retrieve-label-directory');
+const retrieveLabelDirectory = require('../utils/retrieve-label-directory');
 
 /**
  * Check the labels of an issue, and return the 'status' the issue should be sorted into when closed


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7530

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Imported 'retrieveLabelDirectory' function into sort-closed-issues.js 
  - Use 'retrieveLabelDirectory' function to replace each labelName variable with the corresponding labelKey
  - Substitute the labelKey variable with each of the original label names in sort-closed-issues.js

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To refactor the GHA workflows to reference each label by a general ID (labelKey) so that other HFLA groups can use these workflows without having to match the label names used by the website team
  
<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 
No visual changes to website.

Tested workflows:
move-closed-issues.yaml

![Screenshot 2024-11-17 at 19-21-29 issue 31 · aadilahmed_website@1b9ea05](https://github.com/user-attachments/assets/a4ddc2a9-029e-4fdb-af96-4b1008ff7aca)