### PR TITLE
Enhanced code to reference the mentioned labels by a general ID

### DIFF
--- a/github-actions/trigger-issue/add-preliminary-comment/check-label-preliminary-update.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/check-label-preliminary-update.js
@@ -1,6 +1,22 @@
+// Import modules
+const retrieveLabelDirectory = require('../../utils/retrieve-label-directory');
+
 // Global variables
 var github 
 var context
+
+// Label constants use labelKeys to retrieve current labelNames from directory
+const RELEVANT_ROLES = [
+    roleFrontEnd,
+    roleBackEndDevOps,
+    roleDesign,
+    roleUserResearch
+  ] = [
+    "roleFrontEnd",
+    "roleBackEndDevOps",
+    "roleDesign",
+    "roleUserResearch",
+  ].map(retrieveLabelDirectory);
 
 /**
  * @description - entry point of the whole javascript file, finds out whether we need to post the comment or not and returns in the boolean variable shouldpost.
@@ -42,28 +58,10 @@ function obtainLabels(){
  */
 
 function postComment(existingLabels){
-    //issue states that we are to post the comment if--> there is a role: back end/devOps tag...(continued on next comment)
-    if(existingLabels.includes("role: back end/devOps")){
-        return true
-    }
-
-    // or if there is a role: front end tag
-    else if(existingLabels.includes("role: front end")){
-        return true
-    }
-
-    //or if there is a role: design tag
-    else if(existingLabels.includes("role: design")){
-        return true
-    }
-
-    //or if there is a role: user research
-    else if(existingLabels.includes("role: user research")){
-        return true
-    }
-
-    //otherwise we return a false
-    return false
-}
+    // Compare whether a RELEVANT_ROLE is included in the existingLabels
+    const roleFound = RELEVANT_ROLES.some(label => existingLabels.includes(label));
+    console.log(roleFound ? '\nFound relevant role: Continue' : '\nMissing relevant role: Halt');
+    return roleFound
+  }
 
 module.exports = main


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7533

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Imported `retrieveLabelDirectory()` function from `retrieve-label-directory.js` that fetches the label value, also called labelName (thinking in terms of key-value pair).
  - Added constant of the labels appearing in the file, mapped them to the values in `label-directory.json` using `retrieveLabelDirectory()`
  - Refactored the function `postComment()` to use the constant variable created above

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - At this time, the GitHub Actions workflow files that manage labels on issues (adding, removing, or updating them) reference each label directly by its label name (the 'labelName')
  - We want these files to identify each label by its 'labelKey' and use the `retrieve-label-directory.js` module to look up the corresponding 'labelName' in `label-directory.json` instead of hard-coding the labelNames.
  - The specific file modified mentions `role: front end`, `role: back end/devOps`, `role: design` and `role: user research` so the constant variable created addresses this labels in particular.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes to the website

### To reviewers
- This issue works using Github Actions. To properly test the code changes you need to setup your own environment which can take a while if you haven't done it before. There are some tweaks around it, just post your doubts here or message me on Slack.
- There's a guide on how GHA works on the Wiki, how to setup your own version of the project board, etc. [here](https://github.com/hackforla/website/issues/6537#issuecomment-2041147335)
- I created another branch in my repo "refactor-gha-7533-debug" that adds a bunch of comments and `console.log()` to help you understand why the changes were performed that way and to see that the code works as intended.
- Checkout the Project Board on my repo https://github.com/users/santisecco/projects/6, the issues created there and the results from the actions. The following link shows that labels were fetched correctly by the changes and that all the parts of the code run https://github.com/santisecco/website/actions/runs/13726127006
- See the last issue created in my project board (using the debug branch) which shows that even when changing the labelName in `label-directory.json`, this is fetched correctly. You must watch the raw logs of GHA for this, here goes a screenshot as `retrieveLabelDirectory()` logs this.
<details>
  <summary><strong>Here are the screenshots</summary>
  <p><strong>To see the raw logs open the Actions tab, and look for this</strong></h4>
<img width="1700" alt="Screenshot 2025-03-11 at 12 16 49 PM" src="https://github.com/user-attachments/assets/99c73b71-a643-4e34-a339-82eb6856c060" />
  <p><strong>Here's the raw log of the last issue created that shows that the value from the directory is fetched correctly more clearly (as "front end" is now "front end GHA ACTIONS FETCHED CORRECTLY USING labelKey")</p>
<img width="1687" alt="Screenshot 2025-03-11 at 12 05 56 PM" src="https://github.com/user-attachments/assets/76493268-40a1-4e84-b5be-6dce5fb60c0d" />     
</details><br>