### PR TITLE
Fix #8513: Add Oxford comma in Join Us page

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -59,7 +59,7 @@ permalink: /join
         </p>
         <p>
           We are a Do-ocracy: we are not a school, yet everyone here is learning
-          something, growing their experiences, portfolios and ability to work on
+          something, growing their experiences, portfolios, and ability to work on
           inter-disciplinary teams.
         </p>
         <a href="https://www.hackforla.org/getting-started" class="btn btn-primary btn-md btn--default" target="_blank">Project Volunteer</a>


### PR DESCRIPTION
## Summary
- Adds a missing Oxford comma on line 62 of `/pages/join-us.html`
- Changes "experiences, portfolios and ability" to "experiences, portfolios, and ability" for consistent Oxford comma usage

Closes #8513

## Test plan
- [x] Verified the Oxford comma is added at the correct location
- [x] Sentence reads correctly: "...growing their experiences, portfolios, and ability to work on inter-disciplinary teams."

🤖 Generated with [Claude Code](https://claude.com/claude-code)