### PR TITLE
fix: remove deprecated version field from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   hfla_site:
     image: hackforlaops/ghpages:latest


### PR DESCRIPTION
## Summary

Removed the deprecated top-level `version` field from docker-compose.yml.

Recent versions of Docker Compose automatically detect the schema version, and the `version` attribute is now obsolete and triggers a warning.
closes #8555 

## Before

Running:

docker-compose up

Displays warning:

the attribute `version` is obsolete

## After

The warning no longer appears when running docker-compose up.

## Changes

- Removed `version: "3"` from docker-compose.yml