### PR TITLE
E2e test

### DIFF
--- a/.github/workflows/pr-ci-tests.yml
+++ b/.github/workflows/pr-ci-tests.yml
@@ -1,0 +1,14 @@
+name: Run Pull Request CI Tests
+on:
+  pull_request:
+    branches:
+      - 'gh-pages'
+jobs:
+  Run-Pull-Request-CI-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run E2E tests
+        run: docker compose --profile e2e up --exit-code-from hfla_e2e

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ models.json
 
 # Ignore clasp config file
 .clasp.json
+
+tests/e2e/test-results/

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,10 +29,10 @@
   <title>{% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape}}</title>
   <meta name="description"
     content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 400 }}{% else %}{{ site.description }}{% endif %}" />
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | absolute_url }}" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
-  <link rel="shortcut icon" type="image/x-icon" href="{{ '/assets/images/favicon.ico' | absolute_url }}" />
-  <script src="{{ '/assets/js/utils.js' | absolute_url }}"></script>
+  <link rel="shortcut icon" type="image/x-icon" href="/assets/images/favicon.ico" />
+  <script src="/assets/js/utils.js"></script>
 
   <!-- Import Roboto font from Google -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
-version: "3"
 services:
   hfla_site:
     image: hackforlaops/ghpages:latest
     container_name: hfla_site
     command: >
       sh -c "jekyll clean &&
-             jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I"
+            jekyll serve --force_polling --livereload --config _config.yml,_config.docker.yml -I"
     environment:
       - JEKYLL_ENV=docker
     ports:
@@ -13,3 +12,24 @@ services:
       - 35729:35729
     volumes:
       - .:/srv/jekyll
+
+  hfla_e2e:
+    image: mcr.microsoft.com/playwright:v1.59.1-jammy
+    container_name: hfla_e2e
+    profiles:
+      - e2e
+    volumes:
+      - .:/website
+    working_dir: /website
+    depends_on:
+      - hfla_site
+    command: >
+      sh -c "echo 'Waiting for Jekyll...' &&
+             while ! curl -sf http://hfla_site:4000 > /dev/null 2>&1; do
+               sleep 3;
+             done &&
+             echo 'Jekyll ready' &&
+             npm install &&
+             npx playwright test --config=tests/e2e/playwright.config.js"
+
+      

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,76 @@
 {
-  "lockfileVersion": 1
+  "name": "hackforla-website",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hackforla-website",
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "hackforla-website",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
+  }
+}

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -1,0 +1,12 @@
+// playwright.config.js
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: '.',
+  outputDir: './test-results',
+  use: { baseURL: 'http://hfla_site:4000' },
+  webServer: {
+    url: 'http://hfla_site:4000',
+    reuseExistingServer: true,
+  }
+})

--- a/tests/e2e/projects.spec.js
+++ b/tests/e2e/projects.spec.js
@@ -1,0 +1,66 @@
+// e2e/projects.spec.js
+import { test, expect } from '@playwright/test'
+
+test('filter by status shows only matching projects', async ({ page }) => {
+  await page.goto('/projects/')
+  
+  await page.getByLabel('Active').check()
+  
+  const cards = page.locator('.project-card:visible')
+  const count = await cards.count()
+  expect(count).toBeGreaterThan(0)
+  
+  for (let i = 0; i < count; i++) {
+    await expect(cards.nth(i).locator('.status-text')).toHaveText('Active')
+  }
+})
+
+test('search returns relevant results', async ({ page }) => {
+  await page.goto('/projects/')
+  
+  await page.locator('#search-desktop').fill('JavaScript')
+  await page.locator('.search-bar-desktop .search-glass').click()
+  
+  const cards = page.locator('.project-card:visible')
+  const count = await cards.count()
+  expect(count).toBeGreaterThan(0)
+
+  // NOTE: Only checks the 'languages' attribute, and would false
+  //       error if JavaScript is added to another field and not languages
+  for (let i = 0; i < count; i++) {
+    const languages = await cards.nth(i).getAttribute('data-languages')
+    expect(languages?.toLowerCase()).toContain('javascript')
+  }
+})
+
+test('clear all filters works at mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto('/projects/')
+  
+  const totalCards = await page.locator('.project-card').count()
+  
+  await page.locator('.show-filters-button').click()
+  await page.locator('.filter-item a.category-title').filter({ hasText: 'status' }).click()
+  await page.getByLabel('Active').check()
+  
+  await expect(page.locator('.project-card[data-status="Completed"]').first())
+    .toBeHidden({ timeout: 5000 })
+
+  await expect(page.locator('#clear-all-filters')).toBeVisible()
+  await page.locator('#clear-all-filters').click()
+  
+  await expect(page.locator('.project-card:visible')).toHaveCount(totalCards)
+})
+
+test('clear all filters is not present at desktop', async ({ page }) => {
+  // Clear All button is intentionally hidden in desktop view via CSS
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await page.goto('/projects/')
+  
+  await page.getByLabel('Active').check()
+  
+  await expect(page.locator('.project-card[data-status="Completed"]').first())
+    .toBeHidden({ timeout: 5000 })
+  
+  await expect(page.locator('#clear-all-filters')).toBeHidden()
+})


### PR DESCRIPTION
### What changes did you make?
  - Added Playwright E2E test infrastructure (`tests/e2e/`) with Docker Compose integration
  - Added GitHub Actions workflow to run E2E tests on PRs
  - Fixed `head.html` to use relative paths for local assets (CSS, JS, favicon)

### Why did you make the changes (we will use this info to test)?
  - E2E tests let us test user-facing site behavior (filtering, search, mobile interactions) against the built site without the complexity of mocking Jekyll/Liquid data
  - The head.html fix makes sure local assets resolve correctly if the site is served from a different location than the configured url (i.e. configured as localhost, served into Docker container)

### Screenshots of Proposed Changes To The Website (if any)
- No visual changes to the website

### Notes: 
  - Tests run in Docker via `docker compose up hfla_e2e`. The site is served using the existing hfla_site image, with a Playwright container added alongside it that runs the tests.

- [ ] I have checked this PR for CodeQL alerts and none were found.