### PR TITLE
Removed Edwin Jue from 311 Data Project Profile

### DIFF
--- a/_projects/311-data.md
+++ b/_projects/311-data.md
@@ -48,13 +48,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U03RPBE9DL6
       github: https://github.com/hworthen
     picture: https://avatars.githubusercontent.com/hworthen
-  - name: Edwin Jue
-    github-handle: edwinjue
-    role: Engineering Lead
-    links:
-      slack: https://hackforla.slack.com/team/U03SUUZMFEV
-      github: https://github.com/edwinjue
-    picture: https://avatars.githubusercontent.com/edwinjue
   - name: Allison Jeon
     github-handle: allisonjeon
     role: UX Design Lead


### PR DESCRIPTION
Fixes #7550 

### What changes did you make?
  - Removed Edwin Jue info from `_projects/311-data.md` file.

### Why did you make the changes (we will use this info to test)?
  - To keep project information up to date so that visitors to the website can find accurate information.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

![issue_7550_before_pic](https://github.com/user-attachments/assets/22dcb069-988a-42ce-8321-9a9d3be30917)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![issue_7550_after_pic](https://github.com/user-attachments/assets/dd4e169a-9f65-46fa-9b23-74db732f7e71)

</details>
