### PR TITLE
Pin projects filter to top of projects list mobile view

### DIFF
--- a/_includes/current-projects.html
+++ b/_includes/current-projects.html
@@ -34,9 +34,10 @@
         <a href="#" id="search-tip-link">Search Tips</a>
       </div>
 
-      <!-- Search bar moved here to appear directly below the Search Tips link -->
-      <form id="search-bar">
-        <input type="text" name="Search" id="search" placeholder="Search By Keywords">
+      <!-- Search bar moved here to appear directly below the Search Tips link on mobile -->
+
+      <form class="search-bar-mobile">
+        <input type="text" name="Search" id="search-mobile" class="search-input" placeholder="Search By Keywords">
         <button class="search-x" aria-label="Cancel Search" tabindex="2">
           <svg id="search-close" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M18 6L6 18" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -49,10 +50,25 @@
           </svg>
         </button>
       </form>
+
     </div>
   </nav>
-  
+  <!-- Projects and Filters container -->
   <div class="projects-and-filters">
+    <form class="search-bar-desktop">
+    <input type="text" name="Search" id="search-desktop" placeholder="Search By Keywords">
+    <button class="search-x" aria-label="Cancel Search" tabindex="2">
+      <svg id="search-close" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M18 6L6 18" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M6 6L18 18" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+    <button class="search-glass" aria-label="Search by Keywords" tabindex="1">
+      <svg id="search-magnify-glass" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M14.3248 12.8987L19.7048 18.2787C19.8939 18.468 20 18.7246 20 18.9921C19.9999 19.2596 19.8935 19.5161 19.7043 19.7052C19.515 19.8943 19.2584 20.0005 18.9909 20.0004C18.7234 20.0003 18.4669 19.894 18.2778 19.7047L12.8978 14.3247C11.2895 15.5704 9.26705 16.1566 7.24189 15.9641C5.21674 15.7716 3.341 14.8148 1.99625 13.2884C0.6515 11.7619 -0.0612416 9.78056 0.00301976 7.74729C0.0672812 5.71402 0.903718 3.7816 2.34217 2.34315C3.78063 0.904695 5.71305 0.0682577 7.74631 0.00399633C9.77958 -0.0602651 11.761 0.652477 13.2874 1.99723C14.8138 3.34198 15.7706 5.21772 15.9631 7.24287C16.1556 9.26802 15.5694 11.2905 14.3238 12.8987H14.3248ZM7.99977 13.9997C9.59107 13.9997 11.1172 13.3676 12.2424 12.2424C13.3676 11.1172 13.9998 9.59104 13.9998 7.99974C13.9998 6.40845 13.3676 4.88232 12.2424 3.7571C11.1172 2.63189 9.59107 1.99974 7.99977 1.99974C6.40847 1.99974 4.88235 2.63189 3.75713 3.7571C2.63191 4.88232 1.99977 6.40845 1.99977 7.99974C1.99977 9.59104 2.63191 11.1172 3.75713 12.2424C4.88235 13.3676 6.40847 13.9997 7.99977 13.9997Z" fill="#333333"/>
+      </svg>
+    </button>
+  </form>
     <div class="page-contain projects-inner" >
       <ul class="project-list unstyled-list"></ul>
     </div>

--- a/_includes/current-projects.html
+++ b/_includes/current-projects.html
@@ -4,7 +4,7 @@
   <nav class="filter-toolbar" aria-label="Filter Navbar">
     <div class="filtersDiv">
       <h3 class="filters-title">
-        Filters
+        <span class="filters-label-group">Filters <span id="counter_total" class="number-of-checked-boxes"></span> <a href="#" id="clear-all-filters" class="clear-filter-tags">Clear All</a></span>
         <button class="show-filters-button" aria-label="Show All Filters">
           <svg id='hamburger-filter-nav' width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M21.6297 12.2046H3.6297" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/_includes/current-projects.html
+++ b/_includes/current-projects.html
@@ -33,24 +33,26 @@
       <div class="search-tip-link">
         <a href="#" id="search-tip-link">Search Tips</a>
       </div>
