### PR TITLE
Specify default permissions, other security for "Update Label Directory" & "Flag Issues Unlabeled..." workflows

### DIFF
--- a/.github/workflows/flag-issues-unlabeled-after-deletion.yml
+++ b/.github/workflows/flag-issues-unlabeled-after-deletion.yml
@@ -14,6 +14,9 @@ on:
       HACKFORLA_BOT_PA_TOKEN:
         required: true
 
+permissions:
+  contents: read
+  
 jobs:
   Flag-Issues-Unlabeled-After-Deletion:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-label-directory.yml
+++ b/.github/workflows/update-label-directory.yml
@@ -7,7 +7,6 @@ on:
   label:
     types: [edited, created, deleted]
 
-# Set default permissions
 permissions:
     contents: read
 
@@ -39,9 +38,9 @@ jobs:
             const labelPacket = script({g: github, c: context})
             return labelPacket
 
-      # NOTE: the the URL below matches the **current deployment URL** of the Apps Script
-      # associated with the 'Source of Truth'Label spreadsheet and maintained by
-      # `hackforla-bot@hackforla.org`. (If something is broken, check this link first)
+      # NOTE: the secret below references the **current deployment URL** of the Google
+      # Apps Script associated with the 'Source of Truth'Label spreadsheet and maintained
+      # by `hackforla-bot@hackforla.org`. (If something is broken, check this link first)
       - name: Send POST request to Google Apps Script
         env:
           label_edits: ${{ steps.update-label-directory.outputs.result }}

--- a/.github/workflows/update-label-directory.yml
+++ b/.github/workflows/update-label-directory.yml
@@ -7,6 +7,10 @@ on:
   label:
     types: [edited, created, deleted]
 
+# Set default permissions
+permissions:
+    contents: read
+
 jobs:
   # Check if the deleted label was in use. If so, flag the deletion and affected issues
   Flag-Issues-Unlabeled-After-Deletion:
@@ -42,7 +46,7 @@ jobs:
         env:
           label_edits: ${{ steps.update-label-directory.outputs.result }}
         run: |
-          curl -X POST "https://script.google.com/macros/s/AKfycbw_kmDVqQW5J8wXWl1BXvJzALU6k0XYpAc5XJ7inQSyq8_opUuNg4ToBzh3Gf4M5jhw/exec" \
+          curl -X POST "${{ secrets.GOOGLE_APPS_UPDATE_LABEL_DIRECTORY_URL }}" \
           -H "Content-Type: application/json" \
           -d "$label_edits"
 


### PR DESCRIPTION
Fixes #8587


### What changes did you make?
  - in `flag-issues-unlabeled-after-deletion.yml` added default permissions block
  - in `update-label-directory.yml` added default permissions block
  - replaced hard-coded url to the Google Apps spreadsheet with a secret. Note that I already saved the existing URL as a secret. 



### Why did you make the changes (we will use this info to test)?
  - Permissions blocks added to limit default permissions to only what is needed 
  - The hard-coded URL, though not inherently insecure, does not need to be exposed. It also will be easier to update the secret url without committing new code. After this PR is merged, we will need to update the Apps Script and save the updated URL as good practice.


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- no visual changes
- [Test log](https://github.com/t-will-gillis/website/actions/runs/23701503941) showing that the automation runs both with default permissions specified and the "secret" URL.
- [Second test log](https://github.com/t-will-gillis/website/actions/runs/23726010068) showing automation running after label is deleted.