### PR TITLE
Add GitHub handle for Will Gillis

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -62,7 +62,7 @@ leadership:
       github: https://github.com/priyanka02art
     picture: https://avatars.githubusercontent.com/priyanka02art
   - name: Will Gillis
-    github-handle: t-will-gillis
+    github-handle:
     role: Developer Co-Lead
     links:
       slack: 'https://hackforla.slack.com/team/U043LGHSZFT'

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -62,6 +62,7 @@ leadership:
       github: https://github.com/priyanka02art
     picture: https://avatars.githubusercontent.com/priyanka02art
   - name: Will Gillis
+    github-handle: t-will-gillis
     role: Developer Co-Lead
     links:
       slack: 'https://hackforla.slack.com/team/U043LGHSZFT'


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7380

### What changes did you make?
  - Added GitHub handle for Will Gillis in _projects/website.md

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - to create a single variable github-handle to hold the github handle for each member of the leadership team. Eventually github-handle will replace the github and picture variables, reducing redundancy in the project file.
<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
No visual changes to the website