### PR TITLE
Fix #8489: Update the Date Format for the Site Map

### DIFF
--- a/pages/sitemap.html
+++ b/pages/sitemap.html
@@ -22,7 +22,7 @@ permalink: /sitemap/
 <div class="sitemap-page content-section">
   <div class="page-card card-primary page-card-lg page-card--sitemap">
       <div>
-          <h2 class="title4">Site Map as of 7/30/21</h2>
+          <h2 class="title4">Site Map as of 2021-07-30</h2>
           <a href="https://www.hackforla.org/assets/images/sitemap/sitemap.jpg" target="_blank">
               <img src="/assets/images/sitemap/sitemap.jpg">
           </a>


### PR DESCRIPTION
## Summary

Update the date format on the Site Map page from '7/30/21' to '2021-07-30' in the heading text.

## Approach

In pages/sitemap.html, find the line containing '<h2 class="title4">Site Map as of 7/30/21</h2>' and replace '7/30/21' with '2021-07-30'.

## Files Changed

- `pages/sitemap.html`

## Related Issue

Fixes #8489

## Testing

Verified the change manually. Let me know if you'd like any additional tests or adjustments.
