### PR TITLE
Add Mudassir Hussain to the VRMS project team

### DIFF
--- a/_projects/vrms.md
+++ b/_projects/vrms.md
@@ -85,6 +85,13 @@ leadership:
       slack: https://hackforla.slack.com/team/U779QRX3Q
       github: https://github.com/bkmorgan3
     picture: https://avatars.githubusercontent.com/bkmorgan3
+  - name: Mudassir Hussain
+    github-handle: hussainmudassir
+    role: Developer
+    links:
+      slack: https://hackforla.slack.com/team/U07GAGE89TJ
+      github: https://github.com/hussainmudassir
+    picture: https://avatars.githubusercontent.com/hussainmudassir
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/VRMS'


### PR DESCRIPTION
Fixes #7875 

### What changes did you make?
  - Added Mudassir Hussain's profile under the `leadership` variable in the `_projects/vrms.md` file

### Why did you make the changes (we will use this info to test)?
  - To keep project information up to date so that visitors of the website can find accurate information

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)

<details>
<summary>Visuals before changes are applied</summary>

![VRMS_leadership_before](https://github.com/user-attachments/assets/86c97b6b-cbfb-4e01-a626-a671e34cb5cc)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![VRMS_leadership_after](https://github.com/user-attachments/assets/afcea98f-0d66-4d0a-97e1-375078f492c3)

</details>
