### PR TITLE
Change label to `Status: Unassigned by Bot` for previously prioritized issues

### DIFF
--- a/github-actions/trigger-issue/add-preliminary-comment/check-complexity-eligibility.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/check-complexity-eligibility.js
@@ -348,12 +348,12 @@ async function handleIssueComplexityNotPermitted(
       assignees: [assigneeUsername],
     });
     
-    // Add 'Ready for Prioritization' label 
+    // Add 'Status: Unassigned by Bot' label 
     await github.rest.issues.addLabels({
       owner,
       repo,
       issue_number: currentIssueNum,
-      labels: ['Ready for Prioritization'],
+      labels: ['Status: Unassigned by Bot'],
     });
   
     // Change issue's status to New Issue Approval 

--- a/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
@@ -77,7 +77,7 @@ async function main({ g, c }, { shouldPost, issueNum }) {
 
       await unAssignDev();
       await addLabel(STATUS_UNASSIGNED_BY_BOT);
-      console.log(' - remove developer and label for re-prioritization');
+      console.log(' - remove developer and add label for re-prioritization');
 
       // Update item's status to "New Issue Approval"
       let statusValue = statusFieldIds('New_Issue_Approval');

--- a/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
@@ -16,7 +16,7 @@ let assignee;
 
 const emergentRequests = 'Emergent Requests';
 const newIssueApproval = 'New Issue Approval';
-const READY_FOR_PRIORITIZATION = "Ready for Prioritization";
+const STATUS_UNASSIGNED_BY_BOT = "Status: Unassigned by Bot";
 
 
 
@@ -76,8 +76,8 @@ async function main({ g, c }, { shouldPost, issueNum }) {
       console.log(' - add `multiple-issue-reminder.md` comment to issue');
 
       await unAssignDev();
-      await addLabel(READY_FOR_PRIORITIZATION);
-      console.log(' - remove developer and add `Ready for Prioritization` label');
+      await addLabel(STATUS_UNASSIGNED_BY_BOT);
+      console.log(' - remove developer and label for re-prioritization');
 
       // Update item's status to "New Issue Approval"
       let statusValue = statusFieldIds('New_Issue_Approval');

--- a/github-actions/utils/_data/label-directory.json
+++ b/github-actions/utils/_data/label-directory.json
@@ -827,7 +827,7 @@
     "role: data scientist",
     8056944058
   ],
-  "NEW-statusUnassignedByBot": [
+  "statusUnassignedByBot": [
     "Status: Unassigned by Bot",
     8096814358
   ]


### PR DESCRIPTION
Fixes #7881

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - In `check-complexity-eligiblity.js` and `preliminary-update-comments.js`, changed label from `Ready for Prioritization` to `Status: Unassigned by Bot` 
  - In `label-directory.json`, edited key by removing "NEW-" prepend from "statusUnassignedByBot"


### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - The replacement label will be used as a flag to let Product know that the issue was previously prioritized, and therefore does not need to be reviewed again- only prioritized.
  - The prepend is initially added to the label key by the bot to let us know the key is new. It is no longer needed.


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

- No changes to the website
