### PR TITLE
Changed status to on hold and removed current team members

### DIFF
--- a/_projects/brigade-organizers-playbook.md
+++ b/_projects/brigade-organizers-playbook.md
@@ -8,41 +8,6 @@ image-hero: /assets/images/projects/brigade-organizers-playbook-hero.png
 program-area: 
   - Civic Tech Infrastructure
 leadership:
-  - name: Bonnie Wolfe
-    github-handle:
-    role: BOP Project Lead
-    links:
-      slack: 'https://hackforla.slack.com/archives/C01Q24YF56J'
-      github: 'https://github.com/experimentsinhonesty'
-    picture: https://avatars.githubusercontent.com/experimentsinhonesty
-  - name: Aleiya Gafar
-    github-handle:
-    role: Product Manager
-    links:
-      slack: 'https://hackforla.slack.com/team/U01K7QMQ4TC'
-      github: 'https://github.com/ag2463'
-    picture: https://avatars.githubusercontent.com/ag2463
-  - name: Evan Stalker
-    github-handle:
-    role: Lead Designer
-    links:
-      slack: 'https://hackforla.slack.com/team/U04M979AY3G'
-      github: 'https://github.com/ejstalker'
-    picture: https://avatars.githubusercontent.com/ejstalker
-  - name: Liz Brown
-    github-handle:
-    role: UX Designer
-    links:
-      slack: 'https://hackforla.slack.com/team/U052DR4HVJS'
-      github: 'https://github.com/ermbrown'
-    picture: https://avatars.githubusercontent.com/ermbrown
-  - name: Katrina Bonoan
-    github-handle: 
-    role: UX Designer
-    links:
-      slack: 'https://hackforla.slack.com/team/U052LER0010'
-      github: 'https://github.com/kit-katrina20'
-    picture: https://avatars.githubusercontent.com/kit-katrina20
 links:
   - name: GitHub
     url: 'https://github.com/hackforla/BOP'
@@ -66,5 +31,5 @@ location:
 
 partner: Code for Boston, Code for Charlottesville
 visible: true
-status: Active
+status: On Hold
 ---


### PR DESCRIPTION
Fixes #8469 

### What changes did you make?
  - Changed status of BOP project to 'On Hold'
  - Removed current leadership from project

### Why did you make the changes (we will use this info to test)?
  - This project is currently on hold and leaving it in active status can cause people to think they can currently join.
  - Team members were removed since the project was is on hold and no one is actively working on it.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

<img width="193" height="334" alt="Screenshot 2026-01-30 at 3 47 11 PM" src="https://github.com/user-attachments/assets/a8eecb9d-ffd8-45a0-84b3-2e92674707e6" />

<img width="443" height="208" alt="Screenshot 2026-01-30 at 3 48 05 PM" src="https://github.com/user-attachments/assets/2c082570-b8d7-4551-9855-c427ad39db18" />

<img width="441" height="232" alt="Screenshot 2026-01-30 at 3 48 14 PM" src="https://github.com/user-attachments/assets/fa04bc2d-3dd4-44e4-a7eb-579c88a5a60b" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="193" height="334" alt="Screenshot 2026-01-30 at 3 56 18 PM" src="https://github.com/user-attachments/assets/25e614b5-3270-4368-8531-4110d01e9ab7" />

<img width="443" height="208" alt="Screenshot 2026-01-30 at 3 50 29 PM" src="https://github.com/user-attachments/assets/0e2e26e5-0856-413d-a86f-191240095c8f" />

<img width="441" height="232" alt="Screenshot 2026-01-30 at 3 50 21 PM" src="https://github.com/user-attachments/assets/e9002f29-cd98-496c-a077-595275c19996" />

</details>
