### PR TITLE
Add Ariel Lasry to Home Unite Us project profile

### DIFF
--- a/_projects/home-unite-us.md
+++ b/_projects/home-unite-us.md
@@ -6,6 +6,13 @@ image: /assets/images/projects/home-heart.png
 alt: 'Home Unite Us'
 image-hero: /assets/images/projects/home-unite-us-hero.png
 leadership:
+  - name: Ariel Lasry
+    github-handle: lasryariel
+    role: Product Manager (Lead Persona)
+    links:
+      slack: https://hackforla.slack.com/team/U06MG4S8D2B
+      github: https://github.com/lasryariel
+    picture: https://avatars.githubusercontent.com/lasryariel
   - name: Tyler Thome
     github-handle: 
     role: HUU Tech Lead
@@ -47,7 +54,7 @@ leadership:
     links:
       slack: https://hackforla.slack.com/team/U06TAL88YUV
       github: https://github.com/lola3736
-    picture: https://avatars.githubusercontent.com/lola3736    
+    picture: https://avatars.githubusercontent.com/lola3736
 links:
   - name: GitHub
     url: "https://github.com/hackforla/homeuniteus"


### PR DESCRIPTION
Fixes #7909

### What changes did you make?
- Added Ariel Lasry to the leadership list in the Home Unite Us project profile (at the top, as requested)

### Why did you make these changes?
- To reflect the updated team membership based on the issue instructions

### Screenshots of Proposed Changes To The Website
<details>
  <summary>Visuals before changes are applied</summary>

  <img width="959" alt="Before_Adding" src="https://github.com/user-attachments/assets/cfc16af1-c931-41be-8da1-370353446266" />

</details>

<details>
  <summary>Visuals after changes are applied</summary>

  <img width="944" alt="Ariel Lasry" src="https://github.com/user-attachments/assets/cb8bb65b-bba8-409f-8e8a-38bcc9970f2c" />

</details>

---

### CodeQL Alerts
- [x] I have checked this PR for CodeQL alerts and none were found.
