### PR TITLE
Fix #8514: Add missing comma in Site Map page

### DIFF
--- a/pages/sitemap.html
+++ b/pages/sitemap.html
@@ -10,7 +10,7 @@ permalink: /sitemap/
         <h1 class="title1">Site Map</h1>
         <p>
             The Hack for LA website is growing. We started with a one page
-            website and we have been steadily adding content and features
+            website, and we have been steadily adding content and features
             to accommodate our fully remote brigade.
         </p>
     </div>


### PR DESCRIPTION
## Summary
- Adds a missing comma after "website" on line 13 of `/pages/sitemap.html`
- Changes "website and we have been" to "website, and we have been" for correct comma usage in a compound sentence

Closes #8514

## Test plan
- [x] Verified the comma is added at the correct location
- [x] Sentence reads correctly: "We started with a one page website, and we have been steadily adding content and features..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)