### PR TITLE
Replaced Broken Terminal Command With Working Terminal Commands in the CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -704,7 +704,7 @@ git checkout -b upstream-gh-pages --track upstream/gh-pages
 ```
 
 If you have already created the branch upstream-gh-pages, the following commands will incorporate upstream changes:
-<!-- Replace Old Content With New Content-->
+
 1. Move to the branch you want to merge with.
 ```bash
 git checkout upstream-gh-pages 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -704,12 +704,25 @@ git checkout -b upstream-gh-pages --track upstream/gh-pages
 ```
 
 If you have already created the branch upstream-gh-pages, the following commands will incorporate upstream changes:
-
+<!-- Replace Old Content With New Content-->
+1. Move to the branch you want to merge with.
 ```bash
-git checkout upstream-gh-pages # Move to the branch you want to merge with.
-git pull  # This updates your tracking branch to match the gh-pages branch in this repository
-git checkout gh-pages  # Move back to your gh-pages branch
-git merge upstream-gh-pages  # Merge to bring your gh-pages current.
+git checkout upstream-gh-pages 
+```
+
+2. Update your tracking branch with the latest changes from the `gh-pages` branch in this repository
+```bash
+git pull  
+```
+
+3. Move back to your gh-pages branch
+```bash
+git checkout gh-pages  
+```
+
+4. Merge your changes back into your `gh-pages` branch.
+```bash
+git merge upstream-gh-pages
 ```
 If you do all your work on topic branches (as suggested above) and keep gh-pages free of local modifications, this merge should apply cleanly.
 


### PR DESCRIPTION
 Fixes #7378

### What changes did you make?
  - Updated `website/CONTRIBUTING.md` section "2.7e Working on an issue (5): Incorporating changes form upstream"
  - Replaced broken terminal commands with functional terminal commands, if branch upstream-gh-pages has already been created

### Why did you make the changes (we will use this info to test)?
  - The CONTRIBUTING.md section 2.7e has code formatting errors that need to be fixed.

### For Reviewers:
  - Do not review changes locally, rather, review changes at https://github.com/dvernon5/website/blob/replacing-broken-code-command-7378/CONTRIBUTING.md#27e-working-on-an-issue-5-incorporating-changes-from-upstream

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

No visual changes to the website