+
+      <!-- Search bar moved here to appear directly below the Search Tips link -->
+      <form id="search-bar">
+        <input type="text" name="Search" id="search" placeholder="Search By Keywords">
+        <button class="search-x" aria-label="Cancel Search" tabindex="2">
+          <svg id="search-close" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M18 6L6 18" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M6 6L18 18" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
+        <button class="search-glass" aria-label="Search by Keywords" tabindex="1">
+          <svg id="search-magnify-glass" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M14.3248 12.8987L19.7048 18.2787C19.8939 18.468 20 18.7246 20 18.9921C19.9999 19.2596 19.8935 19.5161 19.7043 19.7052C19.515 19.8943 19.2584 20.0005 18.9909 20.0004C18.7234 20.0003 18.4669 19.894 18.2778 19.7047L12.8978 14.3247C11.2895 15.5704 9.26705 16.1566 7.24189 15.9641C5.21674 15.7716 3.341 14.8148 1.99625 13.2884C0.6515 11.7619 -0.0612416 9.78056 0.00301976 7.74729C0.0672812 5.71402 0.903718 3.7816 2.34217 2.34315C3.78063 0.904695 5.71305 0.0682577 7.74631 0.00399633C9.77958 -0.0602651 11.761 0.652477 13.2874 1.99723C14.8138 3.34198 15.7706 5.21772 15.9631 7.24287C16.1556 9.26802 15.5694 11.2905 14.3238 12.8987H14.3248ZM7.99977 13.9997C9.59107 13.9997 11.1172 13.3676 12.2424 12.2424C13.3676 11.1172 13.9998 9.59104 13.9998 7.99974C13.9998 6.40845 13.3676 4.88232 12.2424 3.7571C11.1172 2.63189 9.59107 1.99974 7.99977 1.99974C6.40847 1.99974 4.88235 2.63189 3.75713 3.7571C2.63191 4.88232 1.99977 6.40845 1.99977 7.99974C1.99977 9.59104 2.63191 11.1172 3.75713 12.2424C4.88235 13.3676 6.40847 13.9997 7.99977 13.9997Z" fill="#333333"/>
+          </svg>
+        </button>
+      </form>
     </div>
   </nav>
   
   <div class="projects-and-filters">
-    <form id="search-bar">
-      <input type="text" name="Search" id="search" placeholder="Search By Keywords">
-      <button class="search-x" aria-label="Cancel Search" tabindex="2">
-        <svg id="search-close" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M18 6L6 18" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-          <path d="M6 6L18 18" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-      </button>
-      <button class="search-glass" aria-label="Search by Keywords" tabindex="1">
-        <svg id="search-magnify-glass" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path fill-rule="evenodd" clip-rule="evenodd" d="M14.3248 12.8987L19.7048 18.2787C19.8939 18.468 20 18.7246 20 18.9921C19.9999 19.2596 19.8935 19.5161 19.7043 19.7052C19.515 19.8943 19.2584 20.0005 18.9909 20.0004C18.7234 20.0003 18.4669 19.894 18.2778 19.7047L12.8978 14.3247C11.2895 15.5704 9.26705 16.1566 7.24189 15.9641C5.21674 15.7716 3.341 14.8148 1.99625 13.2884C0.6515 11.7619 -0.0612416 9.78056 0.00301976 7.74729C0.0672812 5.71402 0.903718 3.7816 2.34217 2.34315C3.78063 0.904695 5.71305 0.0682577 7.74631 0.00399633C9.77958 -0.0602651 11.761 0.652477 13.2874 1.99723C14.8138 3.34198 15.7706 5.21772 15.9631 7.24287C16.1556 9.26802 15.5694 11.2905 14.3238 12.8987H14.3248ZM7.99977 13.9997C9.59107 13.9997 11.1172 13.3676 12.2424 12.2424C13.3676 11.1172 13.9998 9.59104 13.9998 7.99974C13.9998 6.40845 13.3676 4.88232 12.2424 3.7571C11.1172 2.63189 9.59107 1.99974 7.99977 1.99974C6.40847 1.99974 4.88235 2.63189 3.75713 3.7571C2.63191 4.88232 1.99977 6.40845 1.99977 7.99974C1.99977 9.59104 2.63191 11.1172 3.75713 12.2424C4.88235 13.3676 6.40847 13.9997 7.99977 13.9997Z" fill="#333333"/>
-        </svg>
-      </button>
-    </form>
     <div class="page-contain projects-inner" >
       <ul class="project-list unstyled-list"></ul>
     </div>

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -239,6 +239,20 @@ a.clear-filter-tags {
   }
 }
 
