### PR TITLE
Update Project Profile Leader Updates - Add and Remove Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-profile-leader-updates---add.md
+++ b/.github/ISSUE_TEMPLATE/project-profile-leader-updates---add.md
@@ -30,15 +30,8 @@ We need to keep project information up to date so that visitors to the website c
 ```
 - [ ] Verify the changes by viewing the following in your local environment and include before and after screenshots with your pull request:
   - [ ] [Insert name of project] page [^2]
-- [ ] Once your pull request is merged, go to the initiating ER [^3]
-  - [ ] Check off this issue under the _Dependency_ section
-  - [ ] If all the issues in the _Dependency_ section are checked off, move initiating ER [^3] to **Questions / In Review** column and uncheck the **Dependency label**.
-    - <details>
-        <summary>Click here to see how to uncheck the <b>Dependency label</b></summary>
-        <img src="https://github.com/hackforla/website/assets/31293603/6f53f4d4-7d2c-45f8-8534-9936fc9adee8" width="300px">
-      </details>
 
 ### Resources/Instructions
+- Initiating epic or ER: #[Insert epic or ER number]
 [^1]: [Info about the front matter block](https://jekyllrb.com/docs/front-matter/)
 [^2]: Project detailed info page URL: [Insert project specific page URL here]
-[^3]: initiating ER:  #[Insert ER number]

--- a/.github/ISSUE_TEMPLATE/project-profile-leader-updates---remove.md
+++ b/.github/ISSUE_TEMPLATE/project-profile-leader-updates---remove.md
@@ -24,15 +24,8 @@ We need to keep project information up to date so that visitors to the website c
 ```
 - [ ] Verify the changes by viewing the following in your local environment and include before and after screenshots with your pull request:
   - [ ] [Insert name of project] page [^2]
-- [ ] Once your pull request is merged, go to the initiating ER [^3]
-  - [ ] Check off this issue under the _Dependency_ section
-  - [ ] If all the issues in the _Dependency_ section are checked off, move initiating ER [^3] to **Questions / In Review** column and uncheck the **Dependency label**.
-    - <details>
-        <summary>Click here to see how to uncheck the <b>Dependency label</b></summary>
-        <img src="https://github.com/hackforla/website/assets/31293603/6f53f4d4-7d2c-45f8-8534-9936fc9adee8" width="300px">
-      </details>
 
 ### Resources/Instructions
+- Initiating epic or ER: #[Insert epic or ER number]
 [^1]: [Info about the front matter block](https://jekyllrb.com/docs/front-matter/)
 [^2]: Project detailed info page URL: [Insert project specific page URL here]
-[^3]: initiating ER:  #[Insert ER number]


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #N/A - hotfix

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
- I updated the templates: "Project Profile leader updates - Add" and "Project Profile leader updates - Remove" by
   - removing the Action Item(s) to go back to the initiating ER to complete some tasks related to the Dependency section, and
   - removed reference "[^3]: initiating ER: #[Insert ER number]" to "- Initiating epic or ER: #[Insert epic or ER number]"

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Since now the "Sub-issues" section will be used to link and track the issues created from an Update Project Profile epic or ER, we will no longer use the Dependency section of the initiating Update Project Profile epic or ER to track those created issues. Thus, the removal of the Action Item(s) and the change the reference "[^3}".

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

![original-add](https://github.com/user-attachments/assets/466816b0-33c3-43ef-afd8-33ac7071a9f7)

![original-remove](https://github.com/user-attachments/assets/d839da8c-799b-48d9-8770-33c4434a4391)


</details>

<details>
<summary>Visuals after changes are applied</summary>

![new-add](https://github.com/user-attachments/assets/961fc9a6-01a0-436a-9544-35290adb0aaa)

![new-remove](https://github.com/user-attachments/assets/32ccd5e3-9a29-4267-ad99-736414a5732b)



</details>

