### PR TITLE
Update Project Profile Leader issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-profile-leader-updates---add.md
+++ b/.github/ISSUE_TEMPLATE/project-profile-leader-updates---add.md
@@ -18,7 +18,8 @@ We need to keep project information up to date so that visitors to the website c
 ### Action Items
 - [ ] In your IDE, open the `_projects/[Insert filename].md` file.
 - [ ] Observe the existing syntax of the front matter block [^1] in the file.
-- [ ] Find the `leadership` variable and add the following profile. 
+- [ ] Find the `leadership` variable and add the following profile after other member(s) with the same role. 
+- The typical order of roles should be:  'role: Owner'  --> 'role: Manager' --> 'role: Lead' --> 'role: Merge Team' --> 'role: Researcher/Designer/Developer/Engineer'  
 ```
   - name: [Insert leadership member's name]
     github-handle: [Insert GitHub handle]
@@ -28,7 +29,7 @@ We need to keep project information up to date so that visitors to the website c
       github: https://github.com/[Insert GitHub handle]
     picture: https://avatars.githubusercontent.com/[Insert GitHub handle]
 ```
-- [ ] Verify the changes by viewing the following in your local environment and include before and after screenshots with your pull request:
+- [ ] Verify the changes by viewing the following in your local environment with Docker, and include 'before' and 'after' screenshots with your pull request:
   - [ ] [Insert name of project] page [^2]
 
 ### Resources/Instructions

--- a/.github/ISSUE_TEMPLATE/project-profile-leader-updates---add.md
+++ b/.github/ISSUE_TEMPLATE/project-profile-leader-updates---add.md
@@ -18,8 +18,7 @@ We need to keep project information up to date so that visitors to the website c
 ### Action Items
 - [ ] In your IDE, open the `_projects/[Insert filename].md` file.
 - [ ] Observe the existing syntax of the front matter block [^1] in the file.
-- [ ] Find the `leadership` variable and add the following profile after other member(s) with the same role. 
-- The typical order of roles should be:  'role: Owner'  --> 'role: Manager' --> 'role: Lead' --> 'role: Merge Team' --> 'role: Researcher/Designer/Developer/Engineer'  
+- [ ] Find the `leadership` variable and add the following profile after other member(s) with the same role.[^2]   
 ```
   - name: [Insert leadership member's name]
     github-handle: [Insert GitHub handle]
@@ -30,8 +29,9 @@ We need to keep project information up to date so that visitors to the website c
     picture: https://avatars.githubusercontent.com/[Insert GitHub handle]
 ```
 - [ ] Verify the changes by viewing the following in your local environment with Docker, and include 'before' and 'after' screenshots with your pull request:
-  - [ ] [Insert name of project] page [^2]
+  - [ ] [Insert name of project] page [^3]
 
 ### Resources/Instructions
 [^1]: [Info about the front matter block](https://jekyllrb.com/docs/front-matter/)
-[^2]: Project detailed info page URL: [Insert project specific page URL here]
+[^2]: Note: The typical order of roles should be:  'role: Owner'  --> 'role: Manager' --> 'role: Lead' --> 'role: Merge Team' --> 'role: Researcher/Designer/Developer/Engineer'. If the intended order is not clear, ask the person who submitted the original request.
+[^3]: Project detailed info page URL: [Insert project specific page URL here]

--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -21,13 +21,6 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U05JS9NLNQJ'
       github: 'https://github.com/the-techgurl'
     picture: https://avatars.githubusercontent.com/the-techgurl
-  - name: Aditya Soni
-    github-handle: Aditya23soni
-    role: Product Manager
-    links:
-      slack: https://hackforla.slack.com/team/U07F766J29M
-      github: https://github.com/Aditya23soni
-    picture: https://avatars.githubusercontent.com/Aditya23soni
   - name: Jesus Diaz
     github-handle: JesseTheCleric
     role: Product Manager

--- a/_projects/guides-team.md
+++ b/_projects/guides-team.md
@@ -21,6 +21,13 @@ leadership:
       slack: 'https://hackforla.slack.com/team/U05JS9NLNQJ'
       github: 'https://github.com/the-techgurl'
     picture: https://avatars.githubusercontent.com/the-techgurl
+  - name: Aditya Soni
+    github-handle: Aditya23soni
+    role: Product Manager
+    links:
+      slack: https://hackforla.slack.com/team/U07F766J29M
+      github: https://github.com/Aditya23soni
+    picture: https://avatars.githubusercontent.com/Aditya23soni
   - name: Jesus Diaz
     github-handle: JesseTheCleric
     role: Product Manager


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #8314

### What changes did you make?
- Clarified the typical order of roles in the leadership list
- Improved instructions for verifying changes locally
- Added project page reference as [^3] and adjusted references

### Why did you make the changes (we will use this info to test)?
- To make the template clearer and easier for contributors to follow
- To ensure consistency when adding/updating leadership members

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

- No visual changes to the website

</details>
