### PR TITLE
Add `hfla-workflow-rollout[bot]` to accepted PR authors

### DIFF
--- a/github-actions/trigger-pr-target/verify-pr.js
+++ b/github-actions/trigger-pr-target/verify-pr.js
@@ -10,7 +10,7 @@ async function main({github,context}) {
     const repo = context.payload.pull_request.base.repo.name;
     const owner = context.payload.pull_request.base.repo.owner.login;
     const isMember = await isMemberOfTeam(github, context, prAuthor, 'website-write');
-    if (isMember || prAuthor =='dependabot[bot]') {    
+    if (isMember || ['dependabot[bot]', 'hfla-workflow-rollout[bot]'].includes(prAuthor)) {    
         console.log('Successfully verified!');
     }
     else {


### PR DESCRIPTION

Fixes #8394 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Add `hfla-workflow-rollout[bot]` to list of accepted PR authors


### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - The "PR verification" workflow is blocking the testing for Automate-The-ORG's auto PR 


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes
