### PR TITLE
Add Citizen Engagement Example Page

### DIFF
--- a/_includes/program-area-pages-cards-example.html
+++ b/_includes/program-area-pages-cards-example.html
@@ -1,0 +1,52 @@
+<!-- These are the cards found on a program area page, such as the cards on https://www.hackforla.org/citizen-engagement webpage. -->
+
+{% assign visible_projects = site.projects | where: "program-area", "Citizen Engagement" | where: "visible", "true" %}
+             {% for item in visible_projects %}
+             {%- if
+                item.problem.size > 0 and
+                item.solution.size > 0 and
+                item.impact.size > 0 and
+                item.sdg.size > 0 and
+                item.sdg-image-src.size > 0
+                -%}
+                  <div class="page-card card-primary page-card-lg program-area" data-dropdown>
+                        <img class="card-image" src="{{ item.image }}" alt="">
+                           <div class="mobile-card-info-container">
+                               <div class="mobile-card-nav">
+                                {% assign project_relative_path = item.slug | prepend: "../projects/" %}
+                                <h3><a class="project-card-mini-title" href="{{ project_relative_path }}">{{ item.title }}</a></h3>
+                                   <input class="dropdown-arrow" data-dropdown-arrow type="image" src="/assets/images/citizen-engagement/arrow-button-icon.svg" alt="dropdown-arrow">
+                               </div>
+                               <div class="project-dropdown">
+                                    <div class="problem-info">
+                                        <h4>Problem</h4>
+                                        <p>{{ item.problem }}</p>
+                                    </div>
+                                    <div class="solution-info">
+                                        <h4>Solution</h4>
+                                        <p>{{ item.solution }}</p>
+                                    </div>
+                                    <div class="impact-info">
+                                        <h4>Impact</h4>
+                                        <p>{{ item.impact }}</p>
+                                    </div>
+                            </div>
+                        </div>
+                    <div class="sustainable-dev-goal">
+                        <h4>Sustainable Development Goal</h4>
+                        <div class="card-bottom-info">
+                            <img class="sdg-image" src="{{ item.sdg-image-src }}" alt="{{ item.sdg-image-alt }}">
+                                    <p>{{ item.sdg }}</p>
+                        </div>
+                    </div>
+                </div>
+                {%- else -%}
+                     <div class="page-card card-primary page-card-lg missing-area" data-dropdown>
+                        <div class="mobile-card-info-container">
+                            {% assign project_relative_path = item.slug | prepend: "../projects/" %}
+                            <h3><a class="project-card-mini-title" href="{{ project_relative_path }}">{{ item.title }}</a></h3>
+                            <p>We are currently drafting the Problem, Solution and Impact statements for this project.</p>
+                        </div>
+                   </div>
+                {%- endif -%}
+            {% endfor %}

--- a/pages/citizen-engagement-example.html
+++ b/pages/citizen-engagement-example.html
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Citizen Engagement
+permalink: /citizen-engagement-example
+---
+<!-- Header banner -->
+<div class="header-container flex-container program-header-container">
+    <div class="header-text">
+        <h1 class="title1">Citizen Engagement</h1>
+        <p>
+            We at Hack for LA are volunteers that believe in building technology
+            and analyzing data to make it easier to participate effectively in your community.
+        </p>
+        <p class="sub-p">
+            Below are our products that are making that happen.
+            If you have a new idea, want to submit feedback that will guide the next iteration
+            of an existing tool, or want to start working on a project team with us, please contact
+            us at <a href="mailto: citizenengagement@hackforla.org">citizenengagement@hackforla.org.</a>
+        </p>
+        <p class="bottom-header-paragraph">
+            Read more about <a href="https://sdg.lamayor.org/about/global-goals">LA’s Sustainable Development Goals</a>.
+        </p>
+    </div>
+    <img class="header-hero-image" src="/assets/images/citizen-engagement/citizen-engagement-header.svg"
+        alt="">
+</div>
+<!-- Header banner -->
+
+<!-- Page body -->
+<section class="content-section project-wrapper">
+    <div class="page-contain projects program-area-container">
+        <h2>Current Projects</h2>
+        <!-- Card -->
+        <!-- Cards have been standardized and can be found in _sass/elements/_cards-->
+        <!-- These cards utilize the previous standardized elements, plus new elements that I have integrated. -->
+        <!-- Specifically I have added data attributes to the page-card container, and the dropdown arrow.
+             We use the data attributes in JS to expand and close the cards. -->
+
+            {% include program-area-pages-cards-example.html %}
+
+            <div class="page-card card-primary page-card-lg organizations">
+                <div class="organizations-info">
+                    <h3>Organizations We Work With</h3>
+                    <p>None of what we do would be possible without the generous
+                        support of many organizations throughout our communities.
+                        A big thank you to:</p>
+                </div>
+                <div class="organizations-images">
+                    {% assign partners = site.data.internal.partners %}
+                    {% for partner in partners %}
+                      {% if partner.program-area contains "Citizen Engagement" %}
+                        <img class="org-img org-img-large" src="{{ partner.image }}" alt="{{ partner.name }}">
+                      {% endif %}
+                    {% endfor %}
+                </div>
+        </div>
+    </div>
+    <!-- Card -->
+</section>
+
+<!-- Include javaScript -->
+<script src="{{ '/assets/js/citizen-engagement.js' | absolute_url }}"></script>


### PR DESCRIPTION
Fixes #8202 

### What changes did you make?
  - Add copy of `program-area-pages-cards.html` called `program-area-pages-cards-example.html` in `_includes` directory.
  - Add copy of `citizen-engagement.html` called `citizen-engagement-example.html` in `pages` directory.
  - Change `citizen-engagement-example.html` to include newly copied `program-area-pages-cards-example.html` content.

### Why did you make the changes (we will use this info to test)?
  - We want to create an example of `citizen-engagement.html` so that Quality Assurance (QA) can reference the original example page when making changes to the citizen engagement page.


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/b41bf85c-83d6-4528-a12c-a0df563c1c68)
- Accessing `localhost:4000/citizen-engagement-example` before changes.
</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/63ff0d97-8907-4c5d-a485-4aae17faa887)
- Accessing `localhost:4000/citizen-engagement-example` after changes.

</details>
