### PR TITLE
Update Comma on Project Meeting Page Description

### DIFF
--- a/pages/project-meetings.html
+++ b/pages/project-meetings.html
@@ -9,7 +9,8 @@ permalink: /project-meetings
 <div class="header-container flex-container">
     <div class="header-text">
         <h1 class="title1">Project Team Meetings</h1>
-        <p>We have teams that meet at various times. You are welcome to attend a project team meeting after you have completed Onboarding and if the team currently has an open role. You can find open roles at the end of the <a href="https://www.hackforla.org/getting-started" target="_blank">Onboarding</a>.</p>    </div>
+        <p>We have teams that meet at various times. You are welcome to attend a project team meeting after you have completed Onboarding and if the team currently has an open role. You can find open roles at the end of the <a href="https://www.hackforla.org/getting-started" target="_blank">Onboarding</a>.</p>
+    </div>
     <img class="header-hero-image" src="../assets/images/project-meetings-page/project-meetings-banner-image.png" alt="project meetings banner image">
 </div>
 

--- a/pages/project-meetings.html
+++ b/pages/project-meetings.html
@@ -9,8 +9,7 @@ permalink: /project-meetings
 <div class="header-container flex-container">
     <div class="header-text">
         <h1 class="title1">Project Team Meetings</h1>
-        <p>We have teams that meet at various times. You are welcome to attend a project team meeting after you have completed Onboarding, and if the team currently has an open role. You can find open roles at the end of the <a href="https://www.hackforla.org/getting-started" target="_blank">Onboarding</a>.</p>
-    </div>
+        <p>We have teams that meet at various times. You are welcome to attend a project team meeting after you have completed Onboarding and if the team currently has an open role. You can find open roles at the end of the <a href="https://www.hackforla.org/getting-started" target="_blank">Onboarding</a>.</p>    </div>
     <img class="header-hero-image" src="../assets/images/project-meetings-page/project-meetings-banner-image.png" alt="project meetings banner image">
 </div>
 


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #8539

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Removed a comma after the word "onboarding" on the Project Meeting page description

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Goal was to update website to use commas consistently so that the website is correct and uniform.


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>
<img width="1470" height="793" alt="Screenshot 2026-05-24 at 3 07 37 PM" src="https://github.com/user-attachments/assets/8548b696-1917-4e22-85d5-b239ebd6a9c0" />

<img width="918" height="799" alt="Screenshot 2026-05-24 at 3 08 06 PM" src="https://github.com/user-attachments/assets/4cf9d047-40f0-48c6-a9c2-8c6fb5816992" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="1470" height="919" alt="Screenshot 2026-05-24 at 2 10 00 PM" src="https://github.com/user-attachments/assets/9a43e0cf-b14c-4754-9940-4630c594174b" />

<img width="829" height="728" alt="Screenshot 2026-05-24 at 2 13 44 PM" src="https://github.com/user-attachments/assets/b301c2c8-dd61-4cb3-ac88-06e1fbf325d2" />

</details>
