### PR TITLE
Fix capitalization of GitHub in 2FA main guide subheader

### DIFF
--- a/_guide-pages/2FA.html
+++ b/_guide-pages/2FA.html
@@ -29,7 +29,7 @@ resource-url-depreciated:
     <div class="section-container">
         <div>
             <h3 class="title-left"><strong>To Enable 2FA:</strong></h3>
-            <h5 class="title-left"><strong>Visit and follow <a href="https://docs.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication" target="blank">Github's Guide to Setting Up 2FA</a></strong></h5>
+            <h5 class="title-left"><strong>Visit and follow <a href="https://docs.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication" target="blank">GitHub's Guide to Setting Up 2FA</a></strong></h5>
         </div>
 
         <div>


### PR DESCRIPTION

<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7418 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Update casing from "Github" to GitHub" on 2FA Guide page main content sub header

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Changes are needed to display company name correctly and consistently throughout the website

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

<img width="1920" height="1032" alt="2FA_Before" src="https://github.com/user-attachments/assets/1aa66220-729b-42bf-b2f8-c18f4840d9f0" />

</details>

<details>
<summary>Visuals after changes are applied</summary>

<img width="1920" height="1032" alt="2FA_After" src="https://github.com/user-attachments/assets/8a767b1f-d9b1-486c-9e53-22b417c63731" />

</details>

