### PR TITLE
Changed img tag on CONTRIBUTING.md pg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -978,7 +978,7 @@ In the dropdown example above [**Click here** to see pull request #2131 example 
 <!--  Notes: 
   - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
   - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
-  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
+  - If your images are too big, use the <img src="" width="" length="">  syntax instead of ![image](link) to format the images
   - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
  --> 
 


### PR DESCRIPTION
Fixes #7835 

### What changes did you make?
  - Line 981 of the CONTRIBUTING.md, updated this:
`If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images`
.... to this:
`If your images are too big, use the <img src="" width="" length="">  syntax instead of ![image](link) to format the images`

### Why did you make the changes (we will use this info to test)?
  - We use <img> HTML tags with no ending slashes in the code base because the <img> tag is self-closing. I updated this so the code base is consistent.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

<img width="1692" height="1004" alt="Screenshot 2026-03-08 at 12 06 18 PM" src="https://github.com/user-attachments/assets/be1c58c9-c6a8-41c0-9943-40e4695d1100" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1702" height="1024" alt="Screenshot 2026-03-08 at 12 07 17 PM" src="https://github.com/user-attachments/assets/9449c042-b77a-4d2f-a303-01766c4f2385" />



</details>
