### PR TITLE
fix(toolkit): prevent "?" from being appended to URL when no filters are active

### DIFF
--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -248,17 +248,15 @@ function applyFilters(filtersParams) {
 
 // Apply current filters to URL
 function applyFiltersToURL(filterParams) {
-    let filters = ''
-    for (let key in filterParams) {
-        if (filterParams[key].length) {
-            filters = filters + `${key}=${filterParams[key].join(',')}&`
-        }
+    const url = new URL(window.location)
+    const params = new URLSearchParams()
+
+    for (const [key, values] of Object.entries(filterParams)) {
+        values.forEach(value => params.append(key, value))
     }
-    // Remove extra &
-    if (filters) {
-        filters = filters.slice(0, filters.length - 1)
-    }
-    window.history.replaceState(null, '', `?${filters}`)
+
+    url.search = params.toString() 
+    window.history.replaceState(null, '', url)
 }
 
 // Apply URL to filters


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7636 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
This PR fixes an issue where a `?` was appended to the URL even when no query parameters were present.

The bug stemmed from `applyFiltersToURL()`, where `replaceState()` was always invoked with a hardcoded `?${filters}` string—even when no filters were active—resulting in a stray `?` in the URL. The function has been refactored to use the URL and URLSearchParams APIs, eliminating the need to manually construct the query string and reducing the risk of similar errors. 

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
 
The changes were made to fix the bug and to make the code more maintainable. 

#### Previous Implementation

The previous implementation constructed the query string manually by iterating over the filterParams object<sup>1</sup>. 
The logic:
- Build a query string by concatenating each filter as `key=value1,value2`
- Trim the trailing `&` from the final string
- Append the result to the URL using: `window.history.replaceState(null, '', `?${filters}`)`

#### The Problem

When no filters are applied, the query string is empty, yet the code still appends a `?` to the URL, resulting in the URL being`hackforla.org/toolkit/?`. This occurs because `window.history.replaceState(null, '', `?${filters}`)` is executed unconditionally—even when filters is an empty string. Since `applyFiltersToURL()` is invoked on both DOMContentLoaded and on every filter checkbox or tag interaction, this leads to `?` being appended unnecessarily on initial page load and when clearing filters.

#### Current Implementation

The updated version uses the URL and URLSearchParams Web APIs for safer and more standardized URL manipulation:
- A URL object is created from `window.location`
- A URLSearchParams instance is populated by iterating over `filterParams`
- The search portion of the URL is set via`url.search = params.toString()`
- Finally, the browser’s address bar is updated using: `window.history.replaceState(null, '', url)`

This ensures that if no filters are active, `params.toString()` returns an empty string and the query portion is omitted entirely—removing the dangling `?`.

#### Testing

I have tested that
- Filtering works
- There is a '?' at the beginning of the filters in URL when at at least one filter is checked
- Filters are added to the URL when checked
- Filters are removed from the URL when unchecked
- After checking a filter then unchecking it, the '?' disappears

<sup>1</sup> The filterParams object is initialized on the DOMContentLoaded event and updated in response to checkbox interactions and page loads containing filters in the URL.

<h3>CodeQL Alerts</h3>

After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.

<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)

</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

<img width="385" alt="Screen Shot 2025-06-10 at 6 19 35 PM" src="https://github.com/user-attachments/assets/6f83d066-498c-4299-85ce-1fec8d14c8f6" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="470" alt="Screen Shot 2025-06-10 at 6 19 01 PM" src="https://github.com/user-attachments/assets/d7c1b4b3-5162-4ddb-8862-e541f0cd2a04" />

</details>
