### PR TITLE
Replace `Github` with `GitHub` in CONTRIBUTING.md Section 1.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ cd website
 
 #### **1.4.b Clone repo (2): Verify `origin` remote url**
 
-Verify that your local cloned repository is pointing to the correct `origin` URL (that is, the forked repo on your own Github account):
+Verify that your local cloned repository is pointing to the correct `origin` URL (that is, the forked repo on your own GitHub account):
 ```bash
 git remote -v
 ```
@@ -187,11 +187,11 @@ origin  https://github.com/<your_GitHub_user_name>/website.git (push)
 upstream        https://github.com/hackforla/website.git (fetch)
 upstream        https://github.com/hackforla/website.git (push)
 ```
-#### **1.4.c What if you accidentally cloned using the repository URL from the HackForLA Github (instead of the fork on your Github)?**
+#### **1.4.c What if you accidentally cloned using the repository URL from the HackForLA GitHub (instead of the fork on your GitHub)?**
 
 ##### **i. Resolve remote (1): reset `origin` remote url**
 
-Set your forked repo on your Github as an `origin` remote:
+Set your forked repo on your GitHub as an `origin` remote:
 ```bash
 git remote set-url origin https://github.com/<your_GitHub_user_name>/website.git
 ```


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7439 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Replaced `Github` with `GitHub` in the first line under section 1.4.b in `CONTRIBUTING.md`
  - Replaced two instances of `Github` with `GitHub` in the title for section 1.4.c in `CONTRIBUTING.md`
  - Replaced `Github` with `GitHub` in the second line under section 1.4.c in `CONTRIBUTING.md`

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To display the correct company name

For Reviewers: Do not review changes locally, rather, review changes at `https://github.com/nchanyal/website/blob/replace-Github-with-GitHub-in-contributing.md-7439/CONTRIBUTING.md`

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

No visual changes to the website.