### PR TITLE
Include PM Team in membership check

### DIFF
--- a/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
@@ -115,12 +115,13 @@ async function memberOfAdminOrMergeTeam() {
   try {
     // Get all members in Admin Team
     const websiteAdminsMembers = await getTeamMembers(github, context, "website-admins");
-  
+    // Get all members in PM Team
+    const websitePmMembers = await getTeamMembers(github, context, "website-pm")
     // Get all members in Merge Team
     const websiteMergeMembers = await getTeamMembers(github, context, "website-merge");
   
     // Return true if developer is a member of the Admin or Merge Teams
-    return(assignee in websiteAdminsMembers || assignee in websiteMergeMembers);
+    return(assignee in websiteAdminsMembers || assignee in websitePmMembers || assignee in websiteMergeMembers);
   } catch(error) {
     throw new Error("Error getting membership status: " + error);
   }


### PR DESCRIPTION

Fixes #8515 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Added `website-pm` to `memberOfAdminOrMergeTeam` in `github-actions/trigger-issue/add-preliminary-update/preliminary-update-comment.js`


### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Website PMs should be automatically excluded from the complexity eligibility checks

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- no visual change
