### PR TITLE
Remove '&' symbol to fix bug with whiteboard / paper and pencil filter

### DIFF
--- a/_projects/food-oasis.md
+++ b/_projects/food-oasis.md
@@ -116,7 +116,7 @@ tools:
   - Figma
   - Photoshop
   - Sketch
-  - whiteboard / paper & pencil
+  - whiteboard / paper and pencil
   - phone calls
   - paper prototyping
   - Google Forms


### PR DESCRIPTION
Fixes #8496 

### What changes did you make?
  - Removed the '&' by replacing the `whiteboard / paper & pencil` filter with `whiteboard / paper and pencil` in `_projects/food-oasis.md`

### Why did you make the changes (we will use this info to test)?
  - The `&` symbol was causing a bug that prevented the filter from being selected.
  - The query string in place caused the browser to incorrectly read the filter due to the `&` acting as a delimiter, reading it as:
    - `tools = whiteboard / paper` and `pencil = (empty value)`


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

<img width="1902" height="805" alt="Before" src="https://github.com/user-attachments/assets/8acfb83e-a2ba-486a-bc7e-fe9fbcb010bf" />
The filter could not be selected.
</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1902" height="807" alt="After" src="https://github.com/user-attachments/assets/4cf2ae9d-bf85-40cb-89aa-483b5832b1a7" />
The filter can now be selected, and Food Oasis is properly displayed.

</details>