+// Style for the Clear All link 
+.filters-title .number-of-checked-boxes {
+  font-size: 0.85em; // slightly smaller than heading
+  color: $color-black; // same color as the "Filters" text
+  margin-left: 2px;
+}
+
+.filters-title .clear-filter-tags {
+  margin-left: 4px; // space between counter and link
+  white-space: nowrap;
+  display: none; // shown via JS when filters selected
+  color: $color-cement;
+}
+
 .number-of-checked-boxes {
   color: $color-red;
 }
@@ -251,6 +265,10 @@ a.clear-filter-tags {
     display: block;
     padding: 32px 16px;
     // flex-direction: column;
+  }
+  // Hide applied filter tags on mobile to conserve space
+  .filter-tag-container {
+    display: none !important;
   }
   .scroll-lock {
     overflow: hidden;
@@ -364,4 +382,28 @@ a.clear-filter-tags {
 .show-none + .dropdown li {
   display: block;
 }
+
+  // Align Filters label, counter, and Clear All link 
+  .filters-label-group {
+    display: flex;
+    align-items: baseline;
+  }
+  .filters-label-group .number-of-checked-boxes {
+    font-size: 0.85em;
+    color: $color-black;
+    margin-left: 4px;
+  }
+  .filters-label-group .clear-filter-tags {
+    margin-left: 8px;
+    white-space: nowrap;
+    display: none;
+    color: $color-cement;
+  }
+}
+
+@media #{$bp-tablet-up} {
+  .filters-label-group .number-of-checked-boxes,
+  .filters-label-group .clear-filter-tags {
+    display: none !important; // hide on desktop
+  }
 }

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -32,7 +32,7 @@ a.filter-item {
 .filter-toolbar {
   padding: 8px 32px;
   box-sizing: border-box;
-  height: calc(100vh - 60px);
+  height: auto;
   position: sticky;
   flex-shrink: 0;
   top: 64px;
@@ -258,9 +258,10 @@ a.clear-filter-tags {
 
   .filter-toolbar {
     background-color: $color-pink;
-    height: 100%;
-    position: static;
+    position: sticky;
     padding: 0;
+    top: 64px;
+    z-index: 99;
   }
 
   .filtersDiv {

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -296,8 +296,9 @@ a.clear-filter-tags {
     left: 0;
     bottom: 0;
     right: 0;
-    overflow-y: scroll;
     background: $color-white;
+    display: flex;
+    flex-direction: column;
   }
   .filters-title {
     background: $color-white;
@@ -335,17 +336,15 @@ a.clear-filter-tags {
 
   .filter-toolbar.show-filters ul.filter-list {
     display: flex;
-    padding: 0 12px 65px 12px;
+    flex-grow: 1;
+    overflow-y: auto;
+    padding: 0 12px 20px 12px;
   }
   .filter-toolbar.show-filters .mobile-filter-buttons {
     display: flex;
     box-sizing: border-box;
     justify-content: space-evenly;
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    width: 100%;
+    flex-shrink: 0;
     background: $color-white;
     padding: 8px;
     box-shadow: 0px -1px 4px 0px $color-mediumgrey;

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -263,7 +263,7 @@ a.clear-filter-tags {
   //resize dropdown on tablet and mobile view
   section.filter-content-container {
     display: block;
-    padding: 32px 16px;
+    padding: 0 16px 32px 16px;
     // flex-direction: column;
   }
   // Hide applied filter tags in collapsed mobile toolbar
@@ -275,10 +275,10 @@ a.clear-filter-tags {
   }
 
   .filter-toolbar {
-    background-color: $color-pink;
+    background-color: #f7f5f5;
     position: sticky;
-    padding: 0;
-    top: 64px;
+    padding: 32px 0 0 0;
+    top: 40px;
     z-index: 99;
   }
 

--- a/_sass/elements/_dropdown_filters.scss
+++ b/_sass/elements/_dropdown_filters.scss
@@ -266,9 +266,9 @@ a.clear-filter-tags {
     padding: 32px 16px;
     // flex-direction: column;
   }
-  // Hide applied filter tags on mobile to conserve space
+  // Hide applied filter tags in collapsed mobile toolbar
   .filter-tag-container {
-    display: none !important;
+    display: none;
   }
   .scroll-lock {
     overflow: hidden;
@@ -319,7 +319,8 @@ a.clear-filter-tags {
     border: none;
   }
   .filter-toolbar.show-filters .filter-tag-container {
-    display: none;
+    display: flex;
+    flex-direction: column;
   }
   ul.filter-list {
     display: none;

--- a/_sass/elements/_search-bar.scss
+++ b/_sass/elements/_search-bar.scss
@@ -1,55 +1,68 @@
-#search-bar {    
-    height: 44px;
-    padding: 10px 16px;
-    border-radius: 5px;
-    border: 1px solid rgba(0, 0, 0, 0.24);
-    display: flex;
-    flex-direction: row;
-    background: $color-white;
-    gap: 4px;
-    margin-bottom: 10px;
+
+
+/* Search bar container (was #search-bar) */
+.search-bar-desktop,
+.search-bar-mobile {
+  height: 44px;
+  padding: 10px 16px;
+  border-radius: 5px;
+  border: 1px solid rgba(0, 0, 0, 0.24);
+  display: flex;
+  flex-direction: row;
+  background: $color-white;
+  gap: 4px;
+  margin-bottom: 10px;
 }
 
-form#search-bar {
-    position: sticky;
-    padding: 10px;
+/* Override _forms.scss (was #search) */
+#search-desktop,
+#search-mobile {
+  padding-right: 0px;
+  padding-left: 0px;
+  appearance: none;
+  background: $color-white;
+  border: none;
+  border-radius: 0px;
+  box-shadow: none;
+  color: $color-black;
+  font-size: 1rem;
+  height: 22px;
+  margin-bottom: 10px;
+  width: 100%;
 }
 
-//Styles to override the styles from _forms.scss
-#search{
-    padding-right: 0px;
-    padding-left: 0px;
-    appearance: none;
-    background: $color-white;
-    border: none;
-    border-radius: 0px;
-    box-shadow: none;
-    color: $color-black;
-    font-size: 1rem;
-    height: 22px;
-    margin-bottom: 10px;
-    width: 100%;
+/* Buttons */
+.search-x,
+.search-glass {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  margin: 0;
+  border: none;
 }
 
 .search-x {
-    width: 24px;
-    height: 24px;
-    padding: 0;
-    margin: 0;
-    display: none;
-    border:none;
+  display: none;
 }
 
-.search-glass {
-    width: 24px;
-    height: 24px;
-    padding: 0;
-    margin: 0;
-    border: none;
-}
 
+
+/* Mobile and below: show mobile search bar only (unchanged behaviour) */
 @media #{$bp-below-tablet} {
-    form#search-bar {
-        padding: 10px;
-    }
+  .search-bar-desktop { display: none; }
+  .search-bar-mobile { display: flex; position: static; }
+}
+
+/* Desktop and up: show desktop search bar; sticky below header */
+@media #{$bp-desktop-up} {
+  .search-bar-mobile { display: none; }
+  .search-bar-desktop {
+    display: flex;
+    position: sticky;
+    top: 61px; 
+    z-index: 90; 
+  }
+  .search-bar-mobile {
+    display: none;
+  }
 }

--- a/_sass/elements/_search-bar.scss
+++ b/_sass/elements/_search-bar.scss
@@ -13,15 +13,8 @@
 form#search-bar {
     position: sticky;
     padding: 10px;
-    top: 60px; 
-    z-index: 10;
 }
-// // Ensure search-bar does not pin on mobile
-@media #{$bp-below-tablet} {
-    form#search-bar {
-        position: static;
-    }
-}
+
 //Styles to override the styles from _forms.scss
 #search{
     padding-right: 0px;
@@ -53,4 +46,10 @@ form#search-bar {
     padding: 0;
     margin: 0;
     border: none;
+}
+
+@media #{$bp-below-tablet} {
+    form#search-bar {
+        padding: 10px;
+    }
 }

