### PR TITLE
Updated wins.js so Wins page uses icon-github.svg

### DIFF
--- a/_includes/wins-page/wins-card-template.html
+++ b/_includes/wins-page/wins-card-template.html
@@ -7,7 +7,11 @@
           <span class="wins-card-name"> </span>
           <span class="wins-card-icons">
             <a target="_blank" class="wins-card-linkedin-icon"><img class="linkedin-icon" alt="" /></a>
-            <a target="_blank" class="wins-card-github-icon"><img class="github-icon" alt="" /></a>
+            <a target="_blank" class="wins-card-github-icon" style="color:black">
+              <div role="img" class="github-icon">
+                {% include svg/icon-github.svg %}
+              </div>
+            </a>
           </span>
         </div>
         <div class="project-inner wins-card-team"></div>

--- a/_sass/components/_wins-page.scss
+++ b/_sass/components/_wins-page.scss
@@ -280,6 +280,17 @@
     display: flex;
 }
 
+.github-icon{
+    width: 32px;
+    height: 32px;
+    max-width: 100%;
+}
+
+.github-icon svg{
+    width: 100%;
+    height: 100%;
+}
+
 @media #{$bp-below-desktop} {
     .wins-card {
         position: relative;

--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -290,7 +290,6 @@
 	const cardTemplate = document.getElementById("wins-card-template");
 	const QUOTE_ICON_PATH = '/assets/images/wins-page/quote-icon.svg'
 	const AVATAR_DEFAULT_PATH = "/assets/images/wins-page/avatar-default.svg"
-	const GITHUB_ICON = '/assets/images/wins-page/icon-github-small.svg';
 	const LINKEDIN_ICON = '/assets/images/wins-page/icon-linkedin-small.svg'
 	const winsCardContainer  = document.querySelector('#responses');
 
@@ -330,8 +329,7 @@
 
 		if (card[github_url].length > 0){
 			cloneCardTemplate.querySelector('.wins-card-github-icon').href = card[github_url];
-			cloneCardTemplate.querySelector('.github-icon').src = GITHUB_ICON ;
-			cloneCardTemplate.querySelector('.github-icon').alt = `GitHub profile for ${card[name]}`;
+			cloneCardTemplate.querySelector('.github-icon').setAttribute('aria-label' ,`GitHub profile for ${card[name]}`);
 		} else {
 			cloneCardTemplate.querySelector('.wins-card-github-icon').setAttribute('hidden', 'true')
 		}


### PR DESCRIPTION
Fixes #6911 

### What changes did you make?
  - Within HTML template `_includes/wins-page/wins-card-template.html/wins-card-template.html`, replaced current reference to `github-icon` using the `img` element, with new inline expression rendering `github-icon` within a `div` element. 
  Specifically replaced: 
  ```<a target="_blank" class="wins-card-github-icon"><img class="github-icon" alt="" /></a>```
  with:
  ```
  <a target="_blank" class="wins-card-github-icon" style = "color:black">
    <div role = "img" class = "github-icon">
        {% include svg/icon-github.svg %}  
    </div>
</a>
  ```
  - Within the `makeCards` function in `assets/js/wins.js`, removed the `img` element source definition since we replaced the `img` element.
  ```
~~cloneCardTemplate.querySelector('.github-icon').src = GITHUB_ICON ;~~
  ```
  - Removed the definition of the constant variable `GITHUB_ICON` which set the path to the svg used to define the source for the previously used img element.
  ```
~~const GITHUB_ICON = '/assets/images/wins-page/icon-github-small.svg';~~
  ```
  - Made SVG WCAG compliant. Added `aria-label` attribute and definition to the `github-icon`'s svg div. Used the previous definition of the `alt` attribute of the `img` element for the `aria-label` of the `github-icon` svg `div`. 
  ```
cloneCardTemplate.querySelector('.github-icon').setAttribute('aria-label' ,`GitHub profile for ${card[name]}`);
  ```
  - Updated `_sass/components/_wins-page.scss` to ensure the styling of the GitHub icon remained unchanged after replacing the source. Set the github-icon element in `_wins-page.scss` `height` and `width` to 32px. Also set the`max-width` to 100% to mimic the behavior of the LinkedIn icon. Set the SVG `width` and `height` properties nested within the `github-icon` element `div`to 100% so they would adhere to the sizing of the parent element. In this case the `github-icon` `div` is the parent element. Therefore the SVG should render to be 32x32 px. 
  ```
  .github-icon{
    width: 32px;
    height: 32px;
    max-width: 100%;
}

.github-icon svg{
    width: 100%;
    height: 100%;
}
  ```

### Why did you make the changes (we will use this info to test)?
  - To reduce the number of duplicate images in the codebase.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes to the website
