### PR TITLE
Fix #8539: Remove incorrect comma in Project Meetings page

### DIFF
--- a/pages/project-meetings.html
+++ b/pages/project-meetings.html
@@ -9,7 +9,7 @@ permalink: /project-meetings
 <div class="header-container flex-container">
     <div class="header-text">
         <h1 class="title1">Project Team Meetings</h1>
-        <p>We have teams that meet at various times. You are welcome to attend a project team meeting after you have completed Onboarding, and if the team currently has an open role. You can find open roles at the end of the <a href="https://www.hackforla.org/getting-started" target="_blank">Onboarding</a>.</p>
+        <p>We have teams that meet at various times. You are welcome to attend a project team meeting after you have completed Onboarding and if the team currently has an open role. You can find open roles at the end of the <a href="https://www.hackforla.org/getting-started" target="_blank">Onboarding</a>.</p>
     </div>
     <img class="header-hero-image" src="../assets/images/project-meetings-page/project-meetings-banner-image.png" alt="project meetings banner image">
 </div>


### PR DESCRIPTION
## Summary
- Removes the incorrect comma after "Onboarding" on line 12 of `/pages/project-meetings.html`
- This corrects the sentence grammar as described in the issue

Closes #8539

## Test plan
- [x] Verified the comma is removed from the correct location
- [x] Sentence reads naturally without the comma: "...after you have completed Onboarding and if the team currently has an open role."

🤖 Generated with [Claude Code](https://claude.com/claude-code)