### PR TITLE
Remove Terence Lo from Civic Tech Jobs leadership

### DIFF
--- a/_projects/civic-tech-jobs.md
+++ b/_projects/civic-tech-jobs.md
@@ -69,13 +69,6 @@ leadership:
       slack: https://hackforla.slack.com/team/U061GQQ56Q4
       github: https://github.com/kevin31yu
     picture: https://avatars.githubusercontent.com/kevin31yu
-  - name: Terence Lo
-    github-handle: LoTerence
-    role: Developer - Backend
-    links:
-      slack: https://hackforla.slack.com/team/U078NLYHHL5
-      github: https://github.com/LoTerence
-    picture: https://avatars.githubusercontent.com/LoTerence
   - name: Gowthami Cherukuri
     github-handle: GowthamiCherukuri
     role: Developer


### PR DESCRIPTION
Fixes #8287

### What changes did you make?

* Removed Terence Lo from the leadership section in `_projects/civic-tech-jobs.md`

### Why did you make the changes (we will use this info to test)?

* To keep the Civic Tech Jobs project profile up to date
* To remove outdated leadership information from the project page

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)

<details>
  <summary>Before</summary>


<img width="1470" height="956" alt="截屏2569-04-19 09 19 10" src="https://github.com/user-attachments/assets/02441db2-610c-459c-acbe-10e8bd94a804" />

</details>

<details>
  <summary>After</summary>
<img width="1470" height="956" alt="after" src="https://github.com/user-attachments/assets/d8b273d8-49a7-46d3-a9ba-7710db48eff3" />



</details>

### CodeQL Alerts
- [x] I have reviewed the CodeQL alerts and acknowledge them.

