### PR TITLE
Maintenance for `label-directory.json` 

### DIFF
--- a/github-actions/utils/_data/label-directory.json
+++ b/github-actions/utils/_data/label-directory.json
@@ -629,7 +629,7 @@
   ],
   "roleMissing": [
     "role missing",
-    9999999999
+    7781839026
   ],
   "roleOrgRep": [
     "role: Org Rep",
@@ -826,10 +826,6 @@
   "NEW-roleFrontEndBackEnd": [
     "role: front-end/back-end",
     9999999999
-  ],
-  "NEW-roleMissing": [
-    "role missing",
-    7781839026
   ],
   "NEW-featureFaq": [
     "feature: FAQ",

--- a/github-actions/utils/_data/label-directory.json
+++ b/github-actions/utils/_data/label-directory.json
@@ -834,5 +834,9 @@
   "NEW-featureFaq": [
     "feature: FAQ",
     7970290985
-  ]
+  ],
+  "NEW-skillsTemplateStatusNeedNextSteps": [ 
+    "Skills Template status: Need Next Steps", 
+    7582275087
+  ], 
 }

--- a/github-actions/utils/_data/label-directory.json
+++ b/github-actions/utils/_data/label-directory.json
@@ -819,14 +819,6 @@
     "milestone: missing",
     7695414022
   ],
-  "NEW-frontEnd": [
-    "front end",
-    9999999999
-  ],
-  "NEW-roleFrontEndBackEnd": [
-    "role: front-end/back-end",
-    9999999999
-  ],
   "NEW-featureFaq": [
     "feature: FAQ",
     7970290985

--- a/github-actions/utils/_data/label-directory.json
+++ b/github-actions/utils/_data/label-directory.json
@@ -787,14 +787,6 @@
     "wontfix",
     905516652
   ],
-  "NEW-labelForTestingOnly": [
-    "Label for TESTING only!!!",
-    9999999999
-  ],
-  "NEW-labelForTestingPart2": [
-    "Label for TESTING part 2",
-    9999999999
-  ],
   "NEW-featureRoadmap": [
     "feature: Roadmap",
     7472857782


### PR DESCRIPTION

<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7770

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - no. 12: JSON updated with existing label from run 
  - no. 20: No changes- this label should not be added, and was deleted
  - no. 25, 26: the `role missing` label, deleted in 25, reassigned with replacement label id from 26, replacement label deleted.
  - no. 19, 23: Deleting JSON entry for False label "New-frontEnd"
  - no. 21, 24: Deleting JSON entry for False label "New-roleFrontEndBackEnd"
  - Deleting early testing labels

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Clean up and maintenance on JSON
 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 
- No visual changes