--- a/_sass/elements/_search-bar.scss
+++ b/_sass/elements/_search-bar.scss
@@ -14,7 +14,7 @@
   margin-bottom: 10px;
 }
 
-
+/* Override _forms.scss (was #search) */
 #search-desktop,
 #search-mobile {
   padding-right: 0px;
@@ -47,13 +47,13 @@
 
 
 
-/* Mobile and below: show mobile search bar only */
+/* Mobile and below: show mobile search bar only (unchanged behaviour) */
 @media #{$bp-below-tablet} {
   .search-bar-desktop { display: none; }
   .search-bar-mobile { display: flex; position: static; }
 }
 
-/* Desktop and up: show desktop search bar */
+/* Desktop and up: show desktop search bar; sticky below header */
 @media #{$bp-desktop-up} {
   .search-bar-mobile { display: none; }
   .search-bar-desktop {
@@ -61,8 +61,5 @@
     position: sticky;
     top: 61px; 
     z-index: 90; 
-  }
-  .search-bar-mobile {
-    display: none;
   }
 }

--- a/_sass/elements/_search-bar.scss
+++ b/_sass/elements/_search-bar.scss
@@ -14,7 +14,7 @@
   margin-bottom: 10px;
 }
 
-/* Override _forms.scss (was #search) */
+
 #search-desktop,
 #search-mobile {
   padding-right: 0px;
