### PR TITLE
Bug fix for "Member Activity Trigger" using `pull_request_target`

### DIFF
--- a/.github/workflows/activity-trigger.yml
+++ b/.github/workflows/activity-trigger.yml
@@ -6,12 +6,18 @@ on:
     types: [opened, assigned, unassigned, closed, reopened]
   issue_comment: 
     types: [created]
-  pull_request:
+  pull_request_target:
     types: [opened, closed, reopened]
   pull_request_review:
     types: [submitted]
   pull_request_review_comment:
     types: [created]
+
+# Limits default token permissions
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   Gather-Activity-Event-Information:

--- a/github-actions/activity-trigger/post-to-skills-issue.js
+++ b/github-actions/activity-trigger/post-to-skills-issue.js
@@ -55,6 +55,7 @@ async function postToSkillsIssue({github, context}, activity) {
         commentData = await github.request('GET /repos/{owner}/{repo}/issues/{issue_number}/comments', {
             owner,
             repo,
+            per_page: 100,
             issue_number: skillsIssueNum,
         });
     } catch (err) {
@@ -108,7 +109,7 @@ async function postToSkillsIssue({github, context}, activity) {
             state: skillsIssueState,
         });
     } catch (err) {
-        console.error(`Failed to update issue #${skillsIssueNum} state:`, err)
+        console.error(`Failed to update issue #${skillsIssueNum} state:`, err);
     }
 }
 


### PR DESCRIPTION
Fixes #8309

### What changes did you make?
  - In `activity-trigger.yml`, changed trigger to `pull_request_target`
  - Same file, added default permissions
  - In `post-to-skills-issue.js`, increased the default `per_page` from 30 to 100 

### Why did you make the changes (we will use this info to test)?
  - `pull_request` trigger does not run against current code and causes an error
  - These permissions are explicitly defining the workflow permissions
  - Sometimes the bot comment will be greater than 30 deep. 100 is the maximum without going to pagination, but this should be adequate. 
  - Added the explicit semicolon for the dependabot.

Note that because this PR affects the workflow itself, the workflow will not be triggered.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes
