### PR TITLE
Update Project Profile: Remove Kelly Chuang – #7750

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -26,13 +26,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U07FMKW5EDR
       github: https://github.com/essencegoff
     picture: https://avatars.githubusercontent.com/essencegoff
-  - name: Kelly Chuang
-    github-handle: kellyc9
-    role: Product Manager
-    links:
-      slack: https://hackforla.slack.com/team/U06REBB5K4M
-      github: https://github.com/kellyc9
-    picture: https://avatars.githubusercontent.com/kellyc9
   - name: Sofiat Ajide
     github-handle: sofiatajide
     role: Product Manager - Dashboards


### PR DESCRIPTION
Fixes #7750

### What changes did you make?
- Removed Kelly Chuang from `_projects/website.md` (lines [insert line numbers here]) under the leadership section

### Why did you make the changes?
- To remove Kelly Chuang from the leadership section, keeping the project profile up to date as requested in issue #7750.


<h3>CodeQL Alerts</h3>

After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.

<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)

</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website

<details>
<summary>Visuals before changes are applied</summary>


<img width="692" alt="KellyChuang" src="https://github.com/user-attachments/assets/a74c514c-7e7d-4538-b891-c0c98104e768" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  

<img width="605" alt="Website_Updated" src="https://github.com/user-attachments/assets/f7aa7186-538e-4801-b2ad-1bc2439d4ee7" />

</details>
