### PR TITLE
Remove Julia Gab from UI/UX leadership list

### DIFF
--- a/_data/internal/communities/ui-ux.yml
+++ b/_data/internal/communities/ui-ux.yml
@@ -17,12 +17,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U0245UJP868
       github: https://github.com/Aparna1Gopal
     picture: https://avatars.githubusercontent.com/u/86335455
-  - name: Julia Gab
-    role: Co-lead
-    links:
-      slack: https://hackforla.slack.com/team/U03AS9FBAAU
-      github: https://github.com/juliagab56
-    picture: https://avatars.githubusercontent.com/u/80308705
   - name: Peter Gwon
     role: Co-lead
     links:


### PR DESCRIPTION

Fixes #8387

### What changes did you make?
- Removed Julia Gab from the UI/UX leadership section in `_data/internal/communities/ui-ux.yml`

### Why did you make the changes (we will use this info to test)?
- To keep the UI/UX community leadership information accurate and up to date

### CodeQL Alerts
- [x] I have checked this PR for CodeQL alerts and none were found.

### Screenshots of Proposed Changes To The Website



#### Before
<img width="1470" height="956" alt="before_change" src="https://github.com/user-attachments/assets/35e342bf-eada-4fba-92ac-537b00f07640" />

#### After
<img width="1470" height="956" alt="after_change" src="https://github.com/user-attachments/assets/2d989415-8ad7-444e-8a2c-8c082aadf7e1" />
