### PR TITLE
Replace github with GitHub in CONTRIBUTING.md Section 2.7.e

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -688,7 +688,7 @@ From https://github.com/hackforla/website
 
 #### **2.7.e Working on an issue (5): Incorporating changes from upstream**
 
-Your fork of this repository on GitHub, and your local clone of that fork, will get out of sync with this (upstream) repository from time to time. (That's what has happened when you see something like "This branch is 1 commit behind hackforla:gh-pages" on the github website version of your hackforla repository.)
+Your fork of this repository on GitHub, and your local clone of that fork, will get out of sync with this (upstream) repository from time to time. (That's what has happened when you see something like "This branch is 1 commit behind hackforla:gh-pages" on the GitHub website version of your hackforla repository.)
 
 One way to keep your fork up to date with this repository is to follow these instruction: [Syncing your fork to the original repository via the browser](https://github.com/KirstieJane/STEMMRoleModels/wiki/Syncing-your-fork-to-the-original-repository-via-the-browser)
 
@@ -732,7 +732,7 @@ Then push the merge changes to your GitHub fork:
 git push
 ```
 
-If you go to your online github repository this should remove the message "This branch is x commit behind hackforla:gh-pages".
+If you go to your online GitHub repository this should remove the message "This branch is x commit behind hackforla:gh-pages".
 
 ##### **i. Incorporating changes into your topic branch**
 


### PR DESCRIPTION
<!--  Note: Delete the message above if you joined this team via onboarding  -->

<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7440

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
In CONTRIBUTING.md Section 2.7.e, I replaced: 
```
Your fork of this repository on GitHub, and your local clone of that fork, will get out of sync with this (upstream) repository from time to time. (That's what has happened when you see something like "This branch is 1 commit behind hackforla:gh-pages" on the github website version of your hackforla repository.)
```
with
```
Your fork of this repository on GitHub, and your local clone of that fork, will get out of sync with this (upstream) repository from time to time. (That's what has happened when you see something like "This branch is 1 commit behind hackforla:gh-pages" on the GitHub website version of your hackforla repository.)
```
AND I replaced:

```
If you go to your online github repository this should remove the message "This branch is x commit behind hackforla:gh-pages".
```
with
```
If you go to your online GitHub repository this should remove the message "This branch is x commit behind hackforla:gh-pages".
```
 

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To replace instances of Github and github with GitHub so that we display the company name correctly.
  - For Reviewers: Do not review changes locally, rather, review changes at https://github.com/lc1715/website/blob/Replace-github-with-GitHub-in-CONTRIBUTING.md-7440/CONTRIBUTING.md
  

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

- No visual changes to the website
