### PR TITLE
fix(#7420): update GitHub capitalization in communities of practice s…

### DIFF
--- a/_sass/components/_communities-of-practice.scss
+++ b/_sass/components/_communities-of-practice.scss
@@ -130,7 +130,7 @@
 }
 
 
-//styling for join Slack and view github buttons
+//styling for join Slack and view GitHub buttons
 .page-card-content{
   .link-buttons{
     display: flex;


### PR DESCRIPTION
Fixes #7420

### What changes did you make?
- Updated the comment in _sass/components/_communities-of-practice.scss
- Changed github to GitHub for correct capitalization 

### Why did you make the changes (we will use this info to test)?
- To maintain consistent company name capitalization across the project
- To match GitHub’s official company name formatting

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)

- No visual changes to the website
  




