### PR TITLE
Added Phalguni Kambhalur to the HFLA Site Current Project Team

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -62,6 +62,13 @@ leadership:
       slack: https://hackforla.slack.com/team/U07TRV9HRFS
       github: https://github.com/priyanka02art
     picture: https://avatars.githubusercontent.com/priyanka02art
+  - name: Phalguni Kambhalur
+    github-handle: kphalguni
+    role: Product Manager
+    links:
+      slack: https://hackforla.slack.com/team/U07USBKRTFX
+      github: https://github.com/kphalguni
+    picture: https://avatars.githubusercontent.com/kphalguni
   - name: Will Gillis
     github-handle:
     role: Developer Co-Lead


### PR DESCRIPTION
Fixes #8347

### What changes did you make?
  - Added Phalguni Kambhalur to the HFLA Site Current Project Team

### Why did you make the changes (we will use this info to test)?
  - We need to keep project information up to date so that visitors to the website can find accurate information.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="755" height="812" alt="Screenshot 2026-01-13 at 6 44 37 PM" src="https://github.com/user-attachments/assets/144335c0-b021-4ee4-a964-6c884140debb" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="771" height="812" alt="Screenshot 2026-01-13 at 6 46 19 PM" src="https://github.com/user-attachments/assets/d0cc177e-aae9-4412-bb0c-2beaa67935a4" />


</details>
