### PR TITLE
Modified current-projects.js to remove OR logic from project filter

### DIFF
--- a/assets/js/current-projects.js
+++ b/assets/js/current-projects.js
@@ -534,7 +534,7 @@ function updateProjectCardDisplayState(filterParams){
             if(key !=='Search'){
                 let inUrl = value;
                 let inCard = projectCardObj[key];
-                if( ( inCard.filter(x => inUrl.includes(x)) ).length == 0 ){
+                if(!inUrl.every(x => inCard.includes(x))){
                     cardsToHideContainer.push([key,projectCard.id]);
                 }
                 else{
@@ -603,7 +603,10 @@ function updateProjectCardDisplayState(filterParams){
                     }                        
                 }       
             }
-            cardsToHideContainer.map(item => document.getElementById(`${item[1]}`).style.display = 'none');
+            if (cardsToHideContainer.length > 0){
+                cardsToHideContainer.map(item => document.getElementById(`${item[1]}`).style.display = 'none');
+                break;
+            }
         }
     });    
 }


### PR DESCRIPTION
Fixes #8353

### What changes did you make?
  - Modified code on line 537 in updateProjectCardDisplayState method to ensure AND logic within same filter category
  - Added conditional to updateProjectCardDisplayState method to ensure AND logic between different filter categories

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To ensure that AND logic is applied to all filter categories selected on the project page
  - Make sure the filter is easier to use and navigate

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

<img width="1894" height="892" alt="Screenshot 2026-02-25 at 03-18-02 Hack for LA" src="https://github.com/user-attachments/assets/2185390f-4c04-4714-831e-cd9e778f1f0c" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1894" height="892" alt="Screenshot 2026-02-25 at 03-18-09 Projects - Hack for LA" src="https://github.com/user-attachments/assets/79f0a3a0-21b0-4506-814e-9f37279bf825" />

</details>
