### PR TITLE
Fix edge-case bug in "Issue Trigger" workflow

### DIFF
--- a/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
+++ b/github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js
@@ -138,7 +138,7 @@ async function assignedToAnotherIssue() {
       owner: context.repo.owner,
       repo: context.repo.repo,
       assignee: assignee
-    })).data;
+    })).data.filter(issue => !issue.pull_request);
 
     const otherIssues = [];
 


### PR DESCRIPTION
Fixes #8634 

### What changes did you make?
  - In `preliminary-update-comment.js` added filter to remove PRs


### Why did you make the changes (we will use this info to test)?

  - We need to ensure that only issues are returned in the query so that if a dev assign themselves to their own PR, the results do not include it- this will cause GraphQL to return an error and the automation checks will fail. 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- [BEFORE condition, test logs](https://github.com/t-will-gillis/website/actions/runs/26045995394/job/76570224487)
  - In my personal repo. Note that I assigned my repo's PR 1311 to myself
  - I then assigned my repo's issue 1309 to myself, triggering the "Issue Trigger" workflow and the step "Ask-For-Preliminary-Update". This result in a failure of the workflow.
  - This duplicates the existing edge case failure: `Could not resolve to an issue with the number of 1311.` because the 1311 is a PR, not an issue.
 - [AFTER condition, test logs](https://github.com/t-will-gillis/website/actions/runs/26047236458/job/76574516830)
   - The AFTER branch includes the line that adds `})).data.filter(issue => !issue.pull_request);` to `preliminary-update-comment.js`
   - Same setup as before: PR 1311 still assigned to self, and triggered workflow by self-assigning issue 1309.
   - Results show that the PR is not included in the list of issues assigned, and therefore the automation can run as expected.