### PR TITLE
Enhance GHA 'post-labels-comment.js' 

### DIFF
--- a/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
@@ -1,14 +1,21 @@
-var fs = require("fs");
+// Import modules
+var fs = require('fs');
 const postComment = require('../../utils/post-issue-comment');
 const formatComment = require('../../utils/format-comment');
+const retrieveLabelDirectory = require('../../utils/retrieve-label-directory');
 
-// Constant variables
-const LABELS_OBJ = {
-  'Complexity: Missing': 'Complexity',
-  'role missing': 'Role',
-  'Feature Missing': 'Feature',
-  'size: missing': 'Size'
-};
+// Label constants use labelKeys to retrieve current labelNames from directory
+const LABELS_OBJ = [
+  sizeMissing,
+  featureMissing,
+  complexityMissing,
+  roleMissing
+] = [
+  "sizeMissing",
+  "featureMissing",
+  "complexityMissing",
+  "roleMissing"
+].map(retrieveLabelDirectory);
 
 // Global variables
 var github;

--- a/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
@@ -5,7 +5,7 @@ const formatComment = require('../../utils/format-comment');
 const retrieveLabelDirectory = require('../../utils/retrieve-label-directory');
 
 // Label constants use labelKeys to retrieve current labelNames from directory
-const LABELS_OBJ = [
+const LABELS_ARR = [
   sizeMissing,
   featureMissing,
   complexityMissing,
@@ -16,6 +16,9 @@ const LABELS_OBJ = [
   "complexityMissing",
   "roleMissing"
 ].map(retrieveLabelDirectory);
+
+const LABELS_VAL = ['Size','Feature','Complexity','Role'];
+const LABELS_OBJ = Object.fromEntries(LABELS_ARR.map((key, i) => [key, LABELS_VAL[i]]));
 
 // Global variables
 var github;


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7532

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Imported 'retrieveLabelDirectory' function into post-labels-comment.js
  - Use 'retrieveLabelDirectory' function to replace each labelName variable with the corresponding labelKey
  - Substitute the labelKey variable with each of the original label names in post-labels.comment.js

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To refactor the GHA workflows to reference each label by a general ID (labelKey) so that other HFLA groups can use these workflows without having to match the label names used by the website team
 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 
No visual changes to website.
Tested workflows:
trigger-issues.yml

![Screenshot 2025-04-05 at 01-37-12 issue 50 · aadilahmed_website@7830984](https://github.com/user-attachments/assets/499c4f23-66fb-403c-8cc5-a2d159787092)
