### PR TITLE
Add Oxford comma in join-us page

### DIFF
--- a/pages/join-us.html
+++ b/pages/join-us.html
@@ -12,7 +12,7 @@ permalink: /join
       <h1 class="title1">Join Us</h1>
       <p>
         We bring together civic-minded volunteers to build digital products,
-        programs and services with community partners and local government to
+        programs, and services with community partners and local government to
         address issues in our LA region and to share these effective processes,
         practices, and code with the larger civic tech community.
       </p>


### PR DESCRIPTION
Fixes #8512

## What changes did you make?
Added a missing Oxford comma on the Join Us page.

## Why did you make the changes?
To improve grammatical consistency.