### PR TITLE
Fix #7112: Update 'Github' to 'GitHub' in social.yml

### DIFF
--- a/_data/navigation/social.yml
+++ b/_data/navigation/social.yml
@@ -28,7 +28,7 @@
   header: false
   footer: true
 
-- name: Github
+- name: GitHub
   link: https://github.com/hackforla
   icon: /svg/icon-github.svg
   header: false


### PR DESCRIPTION
Please note: You must be a member of the HFLA website team in order to create pull requests. Please see our page on how to join us as a member at HFLA: https://www.hackforla.org/getting-started. Delete this message if you joined this team via onboarding.
<!--  Note: Delete the message above if you joined this team via onboarding  -->

<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7112

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Updated `_data/navigation/social.yml` to change `name: Github` → `name: GitHub` to reflect correct branding.
- Verified the affected sections in the codebase that render social media links.
- Documented the file relationships and testing plan.

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
- The brand name GitHub was incorrectly capitalized as “Github.”
- This change ensures the correct and professional representation of GitHub in the website footer.
- The label used in the footer is directly sourced from `site.data.navigation.social`.


<h3>CodeQL Alerts</h3>

After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.

<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)

</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website

- No visual layout changes, but screen reader text will now correctly read "GitHub" instead of "Github". This change can be confirmed by inspecting the HTML span with class `sr-only` in the site footer.

---

### Test Plan

**Steps:**
1. Start the website locally using `docker compose up` or preview in deployment.
2. Visit `http://localhost:4000`.
3. Scroll to the **footer** of the homepage (or any page).
4. Right-click on the GitHub icon and select **Inspect**.
5. Confirm that the following HTML appears:
   ```html
   <span class="sr-only">GitHub</span>

---

### Test Notes

Unable to run Docker locally on my machine. As an alternative, I manually reviewed:

- _data/navigation/social.yml: Contains the social media metadata.

- _includes/footer.html: Renders the footer and pulls from the above data using {{ item.name }}.

- _layouts/default.html: Includes footer.html on every page of the site.

Because footer.html uses the name field in social.yml, the text update from “Github” to “GitHub” should be accurately reflected site-wide in the footer.

Please help confirm through local testing or deployment preview.

