### PR TITLE
Add explicit default permissions to "Add Update Label Weekly" workflow

### DIFF
--- a/.github/workflows/add-update-label-weekly.yml
+++ b/.github/workflows/add-update-label-weekly.yml
@@ -17,6 +17,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   Add-Update-Label-Weekly:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #8576 

### What changes did you make?
  - In `add-update-label-weekly.yml` add explicit default permissions


### Why did you make the changes (we will use this info to test)?
  - Without specifying these default permissions, the default GITHUB_TOKEN inherits the more permissive defaults defined in https://github.com/hackforla/website/settings/actions under "Default permissions" 
  - The new permissions apply to the "checkout repo" step; otherwise the permissions defined by the GitHub App will control


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- no visual changes
- [test log from personal repo](https://github.com/t-will-gillis/website/actions/runs/23620674917)
