### PR TITLE
Update Project Profile: Home Unite Us Remove Samuel Kowitch

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -48,13 +48,6 @@ leadership:
       slack: "https://hackforla.slack.com/team/U02JQLQ6YGY"
       github: "https://github.com/rpbracker"
     picture: https://avatars.githubusercontent.com/rpbracker
-  - name: Samuel Kowitch
-    github-handle: 
-    role: UX/UI Designer
-    links:
-      slack: "https://hackforla.slack.com/team/U04GYSFB98X"
-      github: "https://github.com/KowDesign"
-    picture: https://avatars.githubusercontent.com/KowDesign
   - name: Muyin Zheng
     github-handle:
     role: UX/UI Designer


### PR DESCRIPTION
Fixes #7482 

### What changes did you make?
  - Removed Samuel Kowitch info from `_projects/home-unite-us.md` file.

### Why did you make the changes (we will use this info to test)?
  - To keep project information up to date so that visitors to the website can find accurate information.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)

<details>
<summary>Visuals before changes are applied</summary>

![issue_7482_before_pic](https://github.com/user-attachments/assets/2181c82b-4b08-4444-8218-046b0604fe77)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![issue_7482_after_pic](https://github.com/user-attachments/assets/0df3d766-79d8-47c9-a9f4-d356de313112)

</details>
