### PR TITLE
Augment "Schedule Monthly" open issues assigned to non-team members

### DIFF
--- a/github-actions/trigger-schedule/list-inactive-members/create-new-issue.js
+++ b/github-actions/trigger-schedule/list-inactive-members/create-new-issue.js
@@ -102,7 +102,7 @@ const parseNonTeamOpen = (nonTeamOpens) => {
   if (Object.keys(nonTeamOpens).length === 0) {
     return '';
   } else {
-    let nonTeamOpen = '\r\n\nInactive members with open issues:\r\n';
+    let nonTeamOpen = '\r\n\nNon-team members with open issues:\r\n';
     for (const [user, issues] of Object.entries(nonTeamOpens)) {
       for (const issue of issues) {
         nonTeamOpen += ` - ${user}: #${issue}\r\n`;
@@ -111,6 +111,5 @@ const parseNonTeamOpen = (nonTeamOpens) => {
     return nonTeamOpen;
   }
 };
-
 
 module.exports = main;

--- a/github-actions/trigger-schedule/list-inactive-members/create-new-issue.js
+++ b/github-actions/trigger-schedule/list-inactive-members/create-new-issue.js
@@ -23,7 +23,8 @@ async function main({ g, c }) {
   const filepath = 'github-actions/utils/_data/inactive-members.json';
   const rawData = fs.readFileSync(filepath, 'utf8');
   let inactiveLists = JSON.parse(rawData);
-  const inactiveWithOpen = parseInactiveOpen(inactiveLists['cannotRemoveYet']);
+  const inactiveWithOpen = parseInactiveOpen(inactiveLists['inactiveOpenIssue']);
+  const nonTeamWithOpen = parseNonTeamOpen(inactiveLists['nonTeamOpenIssue']);
   
   const owner = context.repo.owner;
   const repo = context.repo.repo;
@@ -33,7 +34,7 @@ async function main({ g, c }) {
   const issueNumber = issue.number;
 
   // Add issue number used to reference the issue and comment on the `Dev/PM Agenda and Notes`
-  const commentBody = `**Review Inactive Team Members:** #` + issueNumber + inactiveWithOpen;
+  const commentBody = `**Review Inactive Team Members:** #` + issueNumber + inactiveWithOpen + nonTeamWithOpen;
   await postComment(AGENDA_ISSUE_NUM, commentBody, github, context);
 }
 
@@ -84,15 +85,32 @@ const createIssue = async (owner, repo, inactiveLists) => {
 };
 
 const parseInactiveOpen = (inactiveOpens) => {
-  if(Object.keys(inactiveOpens).length === 0){
+  if (Object.keys(inactiveOpens).length === 0) {
     return '';
   } else {
     let inactiveOpen = '\r\n\nInactive members with open issues:\r\n';
-    for(const [key, value] of Object.entries(inactiveOpens)){
-      inactiveOpen += ' - ' + key + ': #' + value + '\r\n';
+    for (const [user, issues] of Object.entries(inactiveOpens)) {
+      for (const issue of issues) {
+        inactiveOpen += ` - ${user}: #${issue}\r\n`;
+      }
     }
     return inactiveOpen;
   }
 };
+
+const parseNonTeamOpen = (nonTeamOpens) => {
+  if (Object.keys(nonTeamOpens).length === 0) {
+    return '';
+  } else {
+    let nonTeamOpen = '\r\n\nInactive members with open issues:\r\n';
+    for (const [user, issues] of Object.entries(nonTeamOpens)) {
+      for (const issue of issues) {
+        nonTeamOpen += ` - ${user}: #${issue}\r\n`;
+      }
+    }
+    return nonTeamOpen;
+  }
+};
+
 
 module.exports = main;

--- a/github-actions/trigger-schedule/list-inactive-members/get-contributors-data.js
+++ b/github-actions/trigger-schedule/list-inactive-members/get-contributors-data.js
@@ -153,7 +153,7 @@ async function fetchContributors(dates){
       allContributorsSinceTwoMonthsAgo = allContributorsSince;
     }
   }   
-  return [allContributorsSinceOneMonthAgo, allContributorsSinceTwoMonthsAgo, inactiveWithOpenSkills, inactiveWithOpenIssue]; 
+  return [allContributorsSinceOneMonthAgo, allContributorsSinceTwoMonthsAgo, inactiveWithOpenSkills, inactiveWithOpenIssue];
 }
 
 

--- a/github-actions/trigger-schedule/list-inactive-members/get-contributors-data.js
+++ b/github-actions/trigger-schedule/list-inactive-members/get-contributors-data.js
@@ -35,7 +35,7 @@ async function main({ g, c }) {
   github = g;
   context = c;
 
-  const [contributorsOneMonthAgo, contributorsTwoMonthsAgo, inactiveWithOpenIssue] = await fetchContributors(dates);
+  const [contributorsOneMonthAgo, contributorsTwoMonthsAgo, inactiveWithOpenSkills,inactiveWithOpenIssue] = await fetchContributors(dates);
   console.log(`-`.repeat(60));
   console.log('List of active contributors since ' + dates[0].slice(0, 10) + ':');
   console.log(contributorsOneMonthAgo);
@@ -43,8 +43,9 @@ async function main({ g, c }) {
   return {
     recentContributors: contributorsOneMonthAgo,
     previousContributors: contributorsTwoMonthsAgo,
-    inactiveWithOpenIssue: inactiveWithOpenIssue,
-    dates: dates,
+    inactiveWithOpenSkills,
+    inactiveWithOpenIssue,
+    dates,
   }; 
 };
 
@@ -58,6 +59,7 @@ async function main({ g, c }) {
 async function fetchContributors(dates){
   let allContributorsSinceOneMonthAgo = {};
   let allContributorsSinceTwoMonthsAgo = {};
+  let inactiveWithOpenSkills = {};
   let inactiveWithOpenIssue = {};
 
   // Members of 'website-maintain' team are considered permanent members
@@ -128,9 +130,9 @@ async function fetchContributors(dates){
           else if (date === dates[1]) {
             const regex = /Pre-work checklist|Skills Issue/i;
             if (regex.test(contributorInfo.title)) {
-              inactiveWithOpenIssue[assignee] = [issueNum, true];
+              inactiveWithOpenSkills[assignee] = [issueNum];
             } else {
-              inactiveWithOpenIssue[assignee] = [issueNum, false];
+              inactiveWithOpenIssue[assignee] = [issueNum];
             }
           }
         }
@@ -151,7 +153,7 @@ async function fetchContributors(dates){
       allContributorsSinceTwoMonthsAgo = allContributorsSince;
     }
   }   
-  return [allContributorsSinceOneMonthAgo, allContributorsSinceTwoMonthsAgo, inactiveWithOpenIssue]; 
+  return [allContributorsSinceOneMonthAgo, allContributorsSinceTwoMonthsAgo, inactiveWithOpenSkills, inactiveWithOpenIssue]; 
 }
 
 

--- a/github-actions/trigger-schedule/list-inactive-members/get-contributors-data.js
+++ b/github-actions/trigger-schedule/list-inactive-members/get-contributors-data.js
@@ -27,7 +27,7 @@ let dates = [oneMonthAgo, twoMonthsAgo];
 
 /**
  * Main function
- * @param {Object} g         - github object from actions/github-script
+ * @param {Object} g         - GitHub object from actions/github-script
  * @param {Object} c         - context object from actions/github-script
  * @return {Object} results  - object to use in `trim-inactive-members.js`
  */
@@ -78,7 +78,7 @@ async function fetchContributors(dates){
       let pageNum = 1;
       let result = [];
 
-      // Since Github only allows to fetch max 100 items per request, we need to 'flip' pages
+      // Since GitHub only allows to fetch max 100 items per request, we need to 'flip' pages
       while(true){
         // Fetch 100 items per each page (`pageNum`)
         const contributors = await github.request(api, {

--- a/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
+++ b/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
@@ -76,7 +76,7 @@ async function removeInactiveMembers(previousContributors, inactiveWithOpenSkill
   // Loop over team members and remove them from the team if they   
   // are not in either previousContributors or inactiveWithOpenIssue
   for (const username in currentTeamMembers) {   
-    if ((!previousContributors[username]) || (!username in inactiveWithOpenIssue)) {
+    if ((!previousContributors[username]) || !(username in inactiveWithOpenIssue)) {
       // Prior to deletion, confirm that member is on the baseTeam
       await addTeamMember(github, context, baseTeam, username);
       // If member was not on the previouslyNotified list, do not remove yet

--- a/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
+++ b/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
@@ -23,10 +23,11 @@ const PMTeam =  'website-pm';
  * @param {Object} c                     - context object from actions/github-script
  * @param {Object} recentContributors    - recentContributors since the dates[0] = recent cutoff
  * @param {Object} previousContributors  - previousContributors since the dates[1] = previous cutoff
+ * @param {Object} inactiveWithOpenSkills- Inactive contributors that have open Skills issues
  * @param {Object} inactiveWithOpenIssue - Inactive contributors that have open issues
  * @param {Object} dates                 - [recent, previous] dates of oneMonthAgo, twoMonthsAgo
  */
-async function main({ g, c }, { recentContributors, previousContributors, inactiveWithOpenSkills,inactiveWithOpenIssue, dates }) {
+async function main({ g, c }, { recentContributors, previousContributors, inactiveWithOpenSkills, inactiveWithOpenIssue, dates }) {
   github = g;
   context = c;
   
@@ -49,10 +50,8 @@ async function main({ g, c }, { recentContributors, previousContributors, inacti
 
   // Final pass to get all open, assigned issues to check whether assignee either isn't a team member or is inactive 
   const currentPMTeam = await getTeamMembers(github, context, PMTeam);
-  const writeAndPMTeam = updatedTeamMembers.concat(currentPMTeam);
-  const [nonTeamOpenIssue, inactiveOpenIssue] = getOpenAssignedIssues(writeAndPMTeam, inactiveWithOpenIssue)
-
-  
+  const writeAndPMTeam = { ...updatedTeamMembers, ...currentPMTeam };
+  const [nonTeamOpenIssue, inactiveOpenIssue] = await getOpenAssignedIssues(github, context, writeAndPMTeam, inactiveWithOpenIssue)
   console.log(`-`.repeat(60));
   console.log('Members inactive since ' + dates[1].slice(0, 10) + ' with open issues preventing removal:');
   console.log(inactiveOpenIssue);
@@ -69,13 +68,13 @@ async function main({ g, c }, { recentContributors, previousContributors, inacti
  * @returns {Array} removedMembers        - List of members that were removed 
  * @returns {Object} cannotRemoveYet      - List of members that cannot be removed due to open issues
  */
-async function removeInactiveMembers(previousContributors, inactiveWithOpenSkills,inactiveWithOpenIssue, currentTeamMembers) {
+async function removeInactiveMembers(previousContributors, inactiveWithOpenSkills, inactiveWithOpenIssue, currentTeamMembers) {
   const removedMembers = [];
   const cannotRemoveYet = {};
   const previouslyNotified = await readPreviousNotifyList();
   
-  // Loop over team members and remove them from the team if they are not in previousContributors list 
-  // or not in the inactiveWithOpenIssue list
+  // Loop over team members and remove them from the team if they are 
+  // not in `previousContributors` list or not in the `inactiveWithOpenIssue` list
   for (const username in currentTeamMembers) {
     if (!(username in previousContributors) | !(username in inactiveWithOpenIssue)) {
       // Prior to deletion, confirm that member is on the baseTeam
@@ -211,7 +210,7 @@ async function checkMemberIsNotNew(member){
  * @param {Array} nonTeamOpenIssue           - List of non-team members with open issues
  * @param {Array} inactiveOpenIssue          - List of inactive members that can't be removed yet
  */
-function writeData(removedContributors, notifiedContributors, nonTeamOpenIssue, inactiveOpenIssue){
+function writeData(removedContributors, notifiedContributors, nonTeamOpenIssue, inactiveOpenIssue) {
   
   const filepath = 'github-actions/utils/_data/inactive-members.json';
   const inactiveMemberLists = { removedContributors, notifiedContributors, nonTeamOpenIssue, inactiveOpenIssue };

--- a/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
+++ b/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
@@ -73,9 +73,10 @@ async function removeInactiveMembers(previousContributors, inactiveWithOpenSkill
   const cannotRemoveYet = {};
   const previouslyNotified = await readPreviousNotifyList();
   
-  // Loop over team members and remove them from the team if they are not in `previousContributors` list 
-  for (const username in currentTeamMembers) {
-    if (!previousContributors[username]) {
+  // Loop over team members and remove them from the team if they   
+  // are not in either previousContributors or inactiveWithOpenIssue
+  for (const username in currentTeamMembers) {   
+    if ((!previousContributors[username]) || (!username in inactiveWithOpenIssue)) {
       // Prior to deletion, confirm that member is on the baseTeam
       await addTeamMember(github, context, baseTeam, username);
       // If member was not on the previouslyNotified list, do not remove yet

--- a/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
+++ b/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
@@ -73,10 +73,9 @@ async function removeInactiveMembers(previousContributors, inactiveWithOpenSkill
   const cannotRemoveYet = {};
   const previouslyNotified = await readPreviousNotifyList();
   
-  // Loop over team members and remove them from the team if they are 
-  // not in `previousContributors` list or not in the `inactiveWithOpenIssue` list
+  // Loop over team members and remove them from the team if they are not in `previousContributors` list 
   for (const username in currentTeamMembers) {
-    if (!(username in previousContributors) | !(username in inactiveWithOpenIssue)) {
+    if (!previousContributors[username]) {
       // Prior to deletion, confirm that member is on the baseTeam
       await addTeamMember(github, context, baseTeam, username);
       // If member was not on the previouslyNotified list, do not remove yet

--- a/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
+++ b/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
@@ -64,13 +64,13 @@ async function main({ g, c }, { recentContributors, previousContributors, inacti
 /**
  * Remove contributors that were last active **before** the previous (twoMonthsAgo) date
  * @param {Object} previousContributors   - List of contributors active since previous date
+ * @param {Object} inactiveWithOpenSkills - Inactive members with open Skills Issue
  * @param {Object} inactiveWithOpenIssue  - Inactive members with open issues
- * @returns {Array} removedMembers        - List of members that were removed 
- * @returns {Object} cannotRemoveYet      - List of members that cannot be removed due to open issues
+ * @param {Object} currentTeamMembers     - Current team members
+ * @returns {Object} removedMembers       - List of members that were removed 
  */
 async function removeInactiveMembers(previousContributors, inactiveWithOpenSkills, inactiveWithOpenIssue, currentTeamMembers) {
   const removedMembers = [];
-  const cannotRemoveYet = {};
   const previouslyNotified = await readPreviousNotifyList();
   
   // Loop over team members and remove them from the team if they   

--- a/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
+++ b/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
@@ -51,7 +51,7 @@ async function main({ g, c }, { recentContributors, previousContributors, inacti
   // Final pass to get all open, assigned issues to check whether assignee either isn't a team member or is inactive 
   const currentPMTeam = await getTeamMembers(github, context, PMTeam);
   const writeAndPMTeam = { ...updatedTeamMembers, ...currentPMTeam };
-  const [nonTeamOpenIssue, inactiveOpenIssue] = await getOpenAssignedIssues(github, context, writeAndPMTeam, inactiveWithOpenIssue)
+  const [nonTeamOpenIssue, inactiveOpenIssue] = await getOpenAssignedIssues(github, context, writeAndPMTeam, inactiveWithOpenIssue);
   console.log(`-`.repeat(60));
   console.log('Members inactive since ' + dates[1].slice(0, 10) + ' with open issues preventing removal:');
   console.log(inactiveOpenIssue);

--- a/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
+++ b/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const getTeamMembers = require('../../utils/get-team-members');
 const addTeamMember = require('../../utils/add-team-member');
+const getOpenAssignedIssues = require('../../utils/get-open-assigned-issues');
 
 // Global variables
 var github;
@@ -10,6 +11,7 @@ var context;
 const baseTeam = 'website';
 const writeTeam = 'website-write';
 const mergeTeam = 'website-merge';
+const PMTeam =  'website-pm';
 
 
 
@@ -24,7 +26,7 @@ const mergeTeam = 'website-merge';
  * @param {Object} inactiveWithOpenIssue - Inactive contributors that have open issues
  * @param {Object} dates                 - [recent, previous] dates of oneMonthAgo, twoMonthsAgo
  */
-async function main({ g, c }, { recentContributors, previousContributors, inactiveWithOpenIssue, dates }) {
+async function main({ g, c }, { recentContributors, previousContributors, inactiveWithOpenSkills,inactiveWithOpenIssue, dates }) {
   github = g;
   context = c;
   
@@ -33,14 +35,10 @@ async function main({ g, c }, { recentContributors, previousContributors, inacti
   console.log('Current members of ' + writeTeam + ':');
   console.log(currentTeamMembers);
 
-  const [removedContributors, cannotRemoveYet] = await removeInactiveMembers(previousContributors, inactiveWithOpenIssue, currentTeamMembers);
+  const removedContributors = await removeInactiveMembers(previousContributors, inactiveWithOpenSkills, inactiveWithOpenIssue, currentTeamMembers);
   console.log(`-`.repeat(60));
   console.log('Removed members from ' + writeTeam + ' inactive since ' + dates[1].slice(0, 10) + ':');
   console.log(removedContributors);
-
-  console.log(`-`.repeat(60));
-  console.log('Members inactive since ' + dates[1].slice(0, 10) + ' with open issues preventing removal:');
-  console.log(cannotRemoveYet);
 
   // Repeat getTeamMembers() after removedContributors to compare with recentContributors
   const updatedTeamMembers = await getTeamMembers(github, context, writeTeam);
@@ -49,7 +47,17 @@ async function main({ g, c }, { recentContributors, previousContributors, inacti
   console.log('Notified members from ' + writeTeam + ' inactive since ' + dates[0].slice(0, 10) + ':');
   console.log(notifiedContributors);
 
-  writeData(removedContributors, notifiedContributors, cannotRemoveYet);
+  // Final pass to get all open, assigned issues to check whether assignee either isn't a team member or is inactive 
+  const currentPMTeam = await getTeamMembers(github, context, PMTeam);
+  const writeAndPMTeam = updatedTeamMembers.concat(currentPMTeam);
+  const [nonTeamOpenIssue, inactiveOpenIssue] = getOpenAssignedIssues(writeAndPMTeam, inactiveWithOpenIssue)
+
+  
+  console.log(`-`.repeat(60));
+  console.log('Members inactive since ' + dates[1].slice(0, 10) + ' with open issues preventing removal:');
+  console.log(inactiveOpenIssue);
+
+  writeData(removedContributors, notifiedContributors, nonTeamOpenIssue, inactiveOpenIssue);
 };
 
 
@@ -61,41 +69,39 @@ async function main({ g, c }, { recentContributors, previousContributors, inacti
  * @returns {Array} removedMembers        - List of members that were removed 
  * @returns {Object} cannotRemoveYet      - List of members that cannot be removed due to open issues
  */
-async function removeInactiveMembers(previousContributors, inactiveWithOpenIssue, currentTeamMembers){
+async function removeInactiveMembers(previousContributors, inactiveWithOpenSkills,inactiveWithOpenIssue, currentTeamMembers) {
   const removedMembers = [];
   const cannotRemoveYet = {};
   const previouslyNotified = await readPreviousNotifyList();
   
-  // Loop over team members and remove them from the team if they are not in previousContributors list
-  for(const username in currentTeamMembers){
-    if (!previousContributors[username]){
+  // Loop over team members and remove them from the team if they are not in previousContributors list 
+  // or not in the inactiveWithOpenIssue list
+  for (const username in currentTeamMembers) {
+    if (!(username in previousContributors) | !(username in inactiveWithOpenIssue)) {
       // Prior to deletion, confirm that member is on the baseTeam
       await addTeamMember(github, context, baseTeam, username);
-      // But if member has an open issue or was not on the previouslyNotified list, do not remove yet
-      if(username in inactiveWithOpenIssue && inactiveWithOpenIssue[username][1] === false){
-        cannotRemoveYet[username] = inactiveWithOpenIssue[username][0];
-      } else if((previouslyNotified.length > 0) && !(previouslyNotified.includes(username))){
-        console.log('Member was not on last month\'s \'Inactive Members\' list, do not remove: ' + username);
+      // If member was not on the previouslyNotified list, do not remove yet
+      if ((previouslyNotified.length > 0) && !(previouslyNotified.includes(username))) {
+        console.log(`Member was not on last month's 'Inactive Members' list, do not remove: ${username}`);
       } else {
         // Remove member from all teams (except baseTeam)
-        const teams = [writeTeam, mergeTeam];
-        for(const team of teams){
+        for (const team of [writeTeam, mergeTeam]) {
           // https://docs.github.com/en/rest/teams/members?apiVersion=2022-11-28#remove-team-membership-for-a-user
           await github.request('DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}', {
             org: context.repo.owner,
             team_slug: team,
-            username: username,
+            username,
           });
         }
         removedMembers.push(username);
         // After removal, close member's "Skills Issue", if open
-        if(username in inactiveWithOpenIssue && inactiveWithOpenIssue[username][1] === true){
-          closePrework(username, inactiveWithOpenIssue[username][0]);
+        if (username in inactiveWithOpenSkills) {
+          closePrework(username, inactiveWithOpenSkills[username]);
         }
       }
     }
   }
-  return [removedMembers, cannotRemoveYet];
+  return removedMembers;
 }
 
 
@@ -200,14 +206,15 @@ async function checkMemberIsNotNew(member){
 
 /**
  * Function to save inactive members list to local repo for use in next job  
- * @param {Array} removedContributors  - List of contributors that were removed
- * @param {Array} notifiedContributors - List of contributors to be notified
- * @param {Array} cannotRemoveYet      - List of contributors that can't be removed yet
+ * @param {Array} removedContributors        - List of contributors that were removed
+ * @param {Array} notifiedContributors       - List of contributors to be notified
+ * @param {Array} nonTeamOpenIssue           - List of non-team members with open issues
+ * @param {Array} inactiveOpenIssue          - List of inactive members that can't be removed yet
  */
-function writeData(removedContributors, notifiedContributors, cannotRemoveYet){
+function writeData(removedContributors, notifiedContributors, nonTeamOpenIssue, inactiveOpenIssue){
   
   const filepath = 'github-actions/utils/_data/inactive-members.json';
-  const inactiveMemberLists = { removedContributors, notifiedContributors, cannotRemoveYet };
+  const inactiveMemberLists = { removedContributors, notifiedContributors, nonTeamOpenIssue, inactiveOpenIssue };
 
   fs.writeFile(filepath, JSON.stringify(inactiveMemberLists, null, 2), (err) => {
     if (err) throw err;

--- a/github-actions/utils/get-open-assigned-issues.js
+++ b/github-actions/utils/get-open-assigned-issues.js
@@ -1,0 +1,51 @@
+/**
+ * Function to get all repo issues that either are not assigned to a currentTeam member, or are assigned to 
+ * inactive members so that leadership can be made aware that the issue does not have an active team member assigned.
+ * @param {Object} currentTeam                 - currentTeam members
+ * @param {Object} inactiveMemberOpenIssue     - inactive team members assigned to an open issue 
+ * @return {Object} nonTeamMemberOpenIssue     - non-team members assigned to open issues
+ * @return {Object} inactiveMemberOpenIssue    - inactive team members, all assignments to open issues
+ */
+async function getOpenAssignedIssues(currentTeam = {}, inactiveMemberOpenIssue = {}) {
+  let nonTeamMemberOpenIssue = {};
+  let pageNum = 1;
+  let result = [];
+
+  // Since Github only allows to fetch max 100 items per request, we need to 'flip' pages
+  while (true) {
+    // Fetch 100 items per each page (`pageNum`)
+    const openIssues = await github.request('GET /repos/{owner}/{repo}/issues', {
+      // owner: context.repo.owner,
+      owner: 'hackforla',
+      repo: context.repo.repo,
+      assignee: '*',
+      per_page: 100,
+      page: pageNum
+    });
+
+    // If the API call returns an empty array, break out of loop- there is no additional data.
+    // Else if data is returned, push it to `result` and increase the page number (`pageNum`)
+    if (!openIssues.data.length) {
+      break;      
+    } else {
+      result = result.concat(openIssues.data);
+      pageNum++;
+    }
+  }
+
+  // For the list of all open issues, check whether there is an assignee who is not a current team member
+  for (const contributorInfo of result) {
+    let assignee = contributorInfo.assignee.login;
+    let issueNum = contributorInfo.number;
+    // Check if the assignee is not on the currentTeam, then 
+    if (!(assignee in currentTeam)) {
+      if (assignee in inactiveMemberOpenIssue && !inactiveMemberOpenIssue[assignee].includes(issueNum)) {
+        inactiveMemberOpenIssue[assignee].push(issueNum);
+      } else {
+        nonTeamMemberOpenIssue[assignee] = issueNum;
+      }
+    }
+  }
+
+  return [nonTeamMemberOpenIssue, inactiveMemberOpenIssue]; 
+}

--- a/github-actions/utils/get-open-assigned-issues.js
+++ b/github-actions/utils/get-open-assigned-issues.js
@@ -1,12 +1,12 @@
 /**
  * Function to get all repo issues that either are not assigned to a currentTeam member, or are assigned to 
  * inactive members so that leadership can be made aware that the issue does not have an active team member assigned.
- * @param {Object} currentTeam                 - currentTeam members
- * @param {Object} inactiveMemberOpenIssue     - inactive team members assigned to an open issue 
+ * @param {Object} currentTeam                 - currentTeam members (optional)
+ * @param {Object} inactiveMemberOpenIssue     - inactive team members assigned to an open issue (optional)
  * @return {Object} nonTeamMemberOpenIssue     - non-team members assigned to open issues
  * @return {Object} inactiveMemberOpenIssue    - inactive team members, all assignments to open issues
  */
-async function getOpenAssignedIssues(currentTeam = {}, inactiveMemberOpenIssue = {}) {
+async function getOpenAssignedIssues(github, context, currentTeam = {}, inactiveMemberOpenIssue = {}) {
   let nonTeamMemberOpenIssue = {};
   let pageNum = 1;
   let result = [];
@@ -14,9 +14,9 @@ async function getOpenAssignedIssues(currentTeam = {}, inactiveMemberOpenIssue =
   // Since Github only allows to fetch max 100 items per request, we need to 'flip' pages
   while (true) {
     // Fetch 100 items per each page (`pageNum`)
+    // https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues
     const openIssues = await github.request('GET /repos/{owner}/{repo}/issues', {
-      // owner: context.repo.owner,
-      owner: 'hackforla',
+      owner: context.repo.owner,
       repo: context.repo.repo,
       assignee: '*',
       per_page: 100,
@@ -33,19 +33,20 @@ async function getOpenAssignedIssues(currentTeam = {}, inactiveMemberOpenIssue =
     }
   }
 
-  // For the list of all open issues, check whether there is an assignee who is not a current team member
+  // Loop through each result individually
   for (const contributorInfo of result) {
     let assignee = contributorInfo.assignee.login;
     let issueNum = contributorInfo.number;
-    // Check if the assignee is not on the currentTeam, then 
+    // Check if assignee is not a currentTeam member, then find their other open issues
+    // Else if assignee is on the inactiveMember list, find all of their open issues
     if (!(assignee in currentTeam)) {
-      if (assignee in inactiveMemberOpenIssue && !inactiveMemberOpenIssue[assignee].includes(issueNum)) {
-        inactiveMemberOpenIssue[assignee].push(issueNum);
-      } else {
-        nonTeamMemberOpenIssue[assignee] = issueNum;
-      }
+      (nonTeamMemberOpenIssue[assignee] ??= []).push(issueNum);
+    } else if (assignee in inactiveMemberOpenIssue) {
+      inactiveMemberOpenIssue[assignee].push(issueNum);
     }
   }
 
   return [nonTeamMemberOpenIssue, inactiveMemberOpenIssue]; 
 }
+
+module.exports = getOpenAssignedIssues;

--- a/github-actions/utils/get-open-assigned-issues.js
+++ b/github-actions/utils/get-open-assigned-issues.js
@@ -41,7 +41,7 @@ async function getOpenAssignedIssues(github, context, currentTeam = {}, inactive
     // Else if assignee is on the inactiveMember list, find all of their open issues
     if (!(assignee in currentTeam)) {
       (nonTeamMemberOpenIssue[assignee] ??= []).push(issueNum);
-    } else if (assignee in inactiveMemberOpenIssue) {
+    } else if (assignee in inactiveMemberOpenIssue && !inactiveMemberOpenIssue[assignee].includes(issueNum)) {
       inactiveMemberOpenIssue[assignee].push(issueNum);
     }
   }


### PR DESCRIPTION
Fixes #8174 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Added `get-open-assigned-issues.js`
  - In `get-contributors-data.js`, split out `inactiveWithOpenSkills` from `inactiveWithOpenIssue`
  - In `trim-inactive-members.js`, followed `inactiveWithOpenSkills` split, added function call to `getOpenAssignedIssues.js`, simplified if/else statements, followed new variable `nonTeamOpenIssue`
  - In `createNewIssue.js`, added section to report `nonTeamWIthOpen`

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - The new utility function retrieves a list of all open issues with assignees, and then iterates through the list to find issues  assigned to non-team members, as well as issues assigned to previously identified inactive members
  - This will help us reassign open issues that are not being worked on.


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [ ] I have checked this PR for CodeQL alerts and none were found.
- [x] I found CodeQL alert(s), and (select one):
   - [x] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes
- [Workflow logs](https://github.com/t-will-gillis/website/actions/runs/15656104194/job/44107388900) of successful test run
- [Test Issue](https://github.com/t-will-gillis/website/issues/1177) created by automation
- [Test Comment to Issue](https://github.com/t-will-gillis/website/issues/1176)

## Notes for Reviewers
- Note that I can do a live demonstration instead of you needing to run this yourself. Otherwise,
- [x] You will need to have a functioning test environment on your local repo. In addition to the 'files changed' in the PR, there are additional changes that you should make to help with testing. If you do not make these edits, you might delete or mis-edit Hack for LA data, delete team members,  generate false or junk notifications, and/or create junk issues on HfLA's live project board. 
- [x] In `schedule-monthly.yml`, you will need to activate two personal tokens. 
  - [x] `HACKFORLA_BOT_PA_TOKEN` scopes: admin:org_hook, public_repo
  - [ ] `HACKFORLA_ADMIN_TOKEN` scopes: admin:org_hook, public_repo, write:org
- [x] In the same file, near line 12, replace 'hackforla' with your personal repo.
- In `get-contributors-data.js`
  - [x] Around line 82 replace with `owner: 'hackforla',`
  - [x] Around line 83 replace with `repo: 'website',`
- In 'trim-inactive-members.js`:
  - [x] IMPORTANT:  Disable lines 84-88 by replacing:  
  ```
  await github.request('DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}', {
            org: context.repo.owner,
            team_slug: team,
            username: username,
          });
      }
  ```  
  with:  
  ```
          console.log('Would be removed: ' + username);
          // await github.request('DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}', {
          //   org: context.repo.owner,
          //   team_slug: team,
          //   username: username,
          // });
        }
  ```  

  - [x] IMPORTANT: Disable entirely the `closePrework()` function, starting around ln 110:
  ```  
  async function closePrework(member, issueNum){ 
    console.log('skipping closePrework()');
    // Close the assignee's "Pre-work Checklist" and add comment
    // await github.request('PATCH /repos/{owner}/{repo}/issues/{issue_number}', {
    //   owner: org,
    //   repo: repo,
    //   issue_number: issueNum,
    //   state: 'closed'
    // });
    // console.log('Closing "Pre-work Checklist" issue number ' + issueNum + ' for ' + member);
    // // Add comment to issue
    // await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/comments', {
    //   owner: org,
    //   repo: repo,
    //   issue_number: issueNum,
    //   body: 'The Hack for LA Bot has closed this issue due to member inactivity.'
    // });
  }
  ```  
- In `create-new-issue.js`:
  - [x] Around line 28 should be OK as written, but you can replace `const owner = '<your name>';` **_NOT_** 'hackforla'
  - [x] Around line 29 should be OK as written, but you can replace `const repo = '<your repo name>';`
  - [x] Around line 10, replace with an issue number in your repo
  - [x] IMPORTANT: Around line 46-47 replace with:
  ```  
  let removedList = removeList.map(x => "@ " + x).join("\n");    // important to add space
  let notifiedList = notifyList.map(x => "@ " + x).join("\n");   // important to add space
  ```  
  - Comment out ln 66, i.e.: `// let milestone = parseInt(issueObject['milestone']);`
  - Comment out ln 81, i.e.: `// milestone,`
- In `/utils/get-team-members.js`:
  - [x] Ln 16, replace with `org: 'hackforla',`
- In `/utils/add-team-member.js`:
  - [x] Ln 11, replace with `org: 'hackforla',`
  - [x] Ln 18, replace with `org: 'hackforla',`
- In `/utils/get-timeline.js`:
  - [x] Ln 16, replace with `owner: 'hackforla',`
  - [x] Ln 17, replace with `repo: 'website',`
- In `/utils/post-issue-comment.js`:
  - [x] Ln 9, replace with `owner: ' <your name> ',` **_NOT_** 'hackforla'
  - [x] Ln 10, replace with `repo: 'website',`
- In `get-open-assigned-issues.js`:
  - [ ]  Ln 18, replace with `owner: 'hackforla',`