### PR TITLE
Remove Aditya Soni from Guides Team profile

### DIFF
--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -21,13 +21,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U05JS9NLNQJ'
       github: 'https://github.com/the-techgurl'
     picture: https://avatars.githubusercontent.com/the-techgurl
-  - name: Aditya Soni
-    github-handle: Aditya23soni
-    role: Product Manager
-    links:
-      slack: https://hackforla.slack.com/team/U07F766J29M
-      github: https://github.com/Aditya23soni
-    picture: https://avatars.githubusercontent.com/Aditya23soni
   - name: Jesus Diaz
     github-handle: JesseTheCleric
     role: Product Manager


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #8113

### What changes did you make?
- Edited _projects/guides-team.md
- Removed the leadership field about **Aditya Soni**

### Why did you make the changes (we will use this info to test)?
- Keep the Guides Team page accurate and up to date
- Verified locally via Docker that the profile no longer appears under **Current Project Team**

<h3>CodeQL Alerts</h3>

After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details>
<summary>Before changes are applied</summary>
<img width="824" height="374" alt="Screenshot before PR" src="https://github.com/user-attachments/assets/f29425c3-4869-4bbe-a269-e3a7d6bf75b6" />
</details>

<details>
<summary>After changes are applied</summary>
<img width="797" height="273" alt="Screenshot after PR" src="https://github.com/user-attachments/assets/276464f7-f4d6-4c21-8f5c-77b03995108d" />
</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)



