### PR TITLE
Changed `Github` and `github` to `GitHub` within `/_data/internal/toolkitresources.yml`

### DIFF
--- a/_data/internal/toolkitresources.yml
+++ b/_data/internal/toolkitresources.yml
@@ -10,8 +10,8 @@
   svg: svg/icon-figma.svg
   resource-url: 'https://www.figma.com/'
 
-- title: Github
-  description: We use github for our project management and to streamline development.
+- title: GitHub
+  description: We use GitHub for our project management and to streamline development.
   card-type: 
   display: true
   practice-area: Development


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #8390 

### What changes did you make?  
  - I replaced the instance of `Github` and `github` to `GitHub` within the `GitHub` property of `toolkitresources.yml`.

### Why did you make the changes (we will use this info to test)?
  - To ensure we consistently display the name of the company GitHub correctly. 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging
</details>

### Connected Files:
[_includes/current-guides.html](https://github.com/hackforla/website/blob/dac386a9942d40421442b64b55fb45377e51714a/_includes/current-guides.html#L66): The `current-guides.html` file is included within the `/toolkit` page in the HFLA website. The `toolkitresources.yml` file is the data the `current-guides.html` file uses to populate the External Resources section of the `/toolkit` page. The changes made for this issue are reflected in the GitHub card within the External Resources section at the bottom of the `/toolkit` page.

[.github/ISSUE_TEMPLATE/suggest-an-external-resource.md](https://github.com/hackforla/website/blob/dac386a9942d40421442b64b55fb45377e51714a/.github/ISSUE_TEMPLATE/suggest-an-external-resource.md?plain=1#L27): The purpose of this markdown file is to serve as a template for suggesting a new external resource to add to the `/toolkit` page. Changes requested by this issue are not reflected in this markdown file. 

### Test Procedure:
1. Create local feature branch and download the changes from GitHub
2. Run the Docker container to run the HackForLA website locally and navigate to [http://localhost:4000/toolkit/](http://localhost:4000/toolkit/)
3. Open to the live HackForLA website toolkit page [https://www.hackforla.org/toolkit/](https://www.hackforla.org/toolkit/)
4. Scroll down to the External Resources section and observe the change between the GitHub cards text for `GitHub` between the feature branch and the live website.

### Link to Test Procedure in Issue #8390  Comment
[https://github.com/hackforla/website/issues/8390#issuecomment-3531120947](https://github.com/hackforla/website/issues/8390#issuecomment-3531120947)

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/0f8234b8-33a3-4557-a73c-cace70ece1f3)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/233cc96e-57b2-441e-9e9e-93c24a08d4de)

</details>
