### PR TITLE
Maintenance on `label_directory.json`

### DIFF
--- a/github-actions/utils/_data/label-directory.json
+++ b/github-actions/utils/_data/label-directory.json
@@ -741,7 +741,7 @@
   ],
   "statusInactive2": [
     "2 weeks inactive",
-    9999999999
+    8048259525
   ],
   "statusMissing": [
     "status: missing",
@@ -787,43 +787,39 @@
     "wontfix",
     905516652
   ],
-  "NEW-featureRoadmap": [
+  "featureRoadmap": [
     "feature: Roadmap",
     7472857782
   ],
-  "NEW-pFeatureAccomplishments": [
+  "pFeatureAccomplishments": [
     "p-feature: accomplishments",
     7505751413
   ],
-  "NEW-roleProject": [
+  "roleProject": [
     "role: project",
     7581729078
   ],
-  "NEW-driveSharedWithMe": [
+  "driveSharedWithMe": [
     "drive: shared with me",
     7657270641
   ],
-  "NEW-featureBranding": [
+  "featureBranding": [
     "feature: branding",
     7657357703
   ],
-  "NEW-milestoneMissing": [
+  "milestoneMissing": [
     "milestone: missing",
     7695414022
   ],
-  "NEW-featureFaq": [
+  "featureFaq": [
     "feature: FAQ",
     7970290985
   ],
-  "NEW-skillsTemplateStatusNeedNextSteps": [
+  "skillsTemplateStatusNeedNextSteps": [
     "Skills Template status: Need Next Steps",
     7582275087
   ],
-  "NEW-2WeeksInactive": [
-    "2 weeks inactive",
-    8048259525
-  ],
-  "NEW-roleDataScientist": [
+  "roleDataScientist": [
     "role: data scientist",
     8056944058
   ],
@@ -831,28 +827,36 @@
     "Status: Unassigned by Bot",
     8096814358
   ],
-  "NEW-langGha": [
+  "langGha": [
     "Lang: GHA",
     8273615621
   ],
-  "NEW-skillRefactor": [
+  "skillRefactor": [
     "Skill: refactor",
     8273639778
   ],
-  "NEW-skillFeasability": [
-    "Skill: feasability",
+  "skillFeasibility": [
+    "Skill: feasibility",
     8273643490
   ],
-  "NEW-langMd": [
+  "langMd": [
     "Lang: .md",
     8273660695
   ],
-  "NEW-skillEdit": [
+  "skillEdit": [
     "Skill: edit",
     8273662609
   ],
-  "NEW-featureMessaging": [
+  "featureMessaging": [
     "feature: messaging",
     8273668967
+  ],
+  "skillCreateNew": [
+    "Skill: create new",
+    8273640350
+  ],
+  "skillEnhance": [
+    "Skill: enhance",
+    8273641077
   ]
 }


### PR DESCRIPTION
Fixes #7940 


### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Consolidated the labelId for the new `2 weeks inactive` with the labelKey and labelName of the mistakenly-deleted `2 weeks inactive`, and transferred 'Description' and 'Color' 
  - Removed the `NEW-` flag appendage from all intentionally added labels
  - Added two labels that were not added to the `.json` because of an error

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To keep `label_directory.json` in sync


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

- No visual changes to website
