### PR TITLE
Remove Language and Tools from Homepage Project Filters

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -43,7 +43,7 @@ document.addEventListener("DOMContentLoaded",function(){
             // for issue #4648, needed to add languages inside the technologies filter-item group,  might be able to optimize for future iterations
 
             // This ensures that the /projects-check page does not change
-            if ((filterName === 'languages' || filterName === 'tools') && window.location.pathname === '/projects/' || window.location.pathname === "/") {
+            if ((filterName === 'languages' || filterName === 'tools') && (window.location.pathname === '/projects/' || window.location.pathname === "/")) {
               // remove the view all button
               document.querySelector(`#technologies`).lastElementChild.remove()
               // insert data inside at the end of the category

--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -43,7 +43,7 @@ document.addEventListener("DOMContentLoaded",function(){
             // for issue #4648, needed to add languages inside the technologies filter-item group,  might be able to optimize for future iterations
 
             // This ensures that the /projects-check page does not change
-            if ((filterName === 'languages' || filterName === 'tools') && window.location.pathname === '/projects/') {
+            if ((filterName === 'languages' || filterName === 'tools') && window.location.pathname === '/projects/' || window.location.pathname === "/") {
               // remove the view all button
               document.querySelector(`#technologies`).lastElementChild.remove()
               // insert data inside at the end of the category


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #8352 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - removed "Languages" and "Tools" filters on Homepage, by transferring the items in "Languages" and "Tools" to "Languages/Technologies/Tools"

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To simplify the project filters layout by removing/combining filters
  - Match layout of Homepage filters with Project page

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

<img width="1440" height="718" alt="Screenshot 2025-10-11 at 12 22 45 PM" src="https://github.com/user-attachments/assets/84de9668-693b-47e2-8ce5-6b3e6ab20360" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1440" height="715" alt="Screenshot 2025-10-11 at 12 23 03 PM" src="https://github.com/user-attachments/assets/ea2c8105-75fe-487b-ac7c-318428544c9a" />


</details>
