### PR TITLE
Fix bug in `check-complexity-eligiblity.js` 

### DIFF
--- a/github-actions/trigger-issue/add-preliminary-comment/check-complexity-eligibility.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/check-complexity-eligibility.js
@@ -64,14 +64,14 @@ async function checkComplexityEligibility(
     context.payload.sender
   );
 
-  // Fetch the current issue's project item id, status name, and status d
-    const { id: projectItemId, statusName, statusId } = await queryIssueInfo(
+  // Fetch the current issue's project item id, status name, and status id
+  const { id: projectItemId, statusName, statusId } = await queryIssueInfo(
     github,
     context,
     currentIssue.issueNum
   );
 
-  // If issue's statusId matches the id for "New Issue Approval", skip complexity check
+  // If issue's status id matches the id for "New Issue Approval", skip complexity check
   if (statusId === NEW_ISSUE_APPROVAL_ID) {
     return true;
   }

--- a/github-actions/trigger-issue/add-preliminary-comment/check-complexity-eligibility.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/check-complexity-eligibility.js
@@ -34,9 +34,9 @@ const [
 const EXCEPTION_LABELS = [ER, epic];
 const REQUIRED_ROLE_LABELS = [roleFrontEnd, roleBackEndDevOps];
 const REQUIRED_COMPLEXITY_LABELS = [complexity1, complexity2, complexity3];
-// Hard-coded statuses
-const NEW_ISSUE_APPROVAL = 'New Issue Approval';
-const IN_PROGRESS = 'In progress (actively working)';
+// Hard-coded status field id values
+const NEW_ISSUE_APPROVAL_ID = statusFieldIds('New_Issue_Approval');
+const IN_PROGRESS_ID = statusFieldIds('In_Progress');
 
 
 /**
@@ -64,15 +64,15 @@ async function checkComplexityEligibility(
     context.payload.sender
   );
 
-  // Fetch the current issue's project item ID and status name
-  const { id: projectItemId, statusName } = await queryIssueInfo(
+  // Fetch the current issue's project item id, status name, and status d
+    const { id: projectItemId, statusName, statusId } = await queryIssueInfo(
     github,
     context,
     currentIssue.issueNum
   );
 
-  // If issue's status is New Issue Approval, skip complexity check
-  if (statusName === NEW_ISSUE_APPROVAL) {
+  // If issue's statusId matches the id for "New Issue Approval", skip complexity check
+  if (statusId === NEW_ISSUE_APPROVAL_ID) {
     return true;
   }
 
@@ -381,7 +381,7 @@ async function handleIssueComplexityNotPermitted(
       github,
       context,
       projectItemId,
-      statusFieldIds(NEW_ISSUE_APPROVAL)
+      NEW_ISSUE_APPROVAL_ID
     );
   
     // If the assignee's Skills Issue (Pre-work Checklist) is closed, open it
@@ -402,7 +402,7 @@ async function handleIssueComplexityNotPermitted(
         github,
         context,
         preWorkIssueProjectItemId,
-        statusFieldIds(IN_PROGRESS)
+        IN_PROGRESS_ID
       );
     }
 

--- a/github-actions/utils/query-issue-info.js
+++ b/github-actions/utils/query-issue-info.js
@@ -49,7 +49,8 @@ async function queryIssueInfo(github, context, issueNum) {
     // and find the node that contains the 'name' property, then get its 'name' value
     const statusName = projectData[0].fieldValues.nodes.find((item) => 
       item.hasOwnProperty("name")).name;
-  // Similarly, find node with 'optionId' property, then get is 'optionId' value
+    
+    // Similarly, find node with 'optionId' property, then get is 'optionId' value
     const statusId = projectData[0].fieldValues.nodes.find((item) => 
       item.hasOwnProperty("optionId")).optionId;
   

--- a/github-actions/utils/query-issue-info.js
+++ b/github-actions/utils/query-issue-info.js
@@ -19,6 +19,7 @@ async function queryIssueInfo(github, context, issueNum) {
               nodes {
                 ... on ProjectV2ItemFieldSingleSelectValue {
                   name
+                  optionId
                 }
               }
             }
@@ -48,8 +49,11 @@ async function queryIssueInfo(github, context, issueNum) {
     // and find the node that contains the 'name' property, then get its 'name' value
     const statusName = projectData[0].fieldValues.nodes.find((item) => 
       item.hasOwnProperty("name")).name;
-
-    return { id, statusName };
+  // Similarly, find node with 'optionId' property, then get is 'optionId' value
+    const statusId = projectData[0].fieldValues.nodes.find((item) => 
+      item.hasOwnProperty("optionId")).optionId;
+  
+    return { id, statusName, statusId };
   } catch (error) {
     throw new Error(`Error finding Issue #${issueNum} id and status; error = ${error}`);
   }


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #8083 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Revised the variables "New Issue Approval" and "In progress (actively working)" statuses so that the variable matches the status field id value, not the name of the field itself. 
  - Revised the GraphQL query to extract the current issue's status field id in additional to the status field name.
  - After doing both, now the status field id of the intended status can be directly compared with the status field id of the current issue. This also allows for the status field id values to be directly placed in the GraphQL mutation
  - Finally, changed `query-issue-info.js` so that it extracts the existing status field id (`optionId`) for the current issue

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - This corrects the broken functionality for changing the status of a just un-assigned issue back to "New Issue Approval". 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [ ] I have checked this PR for CodeQL alerts and none were found.
- [x] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted 
   - [x] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate) - see Comment following
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

    _Comment: : The `statusName` variable is not used for this workflow, but there are other workflows that do use this. I.e. the variable is used in other locations so it needs to remain._  

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

- No visual changes
- Will attach test runs shortly...