### PR TITLE
Update Github handle for Santiago Vidal

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -91,12 +91,12 @@ leadership:
       github: 'https://github.com/mugdhchauhan'
     picture: https://avatars.githubusercontent.com/mugdhchauhan
   - name: Santiago Vidal
-    github-handle: santisecco
+    github-handle: santiseccovidal
     role: Merge Team
     links:
       slack: https://hackforla.slack.com/team/U06MQ37T90E
-      github: https://github.com/santisecco
-    picture: https://avatars.githubusercontent.com/santisecco
+      github: https://github.com/santiseccovidal
+    picture: https://avatars.githubusercontent.com/santiseccovidal
 links:
   - name: Wiki
     url: 'https://github.com/hackforla/website/wiki'


### PR DESCRIPTION
Fixes #8423 

### What changes did you make?
  - Updated Github Handle from 'santisecco' to 'santiseccovidal'
  - Updated profile picture link
  - Verified YAML formatting

### Why did you make the changes (we will use this info to test)?
  - The contributor's Github handle had changed, so the previous link was no longer correct.
  - Updating the handle and profile picture ensures the website displays accurate and up-to-date contributor information.
  
<h3>CodeQL Alerts</h3>
 
Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x ] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

### Screenshots of Proposed Changes To The Website: 
**Before**

<img width="515" height="149" alt="Screenshot 2025-12-12 183205" src="https://github.com/user-attachments/assets/954f6ec5-5276-4d93-8a9d-45b6cd45d0a6" />

**After**
<img width="557" height="184" alt="image" src="https://github.com/user-attachments/assets/b81ee555-9a78-4da5-b1e0-5ecc79dd4820" />