### PR TITLE
Remove PS message in issue trigger

### DIFF
--- a/github-actions/trigger-issue/add-preliminary-comment/developer-complexity-reminder.md
+++ b/github-actions/trigger-issue/add-preliminary-comment/developer-complexity-reminder.md
@@ -4,9 +4,3 @@ Hello @${issueAssignee}, we appreciate you taking on issue #${issueNum}, however
 We are going to unassign you from this issue so you can take on another issue.
 
 Hfla appreciates you! :)
-
-P.S. There is one exception to this rule/automation, and that is if you were away for a long time, and need to do the issue ladder again. If that is the case, please post the following note on the issue and on your Skills Issue (Pre-work Checklist). A Merge team member will reassign you to this issue, and will help you get assigned to subsequent issues up to medium size.
-
-```
-I am returning after a significant time away, and need to do the issue ladder again. Please assign me back to this issue.
-```


### PR DESCRIPTION
Fixes #7941 

### What changes did you make?
  - Remove exception text in issue trigger

### Why did you make the changes (we will use this info to test)?
 - To avoid developer from redoing the same size of issue again.
<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

