### PR TITLE
Updated CONTRIBUTING.md sections 2.7.d and 2.7.e

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -688,7 +688,7 @@ git push --set-upstream origin update-give-link-2093
 
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 
-#### **2.7.e Working on an issue (5):Alternative methods for incorporating changes from upstream**
+#### **2.7.e Working on an issue (5): Alternative methods for incorporating changes from upstream**
 
 This section shows you alternative methods to sync your fork with the main Hack for LA website repository. The recommended method for syncing your fork is through the GitHub browser as detailed in section [2.7.d](https://github.com/hackforla/website/blob/gh-pages/CONTRIBUTING.md#27d-working-on-an-issue-4-pulling-from-upstream-before-you-push)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -672,8 +672,13 @@ git pull upstream gh-pages
 
 ##### **i. If there are no changes in the upstream repository**
 
-If you do not see any output, there have not been any changes in the main Hack for LA website repository since the last time you
-checked. So it is safe to push your local commits to your fork.
+If you pulled the upstream repository and there have not been any changes in the main Hack for LA website repository since you last pulled, you may get an output like this: 
+```bash
+ * branch              gh-pages   -> FETCH_HEAD
+Already up to date.
+```
+This means it is safe to push your local commits to your fork.
+**Note**: Depending on your git settings, you may need to write a commit message to merge the changes that were pulled into your local branch.
 
 If you just type `git push` you will be prompted to create a new branch in your GitHub repository. The more complete command below will create a new branch on your copy of the website repository, and then push your local branch there. The name at the end of this command should be the same as the name of the local branch that you created back in step 3, as in the example below:
 
@@ -681,31 +686,11 @@ If you just type `git push` you will be prompted to create a new branch in your 
 git push --set-upstream origin update-give-link-2093
 ```
 
-##### **ii. If there are conflicting changes in the upstream repository**
-
-When you check the upstream repository, you may see output like this:
-
-```bash
-Fetching upstream
-remote: Enumerating objects: 11, done.
-remote: Counting objects: 100% (11/11), done.
-remote: Compressing objects: 100% (7/7), done.
-remote: Total 11 (delta 5), reused 7 (delta 4), pack-reused 0
-Unpacking objects: 100% (11/11), 8.25 KiB | 402.00 KiB/s, done.
-From https://github.com/hackforla/website
-+ 770d667...14f9f46 Bonnie     -> hackforla/Bonnie  (forced update)
-* [new branch]      bonnie     -> hackforla/bonnie
-5773ebe..0c86ecd  gh-pages   -> hackforla/gh-pages
-```
-
-
-**Note:** You can safely ignore changes in other issue branches, such as `bonnie` above. But if you see changes in gh-pages, as in `5773ebe..0c86ecd  gh-pages   -> hackforla/gh-pages`, you should incorporate those changes into your repository before merging or rebasing your issue branch. Use the [instructions below](#27e-working-on-an-issue-5-incorporating-changes-from-upstream) to bring your fork up to date with the main repository.
-
 <sub>[Back to Table of Contents](#table-of-contents)</sub>
 
-#### **2.7.e Working on an issue (5): Incorporating changes from upstream**
+#### **2.7.e Working on an issue (5):Alternative methods for incorporating changes from upstream**
 
-Your fork of this repository on GitHub, and your local clone of that fork, will get out of sync with this (upstream) repository from time to time. (That's what has happened when you see something like "This branch is 1 commit behind hackforla:gh-pages" on the GitHub website version of your hackforla repository.)
+This section shows you alternative methods to sync your fork with the main Hack for LA website repository. The recommended method for syncing your fork is through the GitHub browser as detailed in section [2.7.d](https://github.com/hackforla/website/blob/gh-pages/CONTRIBUTING.md#27d-working-on-an-issue-4-pulling-from-upstream-before-you-push)
 
 One way to keep your fork up to date with this repository is to follow these instruction: [Syncing your fork to the original repository via the browser](https://github.com/KirstieJane/STEMMRoleModels/wiki/Syncing-your-fork-to-the-original-repository-via-the-browser)
 
@@ -754,6 +739,8 @@ If you go to your online GitHub repository this should remove the message "This 
 ##### **i. Incorporating changes into your topic branch**
 
 To incorporate these updates from the main GitHub repository into your topic branch, you can 'rebase' your branch onto your updated gh-pages branch. NOTE you should only rebase if you have never pushed your topic branch to GitHub (or shared it with another collaborator).
+
+We prefer `rebase` because it keeps the commit history clean and linear. If rebasing fails or becomes complex, use `merge`, which preserves branch history but may add additional merge commits.
 
 ```bash
 git checkout update-give-link-2093


### PR DESCRIPTION
Fixes #8479 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Added more detail to 2.7.d.i
  - Deleted 2.7.d.ii
  - Renamed 2.7.e title
  - Replaced first paragraph in 2.7.e
  - Added clarifying paragraph in 2.7.e.i

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Changes overall were made to reduce redundancy in 2.7.d and 2.7.e
  - Changes where content was added was done so to add clarity 
  - For Reviewers: Do not review changes locally, rather, review changes at https://github.com/cadenramey/website/blob/update-contributing-8479/CONTRIBUTING.md

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

https://github.com/hackforla/website/blob/d952b81034634a0e2ad55eb380d45458d782203a/CONTRIBUTING.md

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
https://github.com/cadenramey/website/blob/update-contributing-8479/CONTRIBUTING.md

</details>
