### PR TITLE
Refactoring `check-labels.js` to use `label-directory.json`

### DIFF
--- a/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
@@ -10,6 +10,7 @@ const [
   featureMissing,
   complexityMissing,
   roleMissing,
+  complexity1,
   complexity2,
   readyForDevLead,
   featureAdministrative,
@@ -20,6 +21,7 @@ const [
   "featureMissing",
   "complexityMissing",
   "roleMissing",
+  "complexity1",
   "complexity2",
   "readyForDevLead",
   "featureAdministrative",
@@ -30,10 +32,11 @@ const [
 // Constant variables
 const REQUIRED_LABELS = ['complexity', 'role', 'feature', 'size'];
 const LABEL_MISSING = [complexityMissing, roleMissing, featureMissing, sizeMissing];
-
+// Exception for the `good first issue` label
+const COMPLEXITY_EXCEPTIONS = [complexity1];
 
 // SPECIAL_CASE is for issue created by reference with issue title "Hack for LA website bot"
-// (from "Review Inactive Team Members", "Schedule Monthly" workflow)
+// ("Review Inactive Team Members" from the "Schedule Monthly" workflow)
 const SPECIAL_CASE = [readyForDevLead, featureAdministrative, size025pt, complexity2, roleDevLeads];
 
 // Global variables
@@ -110,6 +113,11 @@ function checkLabels(labels) {
   REQUIRED_LABELS.forEach((requiredLabel, i) => {
     const regExp = new RegExp(`\\b${requiredLabel}\\b`, 'gi');
     const isLabelPresent = labels.some(label => {
+      // If the label is in the complexity exceptions array, it also fulfills the complexity requirements
+      if (COMPLEXITY_EXCEPTIONS.includes(label) && requiredLabel === 'Complexity') {
+        return true;
+      }
+
       return regExp.test(label);
     })
 
@@ -117,7 +125,7 @@ function checkLabels(labels) {
       labelsToAdd.push(LABEL_MISSING[i]);
     }
   })
-  
+
   return labelsToAdd;
 }
 

--- a/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
@@ -2,14 +2,39 @@
 const statusFieldIds = require('../../utils/_data/status-field-ids');
 const queryIssueInfo = require('../../utils/query-issue-info');
 const mutateIssueStatus = require('../../utils/mutate-issue-status');
+const retrieveLabelDirectory = require('../../utils/retrieve-label-directory');
+
+// Use labelKeys to retrieve current labelNames from directory
+const [
+  sizeMissing,
+  featureMissing,
+  complexityMissing,
+  roleMissing,
+  complexity2,
+  readyForDevLead,
+  featureAdministrative,
+  size025pt,
+  roleDevLeads
+] = [
+  "sizeMissing",
+  "featureMissing",
+  "complexityMissing",
+  "roleMissing",
+  "complexity2",
+  "readyForDevLead",
+  "featureAdministrative",
+  "size025pt",
+  "roleDevLeads"
+].map(retrieveLabelDirectory);
 
 // Constant variables
-const REQUIRED_LABELS = ['Complexity', 'role', 'Feature', 'size'];
-const LABEL_MISSING = ['Complexity: Missing', 'role missing', 'Feature Missing', 'size: missing'];
-const COMPLEXITY_EXCEPTIONS = ['good first issue'];
+const REQUIRED_LABELS = ['complexity', 'role', 'feature', 'size'];
+const LABEL_MISSING = [complexityMissing, roleMissing, featureMissing, sizeMissing];
 
-// SPECIAL_CASE is for issue created by reference with issue title "Hack for LA website bot" (from "Review Inactive Team Members")
-const SPECIAL_CASE = ['ready for dev lead','Feature: Administrative','size: 0.25pt','Complexity: Small','role: dev leads'];
+
+// SPECIAL_CASE is for issue created by reference with issue title "Hack for LA website bot"
+// (from "Review Inactive Team Members", "Schedule Monthly" workflow)
+const SPECIAL_CASE = [readyForDevLead, featureAdministrative, size025pt, complexity2, roleDevLeads];
 
 // Global variables
 var github;
@@ -85,11 +110,6 @@ function checkLabels(labels) {
   REQUIRED_LABELS.forEach((requiredLabel, i) => {
     const regExp = new RegExp(`\\b${requiredLabel}\\b`, 'gi');
     const isLabelPresent = labels.some(label => {
-      // If the label is in the complexity exceptions array, it also fulfills the complexity requirements
-      if (COMPLEXITY_EXCEPTIONS.includes(label) && requiredLabel === 'Complexity') {
-        return true;
-      }
-
       return regExp.test(label);
     })
 

--- a/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
@@ -114,7 +114,7 @@ function checkLabels(labels) {
     const regExp = new RegExp(`\\b${requiredLabel}\\b`, 'gi');
     const isLabelPresent = labels.some(label => {
       // If the label is in the complexity exceptions array, it also fulfills the complexity requirements
-      if (COMPLEXITY_EXCEPTIONS.includes(label) && requiredLabel === 'Complexity') {
+      if (COMPLEXITY_EXCEPTIONS.includes(label) && requiredLabel === 'complexity') {
         return true;
       }
 

--- a/github-actions/utils/_data/status-field-ids.js
+++ b/github-actions/utils/_data/status-field-ids.js
@@ -1,7 +1,7 @@
 /**
   * The purpose of this utility is to list the (non-changing) GraphQL ids of the 'Status' fields
-  * for the Website Project so that functions will not need to run a GraphQL query when needed
-  *                   SEE BELOW for GraphQL query used to generate this list
+  * for the Website Project so that functions will not need to run a GraphQL query each time
+  *                   SEE BELOW for GraphQL query used to generate the values from this list
   *
   * @params {String} statusField  - Standardized name of status field (see lines 10-27)
   * @returns {String} statusId    - the field id of the selected status
@@ -10,6 +10,12 @@
 function statusFieldIds(statusField) {
 
   const statusValues = new Map([
+
+    // Default values for HfLA Website Project 86
+    ["WEBSITE_PROJECT_ID", "PVT_kwDOALGKNs4Ajuck"],
+    ["STATUS_FIELD_ID", "PVTSSF_lADOALGKNs4AjuckzgcCutQ"],
+
+    // Individual Status field values
     ["Agendas", "864392c1"],
     ["Ice_Box", "2b49cbab"],
     ["Emergent_Requests", "d468e876"],    
@@ -40,15 +46,13 @@ query findStatusSubfieldIds ($login: String!, $projNum: Int!, $fieldName: String
   organization(login: $login) {
     projectV2(number: $projNum) {
       id
-      field(name:$fieldName) { 
-        ... on ProjectV2SingleSelectField { 	
-        id options{ 
+      field(name: $fieldName) {
+        ... on ProjectV2SingleSelectField {
+          id 
+          options {
             id
             name
-            ... on ProjectV2SingleSelectFieldOption {
-              id
-            }
-          } 
+          }
         }
       }
     }
@@ -56,7 +60,7 @@ query findStatusSubfieldIds ($login: String!, $projNum: Int!, $fieldName: String
 }
 
 {
-  "login":"hackforla",
+  "login": "hackforla",
   "projNum": 86,
 	"fieldName": "Status"
 }

--- a/github-actions/utils/_data/status-field-ids.js
+++ b/github-actions/utils/_data/status-field-ids.js
@@ -12,8 +12,8 @@ function statusFieldIds(statusField) {
   const statusValues = new Map([
 
     // Default values for HfLA Website Project 86
-    ["WEBSITE_PROJECT_ID", "PVT_kwDOALGKNs4Ajuck"],
-    ["STATUS_FIELD_ID", "PVTSSF_lADOALGKNs4AjuckzgcCutQ"],
+    ["PROJECT_ID", "PVT_kwDOALGKNs4Ajuck"],
+    ["FIELD_ID", "PVTSSF_lADOALGKNs4AjuckzgcCutQ"],
 
     // Individual Status field values
     ["Agendas", "864392c1"],

--- a/github-actions/utils/_data/status-field-ids.js
+++ b/github-actions/utils/_data/status-field-ids.js
@@ -62,7 +62,7 @@ query findStatusSubfieldIds ($login: String!, $projNum: Int!, $fieldName: String
 {
   "login": "hackforla",
   "projNum": 86,
-	"fieldName": "Status"
+  "fieldName": "Status"
 }
 */
 

--- a/github-actions/utils/mutate-issue-status.js
+++ b/github-actions/utils/mutate-issue-status.js
@@ -1,5 +1,5 @@
 // Import modules
-const statusFieldIds = require('../../utils/_data/status-field-ids');
+const statusFieldIds = require('./_data/status-field-ids');
 
 /**
  * Changes the 'Status' of an issue (with the corresponding itemId) to a newStatusValue
@@ -14,8 +14,8 @@ async function mutateIssueStatus(
   newStatusValue
 ) {
   // Defaults for HfLA Website Project 86
-  const WEBSITE_PROJECT_ID = statusFieldIds("WEBSITE_PROJECT_ID");
-  const STATUS_FIELD_ID = statusFieldIds("STATUS_FIELD_ID");
+  const PROJECT_ID = statusFieldIds("PROJECT_ID");
+  const FIELD_ID = statusFieldIds("FIELD_ID");
 
   const mutation = `mutation($projectId: ID!, $fieldId: ID!, $itemId: ID!, $value: String!) {
     updateProjectV2ItemFieldValue(input: {
@@ -33,8 +33,8 @@ async function mutateIssueStatus(
   }`;
 
   const variables = {
-    projectId: WEBSITE_PROJECT_ID,
-    fieldId: STATUS_FIELD_ID,
+    projectId: PROJECT_ID,
+    fieldId: FIELD_ID,
     itemId: itemId,
     value: newStatusValue,
   };

--- a/github-actions/utils/mutate-issue-status.js
+++ b/github-actions/utils/mutate-issue-status.js
@@ -1,3 +1,6 @@
+// Import modules
+const statusFieldIds = require('../../utils/_data/status-field-ids');
+
 /**
  * Changes the 'Status' of an issue (with the corresponding itemId) to a newStatusValue
  * @param {String} itemId          -  GraphQL item Id for the issue
@@ -11,8 +14,8 @@ async function mutateIssueStatus(
   newStatusValue
 ) {
   // Defaults for HfLA Website Project 86
-  const WEBSITE_PROJECT_ID = 'PVT_kwDOALGKNs4Ajuck';
-  const STATUS_FIELD_ID = 'PVTSSF_lADOALGKNs4AjuckzgcCutQ';
+  const WEBSITE_PROJECT_ID = statusFieldIds("WEBSITE_PROJECT_ID");
+  const STATUS_FIELD_ID = statusFieldIds("STATUS_FIELD_ID");
 
   const mutation = `mutation($projectId: ID!, $fieldId: ID!, $itemId: ID!, $value: String!) {
     updateProjectV2ItemFieldValue(input: {
@@ -39,7 +42,7 @@ async function mutateIssueStatus(
   try {
     await github.graphql(mutation, variables);
   } catch (error) {
-    throw new Error('Error in mutateItemStatus() function: ' + error);
+    throw new Error('Error in mutateIssueStatus() function: ' + error);
   }
 }
 


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7531 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - In `check-labels.js`, replaced labelNames with equivalent labelKey values and call to `retrieveLabelDirectory`
  - Moved hard-coded values from `mutate-issue-status.js` and consolidated into `status-field-ids.js`
  - Changed variable name and corrected error message in `mutate-issue-status.js`

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - We are refactoring codebase to use the labelKey values so that the functions can be shared throughout the org
  - Having all of the hard-coded values in one location makes them easier to track. 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes
- [Issue created](https://github.com/t-will-gillis/website/issues/1125) after refactoring
- [Workflow log](https://github.com/t-will-gillis/website/actions/runs/12073614272) showing correct functioning after refactoring
- [Issue created](https://github.com/t-will-gillis/website/issues/1128) for second part (see below)
- [Workflow log](https://github.com/t-will-gillis/website/actions/runs/12073984241/) for second part

## Notes for Reviewers
In order to review this issue, you will need to set up your environment first:
- Refer to [Hack for LA's GitHub Actions (current revision)](https://github.com/hackforla/website/issues/6537#issuecomment-2041147335), especially Tips 6, 7, and 8, if you have not already created you personal environment for testing.
- [How to Test GitHub Actions](https://drive.google.com/drive/u/0/folders/1MPY9CKcfKKN7hpDCG46ARrRzRSM8d8OA)
- [Additional Notes for GitHub Actions](https://docs.google.com/document/d/1frtvr5twBa_3yRGCG0divhlOMW8dPJxT/edit)
- To test the first part of this: go to "Issues" in your repo, select "New issue", and select any of the issues templates. Remove any labels that are there, and add back either no labels or one or two such as `good first issue` and `size: 5pt`, then create issue. The bot should add the `Complexity: missing`, `role: missing`, etc. as appropriate.
- To test the second part of this, there is a little bit more work to do:
  - First, open [GithHub's GraphQL Explorer](https://docs.github.com/en/graphql/overview/explorer). Link up to your repo if needed
  - Go to `github-actions/utils/_data/status-field-ids.js` and scroll down to the comments. Copy lines 47-62 in the query section, and lines 64-68 under variables. Replace with your login and the number of your project board- it is probably '1' but you can check by selecting "Projects" from your repo and seeing what number yours is.
  - Run Explorer, then change "organization" to "user", substitute your values for the "projectV2" and "filed" ids, as well as the value for "Questions/ In Review", into `status-field-ids.js`.
  - Go to "Issues" again, select "New issue",  find "Blank Issue Template" and select "Get started". Remove all the labels, then title your issue:
  ```  
  The Hack for LA website bot removed me!  
  ```  
  - Then "Submit new issue". If everything works, the issue will be labelled correctly and moved to "Status" "Questions/ In Review"
