### PR TITLE
added civic tech legal info and hr to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,5 +20,9 @@
         </div>
       </div>
     </nav>
+    <div class="footer-legal">
+      <hr />
+      <p>Civic Tech Structure, Inc., a 501(c)(3) nonprofit organization.</p>
+    </div>
   </div>
 </footer>

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -42,4 +42,25 @@
       margin: 0;
     }
   }
+
+  .footer-legal {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-top: 10px;
+
+    hr {
+      width: 100%;
+      margin: 0;
+      border: 0;
+      border-top: 1px solid rgba($color-white, 0.3);
+    }
+
+    p {
+      margin-top: 8px;
+      margin-bottom: 0;
+      text-align: center;
+    }
+  }
 }


### PR DESCRIPTION

Fixes #8500

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Added civic tech legal info to footer
  - Added hr element to footer

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To make our website compliant with legal non-profit standards
  - The hr is to create a clean separation from nav items 


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>
<img width="750" height="200" alt="Screenshot 2026-03-31 at 3 58 24 PM" src="https://github.com/user-attachments/assets/8ded2dc6-d7b2-4bc9-a432-57805e5a92c2" />

<img width="567" height="229" alt="Screenshot 2026-03-31 at 3 59 29 PM" src="https://github.com/user-attachments/assets/9b2de1ef-a3ca-4359-b238-68fa6e615de8" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="750" height="244" alt="Screenshot 2026-03-31 at 6 41 48 PM" src="https://github.com/user-attachments/assets/a6d8541d-ec49-4e62-8a99-88928b156e6e" />

<img width="451" height="244" alt="Screenshot 2026-03-31 at 6 42 28 PM" src="https://github.com/user-attachments/assets/832a7678-504c-46a2-a7d9-cd9b3406eb0b" />

</details>
