### PR TITLE
Update Wins overlay to use different SVG

### DIFF
--- a/_includes/wins-page/wins-overlay.html
+++ b/_includes/wins-page/wins-overlay.html
@@ -9,7 +9,14 @@
           <div class="wins-card-top-right">
             <div class="wins-card-title project-card-inner">
               <span id="overlay-name" class="wins-card-name">Blank</span>
-              <span id="overlay-icons" class="wins-card-icons" alt=""></span>
+              <span id="overlay-icons" class="wins-card-icons" alt="">
+                <a target="_blank" class="wins-card-linkedin-icon"></a>
+                <a target="_blank" class="wins-card-github-icon" style="color:black">
+                  <div role="img" class="github-icon">
+                    {% include svg/icon-github.svg %}
+                  </div>
+                </a>
+              </span>
             </div>
             <div id="overlay-teams" class="project-inner wins-card-team">Team(s): Blank</div>
             <div id="overlay-roles" class="project-inner wins-card-team">Role(s): Blank</div>

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -442,8 +442,16 @@
 			}
 		}
 	}
-
-
+    #overlay-icons {
+        .linkedin-icon, .github-icon {
+            height: 32px;
+            width: 32px;
+        }
+        .linkedin-icon > svg, .github-icon > svg {
+            height: 100%;
+            width: 100%;
+        }
+    }
 }
 
 //mobile see more

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -498,14 +498,31 @@ function changeSeeMoreBtn(x) {
 	  	const bigQuoteImg = document.querySelector('.wins-card-big-quote');
 	  	bigQuoteImg.alt = "Quote from " + data[i][name];
 
-  		const overlayIcons = document.querySelector('#overlay-icons');
-  		overlayIcons.textContent = "";
+			const overlayIcons = document.querySelector('#overlay-icons');
+      overlayIcons.querySelector('.wins-card-linkedin-icon').textContent = '';
 
-  		if (data[i][linkedin_url].length > 0) {
-  			makeIcon(data[i][linkedin_url], overlayIcons, 'linkedin-icon', '/assets/images/wins-page/icon-linkedin-small.svg', 'LinkedIn profile for ' + data[i][name]);
-  		} if (data[i][github_url].length > 0) {
-  			makeIcon(data[i][github_url], overlayIcons, 'github-icon', '/assets/images/wins-page/icon-github-small.svg', 'GitHub profile for ' + data[i][name]);
-  		}
+      if (data[i][linkedin_url].length > 0) {
+        makeIcon(
+          data[i][linkedin_url],
+          overlayIcons.querySelector('.wins-card-linkedin-icon'),
+          'linkedin-icon',
+          '/assets/images/wins-page/icon-linkedin-small.svg',
+          'LinkedIn profile for ' + data[i][name]
+        );
+      }
+
+			const winsCardGithubIcon = overlayIcons.querySelector('.wins-card-github-icon');
+
+      if (data[i][github_url].length > 0) {
+        winsCardGithubIcon.href = data[i][github_url];
+        winsCardGithubIcon.removeAttribute('hidden');
+        winsCardGithubIcon.querySelector('div.github-icon').setAttribute(
+          'aria-label',
+          'GitHub profile for ' + data[i][name]
+        );
+      } else {
+        winsCardGithubIcon.setAttribute('hidden', 'true');
+      }
 
   		const overlayName = document.querySelector('#overlay-name');
 		overlayName.textContent = data[i][name];


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7937

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Added GitHub icon and empty LinkedIn link to the wins overlay HTML.
  - Updated the `updateOverlay` function in `wins.js` to attach `href` and `aria-label` attributes to and hide/show the GitHub icons, as well as have the code for the LinkedIn icon utilize the new anchor element in the HTML.
  - Explicitly set the GitHub and LinkedIn icon sizes in the wins page SCSS.

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Since the icons are now being used from `_includes\svg\`, the JavaScript code in `assets/js/wins.js` could not access the `_includes` folder.  The workaround is to use the `include` tag from Jekyll in the HTML.
  - The `aria-label` needed to be added to the GitHub icon to make it WCAG compliant.
  - The icon sizes needed to be set in the CSS, as the former sizes no longer applied.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

- No visual changes to the website, but verify this.
