### PR TITLE
Update GitHub text in wins.js

### DIFF
--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -9,8 +9,8 @@
   const name = "Full name"
   const linkedin_url = "Linkedin URL (optional)"
   const linkedin_permission = "Could we use your Linkedin profile picture next to your story?"
-  const github_url = "GitHub URL (optional)"
-  const github_permission = "Could we use your GitHub profile picture next to your story?"
+  const github_url = "Github URL (optional)"
+  const github_permission = "Could we use your Github profile picture next to your story?"
   const team = "Select the team(s) you're on"
   const role = "Select your role(s) on the team"
   const specific_role = "What is/was your specific role? (optional)"
@@ -25,7 +25,7 @@
 		"I produced something for my portfolio": `file.svg`,
 		"I improved my LinkedIn": `linkedin.svg`,
 		"I learned how to work better on a team": `team.svg`,
-		"I increased the number of commits on my GitHub profile": `github.svg`,
+		"I increased the number of commits on my Github profile": `github.svg`,
 		"I learned a new language": `code.svg`,
 		"I set up 2FA": `twofa.svg`,
 		"I became part of a a caring community": `$community.svg`,
@@ -337,15 +337,15 @@
 		}
 
 		// Avoiding using innerHTML due to security risks
-		// Creating the elements 
+		// Creating the elements
 		const teamContainer = cloneCardTemplate.querySelector('.project-inner.wins-card-team');
 		const roleContainer = cloneCardTemplate.querySelector('.project-inner.wins-card-role');
 		const teamSpanElement = document.createElement('span');
 		teamSpanElement.classList.add('wins-team-role-color');
 		const roleSpanElement = document.createElement('span');
 		roleSpanElement.classList.add('wins-team-role-color');
-		
-		// Preparing the text of the elements 
+
+		// Preparing the text of the elements
 		teamSpanElement.textContent = "Team(s): ";
 		const teamTextNode = document.createTextNode(card[team]);
 		roleSpanElement.textContent = "Role(s): ";

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -9,8 +9,8 @@
   const name = "Full name"
   const linkedin_url = "Linkedin URL (optional)"
   const linkedin_permission = "Could we use your Linkedin profile picture next to your story?"
-  const github_url = "Github URL (optional)"
-  const github_permission = "Could we use your Github profile picture next to your story?"
+  const github_url = "GitHub URL (optional)"
+  const github_permission = "Could we use your GitHub profile picture next to your story?"
   const team = "Select the team(s) you're on"
   const role = "Select your role(s) on the team"
   const specific_role = "What is/was your specific role? (optional)"
@@ -25,7 +25,7 @@
 		"I produced something for my portfolio": `file.svg`,
 		"I improved my LinkedIn": `linkedin.svg`,
 		"I learned how to work better on a team": `team.svg`,
-		"I increased the number of commits on my Github profile": `github.svg`,
+		"I increased the number of commits on my GitHub profile": `github.svg`,
 		"I learned a new language": `code.svg`,
 		"I set up 2FA": `twofa.svg`,
 		"I became part of a a caring community": `$community.svg`,
@@ -506,7 +506,7 @@ function changeSeeMoreBtn(x) {
   		if (data[i][linkedin_url].length > 0) {
   			makeIcon(data[i][linkedin_url], overlayIcons, 'linkedin-icon', '/assets/images/wins-page/icon-linkedin-small.svg', 'LinkedIn profile for ' + data[i][name]);
   		} if (data[i][github_url].length > 0) {
-  			makeIcon(data[i][github_url], overlayIcons, 'github-icon', '/assets/images/wins-page/icon-github-small.svg', 'Github profile for ' + data[i][name]);
+  			makeIcon(data[i][github_url], overlayIcons, 'github-icon', '/assets/images/wins-page/icon-github-small.svg', 'GitHub profile for ' + data[i][name]);
   		}
 
   		const overlayName = document.querySelector('#overlay-name');


### PR DESCRIPTION
Fixes #7495 

### What changes did you make?
  - On line 509, in `function updateOverlay(i)`, changed
```
makeIcon(data[i][github_url], overlayIcons, 'github-icon', '/assets/images/wins-page/icon-github-small.svg', 'Github profile for ' + data[i][name]);
```
to
```
makeIcon(data[i][github_url], overlayIcons, 'github-icon', '/assets/images/wins-page/icon-github-small.svg', 'GitHub profile for ' + data[i][name]);
```

### Why did you make the changes (we will use this info to test)?
  - We needed to replace the instance of `Github` with `GitHub` to correctly display the company name and test the changes to ensure the behavior and appearance of any and all related webpages were unchanged.

<h3>CodeQL Alerts</h3>

After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.

<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)

</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes to the website

### Related Files
- Since the only instance of `Github` changed to `GitHub` was on line 509, the only files affected are:
  - `_includes/wins-page/wins-card-template.html` and
  - `pages/wins/wins.html`
- The only expected change is to see the alt text for the GitHub profile icon within each person's card in the Wins page will be updated from `Github profile for <name>` to `GitHub profile for <name>`.
  - Making this change on line 509 within the `updateOverlay` function inside the `assets/js/wins.js` file changes how the alt text is prepared for each person's Wins card on the Wins page of the website by changing what text is passed to these components.
- If other instances of `Github` need to be changed in the future, see my [issue comment](https://github.com/hackforla/website/issues/7495#issuecomment-2628726162) addressing how these files would also be affected:
  - `_data/external/_wins-data.json`
  - `google-apps-scripts/wins-form-responses/Code.js`

### Notes for Testing
- Please test for the correct change to the GitHub icon alt text as documented in the issue here: https://github.com/hackforla/website/issues/7495#issuecomment-2640501913
