### PR TITLE
Labels maintenance: restore deleted `role missing` label

### DIFF
--- a/github-actions/utils/_data/label-directory.json
+++ b/github-actions/utils/_data/label-directory.json
@@ -451,10 +451,6 @@
     "P-Feature: Projects page",
     3272306602
   ],
-  "pFeatureRelatedCollateral": [
-    "P-Feature: Related Collateral",
-    9999999999
-  ],
   "pFeatureSDGs": [
     "p-feature: SDGs",
     5299505540
@@ -629,7 +625,7 @@
   ],
   "roleMissing": [
     "role missing",
-    9999999999
+    8613983080
   ],
   "roleOrgRep": [
     "role: Org Rep",
@@ -858,9 +854,5 @@
   "skillEnhance": [
     "Skill: enhance",
     8273641077
-  ],
-  "NEW-roleMissing": [
-    "role missing",
-    8613983080
   ]
 }


### PR DESCRIPTION
Fixes #8157

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Removed unused label `pFeatureRelatedCollateral`
  - Synced `NEW-roleMissing` with previous `roleMissing`


### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To keep the labels directory in sync
  

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

- No visual changes