### PR TITLE
Refactor minimizeIssueComments() to Avoid Limit

### DIFF
--- a/.github/workflows/schedule-fri-0700.yml
+++ b/.github/workflows/schedule-fri-0700.yml
@@ -2,9 +2,6 @@ name: Schedule Friday 0700
 
 # This action runs at 7:00 UTC/ 0:00 PDT (midnight) every Friday, except during July and December.
 on:
-  push:
-    branches:
-      - refactor-minimizeissuecomments-avoid-limit-TEST
   schedule:
     - cron:  '0 7 * 1-6,8-11 5'
   workflow_dispatch:
@@ -12,7 +9,7 @@ on:
 jobs:
   Add-Update-Label-to-Issues-Weekly:
     runs-on: ubuntu-latest
-    # if: github.repository == 'hackforla/website'
+    if: github.repository == 'hackforla/website'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/github-script@v7

--- a/.github/workflows/schedule-fri-0700.yml
+++ b/.github/workflows/schedule-fri-0700.yml
@@ -2,6 +2,9 @@ name: Schedule Friday 0700
 
 # This action runs at 7:00 UTC/ 0:00 PDT (midnight) every Friday, except during July and December.
 on:
+  push:
+    branches:
+      - refactor-minimizeissuecomments-avoid-limit-TEST
   schedule:
     - cron:  '0 7 * 1-6,8-11 5'
   workflow_dispatch:
@@ -9,7 +12,7 @@ on:
 jobs:
   Add-Update-Label-to-Issues-Weekly:
     runs-on: ubuntu-latest
-    if: github.repository == 'hackforla/website'
+    # if: github.repository == 'hackforla/website'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/github-script@v7

--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -32,12 +32,14 @@ const [
 const updatedByDays = 3;                // If last update update  3 days, the issue is considered updated
 const commentByDays = 7;                // If last update between 7 to 14 days ago, issue is outdated and needs update
 const inactiveUpdatedByDays = 14;       // If last update greater than 14 days ago, the issue is considered inactive
-
+const upperLimitDays = 30;              // Bot-generated comments older than this are not checked by minimizeComments()
 const threeDayCutoffTime = new Date();
 threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays);
 const sevenDayCutoffTime = new Date();
 sevenDayCutoffTime.setDate(sevenDayCutoffTime.getDate() - commentByDays);
 const fourteenDayCutoffTime = new Date();
+const upperLimitCutoffTime = new Date();
+upperLimitCutoffTime.setDate(upperLimitCutoffTime.getDate() - upperLimitDays);
 fourteenDayCutoffTime.setDate(fourteenDayCutoffTime.getDate() - inactiveUpdatedByDays);
 
 
@@ -184,8 +186,8 @@ function isTimelineOutdated(timeline, issueNum, assignees) { // assignees is an 
       lastAssignedTimestamp = eventTimestamp;
     }
 
-    // If this event is more than 7 days old AND this event is a comment by the GitHub Actions Bot, then hide the comment as outdated.
-    if (!isMomentRecent(eventObj.created_at, sevenDayCutoffTime) && eventType === 'commented' && isCommentByBot(eventObj)) { 
+    // If this event is more than 7 days old but less than the upperLimitCutoffTime AND this event is a comment by the GitHub Actions Bot, then hide the comment as outdated.
+    if (isMomentRecent(eventObj.created_at, upperLimitCutoffTime) && !isMomentRecent(eventObj.created_at, sevenDayCutoffTime) && eventType === 'commented' && isCommentByBot(eventObj)) { 
       console.log(`Comment ${eventObj.node_id} is outdated (i.e. > 7 days old) and will be minimized.`);
       commentsToBeMinimized.push(eventObj.node_id); // retain node id so its associated comment can be minimized later
     }

--- a/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
+++ b/github-actions/trigger-schedule/add-update-label-weekly/add-label.js
@@ -33,14 +33,15 @@ const updatedByDays = 3;                // If last update update  3 days, the is
 const commentByDays = 7;                // If last update between 7 to 14 days ago, issue is outdated and needs update
 const inactiveUpdatedByDays = 14;       // If last update greater than 14 days ago, the issue is considered inactive
 const upperLimitDays = 30;              // Bot-generated comments older than this are not checked by minimizeComments()
+
 const threeDayCutoffTime = new Date();
 threeDayCutoffTime.setDate(threeDayCutoffTime.getDate() - updatedByDays);
 const sevenDayCutoffTime = new Date();
 sevenDayCutoffTime.setDate(sevenDayCutoffTime.getDate() - commentByDays);
 const fourteenDayCutoffTime = new Date();
-const upperLimitCutoffTime = new Date();
-upperLimitCutoffTime.setDate(upperLimitCutoffTime.getDate() - upperLimitDays);
 fourteenDayCutoffTime.setDate(fourteenDayCutoffTime.getDate() - inactiveUpdatedByDays);
+const upperLimitCutoffTime = new Date();
+upperLimitCutoffTime.setDate(upperLimitCutoffTime.getDate() - upperLimitDays);  
 
 
 


### PR DESCRIPTION
<!--  Note: Delete the message above if you joined this team via onboarding  -->

<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7562 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - I refactored the `minimizeIssueComments()` to add an upper time limit when hiding bot-generated comments.
  - Instead of hiding all comments older than 7 days, the function now only hides comments older than 7 days but newer than 30 days.

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - The original workflow was making too many GraphQL requests by trying to minimize all comments older than 7 days, including very old ones that were already hidden.
  - This caused the workflow to hit GitHub's secondary rate limit and fail.
  - By limiting the comment minimization to a 7 to 30 day window, the number of API calls is reduced.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
  - No visual changes to the website
  - [Workflow logs](https://github.com/katiejnete/website/actions/runs/15202843103) showing successful run
