### PR TITLE
Modify wins.js to accept GitHub and LinkedIn usernames and construct URLs

### DIFF
--- a/assets/js/wins.js
+++ b/assets/js/wins.js
@@ -8,8 +8,10 @@
   const email = "Email Address"
   const name = "Full name"
   const linkedin_url = "Linkedin URL (optional)"
+  const linkedin_profile = "LinkedIn Name"
   const linkedin_permission = "Could we use your Linkedin profile picture next to your story?"
   const github_url = "Github URL (optional)"
+  const github_handle = "GitHub Handle"
   const github_permission = "Could we use your Github profile picture next to your story?"
   const team = "Select the team(s) you're on"
   const role = "Select your role(s) on the team"
@@ -42,6 +44,16 @@
     {% assign localData = site.data.external._wins-data %}
     // Escapes JSON for injections. See: #2134. If this is no longer the case, perform necessary edits, and remove this comment
     const cardData = JSON.parse(decodeURIComponent("{{ localData | jsonify | uri_escape }}"));
+	
+	  cardData.forEach(card => {
+		  if (card['Linkedin URL (optional)'].length === 0 && card['LinkedIn Name'].length > 0) {
+			  card['Linkedin URL (optional)'] = `https://www.linkedin.com/in/${card['LinkedIn Name']}`;
+		  }
+		  if (card['Github URL (optional)'].length === 0 && card['GitHub Handle'].length > 0) {
+			  card['Github URL (optional)'] = `https://github.com/${card['GitHub Handle']}`;
+		  }
+	  })
+	
     window.localStorage.setItem('data', JSON.stringify(cardData));
     makeCards(cardData);
     ifPageEmpty();


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #5470 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Updated the code in assets/wins.js so that if the existing fields `Github URL (optional)` and `Linkedin URL (optional)` are blank, the code will reference the new fields `GitHub Handle` and `LinkedIn Name` and will construct the appropriate URLs.

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - We need to modify wins.js so that if the existing GitHub/LinkedIn fields (which contain URLs) are not populated, the code will use the new fields `GitHub Handle` and `LinkedIn Name` and reconstruct the appropriate URLs.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

- No visual changes to the website