### PR TITLE
Restore `2 weeks inactive` label

### DIFF
--- a/github-actions/utils/_data/label-directory.json
+++ b/github-actions/utils/_data/label-directory.json
@@ -737,7 +737,7 @@
   ],
   "statusInactive2": [
     "2 weeks inactive",
-    9999999999
+    8699858132
   ],
   "statusMissing": [
     "status: missing",
@@ -854,9 +854,5 @@
   "skillEnhance": [
     "Skill: enhance",
     8273641077
-  ],
-  "NEW-2WeeksInactive": [
-    "2 weeks inactive",
-    8699858132
   ]
 }


### PR DESCRIPTION

Fixes #8176 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Saved the labelId for the bot-generated, new `2 weeks inactive` label and replaced the labelId from the deleted label.
  - Deleted the labelKey entry for "NEW-2WeeksInactive" 
  - Restored the color and the description from the deleted label back to the updated label (see screenshot of settings under "Screenshots" below)


### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Restored the original label settings and the new labelId to the previous labelKey for `2 weeks inactive`
  - This was needed because a dev deleted an important label. When the bot recreated the label, the new label had as incorrect labelKey and settings


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots 
- No visual changes to website
<details><summary>Restored label settings</summary>

<img width="750" alt="Screenshot 2025-06-10 114817" src="https://github.com/user-attachments/assets/4258fbe0-f150-42af-9def-72a63d9ee9f4" />

</details>