@@ -47,13 +47,13 @@
 
 
 
-/* Mobile and below: show mobile search bar only (unchanged behaviour) */
+/* Mobile and below: show mobile search bar only */
 @media #{$bp-below-tablet} {
   .search-bar-desktop { display: none; }
   .search-bar-mobile { display: flex; position: static; }
 }
 
-/* Desktop and up: show desktop search bar; sticky below header */
+/* Desktop and up: show desktop search bar */
 @media #{$bp-desktop-up} {
   .search-bar-mobile { display: none; }
   .search-bar-desktop {

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -101,11 +101,17 @@ document.addEventListener("DOMContentLoaded",function(){
         // Add onclick event handlers to close search tips modal if it is open.
         attachEventListenerCloseModal();
         
-        //events related to search bar
-        document.querySelector("#search").addEventListener("focus",searchOnFocusEventHandler);
-        document.querySelector("#search").addEventListener("keydown", searchEnterKeyHandler);
-        document.querySelector(".search-glass").addEventListener("click",searchEventHandler);
-        document.querySelector(".search-x").addEventListener("click",searchCloseEventHandler);
+        // events related to search bar (adjusted selectors only)
+        const inputEl = document.querySelector('#search-desktop') || document.querySelector('#search-mobile') || document.querySelector('#search');
+        const glassEl = document.querySelector('.search-bar-desktop .search-glass') || document.querySelector('.search-bar-mobile .search-glass') || document.querySelector('.search-glass');
+        const closeEl = document.querySelector('.search-bar-desktop .search-x') || document.querySelector('.search-bar-mobile .search-x') || document.querySelector('.search-x');
+
+        if (inputEl) {
+            inputEl.addEventListener('focus', searchOnFocusEventHandler);
+            inputEl.addEventListener('keydown', searchEnterKeyHandler);
+        }
+        if (glassEl) { glassEl.addEventListener('click', searchEventHandler); }
+        if (closeEl) { closeEl.addEventListener('click', searchCloseEventHandler); }
 
         // Update UI on page load based on url parameters
         updateUI()
@@ -338,7 +344,8 @@ function cancelMobileFiltersEventHandler(e) {
 //search bar event handler
 function searchEventHandler(e){
     e.preventDefault();
-    let searchTerm=document.querySelector("#search").value;
+    const input = document.querySelector('#search-desktop') || document.querySelector('#search-mobile') || document.querySelector('#search');
+    let searchTerm = input ? input.value : '';
     let tokenObj={};
     tokenObj['Search']=searchTerm;
      
@@ -362,12 +369,14 @@ function searchEnterKeyHandler(e){
 }
 
 function searchOnFocusEventHandler(){
-    document.querySelector(".search-x").style.display='block';
+    const xBtn = document.querySelector('.search-bar-desktop .search-x') || document.querySelector('.search-bar-mobile .search-x') || document.querySelector('.search-x');
+    if (xBtn) xBtn.style.display='block';
 }
 
 function searchCloseEventHandler(e){
     e.preventDefault();
-    document.querySelector("#search").value="";
+    const input = document.querySelector('#search-desktop') || document.querySelector('#search-mobile') || document.querySelector('#search');
+    if (input) input.value="";
 }
 
 /**

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -478,13 +478,24 @@ function updateCategoryCounter(filterParams){
           }
         }
 
-        for(const [key,value] of container){
-          // for issue #4648, added this to show the sum of selected filters for both technology and language filters
-          let totalValue = 0
-          for (const innerValue of container){
-            totalValue += innerValue[1]
-          }
-          document.querySelector(`#${key}`).innerHTML = ` (${totalValue})`;
+        // Calculate total selected filters across all categories (excluding Search)
+        let totalSelected = container.reduce((sum, [,val]) => sum + val, 0);
+
+        // Update each category counter – preserve existing behaviour of showing combined totals
+        for(const [key] of container){
+          document.querySelector(`#${key}`) && (document.querySelector(`#${key}`).innerHTML = ` (${totalSelected})`);
+        }
+
+        // Update the new overall filters counter in the title
+        const totalCounterSpan = document.querySelector('#counter_total');
+        if (totalCounterSpan){
+          totalCounterSpan.innerHTML = totalSelected>0 ? ` (${totalSelected})` : '';
+        }
+
+        // Show/hide Clear All link
+        const clearAllLink = document.getElementById('clear-all-filters');
+        if(clearAllLink){
+            clearAllLink.style.display = totalSelected>0 ? 'inline' : 'none';
         }
     
 }
@@ -621,13 +632,14 @@ function attachEventListenerToFilterTags(){
             button.addEventListener('click',filterTagOnClickEventHandler)
         })
 
-        // If there exist a filter-tag button on the page add a clear all button after the last filter tag button
-        if(!document.querySelector('.clear-filter-tags')){
-            document.querySelector('.filter-tag:last-of-type').insertAdjacentHTML('afterend',`<a class="clear-filter-tags" tabindex="0" aria-label="Clear All Filters" style="white-space: nowrap;">Clear All</a>`);
+        // No longer inserting bottom Clear All link; top link exists.
+    }
 
-            //Attach an event handler to the clear all button
-            document.querySelector('.clear-filter-tags').addEventListener('click',clearAllEventHandler);
-        }
+    // Attach event to top Clear All link once (after DOM ready)
+    const clearAllTop = document.getElementById('clear-all-filters');
+    if(clearAllTop && !clearAllTop.dataset.listenerAdded){
+        clearAllTop.addEventListener('click', function(e){ e.preventDefault(); clearAllEventHandler(); });
+        clearAllTop.dataset.listenerAdded = 'true';
     }
 }
 
@@ -647,12 +659,16 @@ function noUrlParameterUpdate(){
 
     // Clear all number of checkbox counters
     document.querySelectorAll('.number-of-checked-boxes').forEach(checkBoxCounter => {checkBoxCounter.innerHTML = ''} );
+    const totalCounterSpan = document.querySelector('#counter_total');
+    if (totalCounterSpan) { totalCounterSpan.innerHTML = ''; }
 
-    // Clear all filter tags
-    document.querySelectorAll('.filter-tag') && document.querySelectorAll('.filter-tag').forEach(filterTag => filterTag.remove() );
+    const clearAllLink = document.getElementById('clear-all-filters');
+    if(clearAllLink){ clearAllLink.style.display='none'; }
 
-    // Remove Clear All Button
-    document.querySelector('.clear-filter-tags') && document.querySelector('.clear-filter-tags').remove();
+    // Remove any legacy bottom Clear All links if present
+    document.querySelectorAll('.clear-filter-tags').forEach(el => {
+        if(el.id !== 'clear-all-filters') el.remove();
+    });
     return;
 }
 

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -498,13 +498,13 @@ function updateCategoryCounter(filterParams){
         // Update the new overall filters counter in the title
         const totalCounterSpan = document.querySelector('#counter_total');
         if (totalCounterSpan){
-          totalCounterSpan.innerHTML = totalSelected>0 ? ` (${totalSelected})` : '';
+          totalCounterSpan.innerHTML = totalSelected > 0 ? ` (${totalSelected})` : '';
         }
 
         // Show/hide Clear All link
         const clearAllLink = document.getElementById('clear-all-filters');
         if(clearAllLink){
-            clearAllLink.style.display = totalSelected>0 ? 'inline' : 'none';
+            clearAllLink.style.display = totalSelected > 0 ? 'inline' : 'none';
         }
     
 }


### PR DESCRIPTION
Fixes #7525

### What changes did you make?

- **Pinned Filter and Search Bars:** The filter and search input fields are now  pinned to the top of the screen  when scrolling, ensuring they're always accessible for quick adjustments.
- **Filter Counter and Clear All:** A new counter has been added to indicate the number of active filters, alongside a convenient "Clear All" option to quickly remove all applied filters.
- **Contextual Filter Pills:** Filter "pills" are now displayed only within the opened filter feature, reducing clutter and providing a cleaner interface when filters aren't actively being managed.

### Why did you make the changes?
  - To reduce clutter and provide a cleaner interface when filters aren't actively being managed.
  - Improve the usability of filter and have the opportunity to modify search when scrolling projects list. 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website:



<details>
<summary>Visuals before changes are applied</summary>

<img width="532" alt="Screenshot 2025-06-18 at 5 31 44 PM" src="https://github.com/user-attachments/assets/97b1eb2e-b29d-4569-ab84-bb29c0318306" />
<img width="526" alt="Screenshot 2025-06-18 at 5 32 16 PM" src="https://github.com/user-attachments/assets/66231ce5-b45e-42c7-849e-8ff3879c3739" />

<img width="532" alt="Screenshot 2025-06-18 at 5 31 03 PM" src="https://github.com/user-attachments/assets/bfbd7bbe-129c-421a-bcfe-a7d46b115f71" />
<img width="524" alt="Screenshot 2025-06-18 at 5 31 28 PM" src="https://github.com/user-attachments/assets/93d0cd72-bf99-4b60-9855-3983389f22df" />
<img width="529" alt="Screenshot 2025-06-18 at 5 32 37 PM" src="https://github.com/user-attachments/assets/9fe02323-fe57-434c-afbf-a8d87ac89115" />



</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="535" alt="Screenshot 2025-06-18 at 5 33 50 PM" src="https://github.com/user-attachments/assets/2c9a307b-6d06-438e-b8ac-73fb171a4ae7" />
<img width="533" alt="Screenshot 2025-06-18 at 5 34 28 PM" src="https://github.com/user-attachments/assets/85ef99a8-c424-49fe-9716-422abd2d175f" />
<img width="531" alt="Screenshot 2025-06-18 at 5 34 47 PM" src="https://github.com/user-attachments/assets/2d940f75-f0ed-4745-b8d7-396baaebf107" />

</details>
