### PR TITLE
Add complexity0, er, and epic to labels to exclude for check

### DIFF
--- a/github-actions/check-closed-issue-for-linked-pr/check-for-linked-issue/check-issue-labels-and-linked-prs.js
+++ b/github-actions/check-closed-issue-for-linked-pr/check-for-linked-issue/check-issue-labels-and-linked-prs.js
@@ -2,9 +2,15 @@ const retrieveLabelDirectory = require('../../utils/retrieve-label-directory');
 
 // Use labelKeys to retrieve current labelNames from directory
 const [
-  nonPrContribution
+  nonPrContribution,
+  complexity0,
+  er,
+  epic
 ] = [
-  'NEW-nonPrContribution'
+  'NEW-nonPrContribution',
+  'complexity0',
+  'er',
+  'epic'
 ].map(retrieveLabelDirectory);
 
 // ==================================================
@@ -15,8 +21,9 @@ const [
  *
  * @param {{github: object, context: object}} actionsGithubScriptArgs - GitHub
  *  objects from actions/github-script
- * @returns {boolean} False if the issue does not have a linked PR, a "non-PR
- *  contribution" label, or an "Ignore..." label.
+ * @returns {boolean} False if the issue does not have a linked PR, one of the following contribution labels: "non-PR
+ *  contribution", "Complexity: Prework", "ER", "epic", or an 
+ * "Ignore..." label.
  */
 async function hasLinkedPrOrExcusableLabel({ github, context }) {
   const repoOwner = context.repo.owner;
@@ -31,10 +38,12 @@ async function hasLinkedPrOrExcusableLabel({ github, context }) {
   // --------------------------------------------------
 
   // Check if the issue has the labels that will avoid re-opening it.
+  const excludedLabels = [nonPrContribution, complexity0, er, epic];
+
   if (
     labels.some(
       (label) =>
-        label === nonPrContribution || label.toLowerCase().includes('ignore')
+        excludedLabels.inlcudes(label) || label.toLowerCase().includes('ignore')
     )
   ) {
     console.info(consoleMessageAllowClose);

--- a/github-actions/check-closed-issue-for-linked-pr/check-for-linked-issue/check-issue-labels-and-linked-prs.js
+++ b/github-actions/check-closed-issue-for-linked-pr/check-for-linked-issue/check-issue-labels-and-linked-prs.js
@@ -43,7 +43,7 @@ async function hasLinkedPrOrExcusableLabel({ github, context }) {
   if (
     labels.some(
       (label) =>
-        excludedLabels.inlcudes(label) || label.toLowerCase().includes('ignore')
+        excludedLabels.includes(label) || label.toLowerCase().includes('ignore')
     )
   ) {
     console.info(consoleMessageAllowClose);


### PR DESCRIPTION
Fixes #8546 

### What changes did you make? 
  - Added complexity0 ("Complexity: Prework"), er ("ER"), and epic labels in the "Check Closed Issue For Linked PR" workflow
  - Refractored the list of label.

### Why did you make the changes (we will use this info to test)?
  - The "Check Closed Issue For Linked PR" workflow previously had a bug that would make it reopen someone's Skills Issues even if they were inactive members, even after if the "Schedule Monthly" workflow attempted to close. This means those bots action were in conflict with each other and the desired outcome (inactive members' Skills Issues being closed) was not accomplished perminently.
  - Refractoring: to keep it clean and so it can continue to grow if needed.
 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes to the website

