### PR TITLE
Bug fix: "Schedule Monthly" workflow

### DIFF
--- a/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
+++ b/github-actions/trigger-schedule/list-inactive-members/trim-inactive-members.js
@@ -73,10 +73,10 @@ async function removeInactiveMembers(previousContributors, inactiveWithOpenSkill
   const removedMembers = [];
   const previouslyNotified = await readPreviousNotifyList();
   
-  // Loop over team members and remove them from the team if they   
-  // are not in either previousContributors or inactiveWithOpenIssue
+  // Loop over team members and remove them from the team if they are not on the previousContributors
+  // list (i.e. they are inactive) and they are also not on the inactiveWithOpenIssue list 
   for (const username in currentTeamMembers) {   
-    if ((!previousContributors[username]) || !(username in inactiveWithOpenIssue)) {
+    if ((!previousContributors[username]) && !(username in inactiveWithOpenIssue)) {
       // Prior to deletion, confirm that member is on the baseTeam
       await addTeamMember(github, context, baseTeam, username);
       // If member was not on the previouslyNotified list, do not remove yet


### PR DESCRIPTION



<!--  Important! Add the number of the issue you worked on  --> 
Fixes #8239 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - In the `removeInactiveMembers()` function of `trim-inactive-member.js`, change the previous 'or' condition to 'and'.

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - This section of the function indicates that the process should continue if the member is not on the previousContributors list (because they are inactive), AND the member also is not on the inactiveWithOpenIssue list.
  - The previous OR condition resulted in some members being removed who had activity.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [ ] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes
- [Test logs for OR](https://github.com/t-will-gillis/website/actions/runs/16014078908)
- [Test logs for AND](https://github.com/t-will-gillis/website/actions/runs/16014160533)