### PR TITLE
Added Kerstin Carson to website project pg

### DIFF
--- a/_projects/website.md
+++ b/_projects/website.md
@@ -118,6 +118,13 @@ leadership:
       slack: https://hackforla.slack.com/team/U08SCL4KK3N
       github: https://github.com/ryanfkeller
     picture: https://avatars.githubusercontent.com/ryanfkeller
+  - name: Kerstin Carson
+    github-handle: kdaca19xx
+    role: Merge Team
+    links:
+      slack: https://hackforla.slack.com/team/U08G2GETURJ
+      github: https://github.com/kdaca19xx
+    picture: https://avatars.githubusercontent.com/kdaca19xx
 links:
   - name: Wiki
     url: 'https://github.com/hackforla/website/wiki'


### PR DESCRIPTION
Fixes #8440 

### What changes did you make?
  - added this to _projects/website.md:
 ```
 - name: Kerstin Carson
    github-handle: kdaca19xx
    role: Merge Team
    links:
      slack: https://hackforla.slack.com/team/U08G2GETURJ
      github: https://github.com/kdaca19xx
    picture: https://avatars.githubusercontent.com/kdaca19xx
```

### Why did you make the changes (we will use this info to test)?
- Kerstin Carson is now a member of the Merge Team so the list of project leadership needs to be updated.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [ ] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="2355" height="1358" alt="before8440" src="https://github.com/user-attachments/assets/0093a8df-1785-4dea-8f9b-a82a018b8fc8" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="2327" height="1399" alt="after8440" src="https://github.com/user-attachments/assets/a8776e29-341d-43af-b6be-e9e373bb2651" />


</details>
