### PR TITLE
Specify default permissions for GitHub Action: CodeQL Create Issues

### DIFF
--- a/.github/workflows/codeql-create-issues.yml
+++ b/.github/workflows/codeql-create-issues.yml
@@ -5,10 +5,10 @@ name: "CodeQL Create Issues"
 on:  
   workflow_dispatch:
 
-# permissions:
-#     contents: read
-#     security-events: read
-#     issues: read
+permissions:
+    contents: read
+    security-events: read
+    issues: read
 
 jobs:
   codql-scan-job:

--- a/.github/workflows/codeql-create-issues.yml
+++ b/.github/workflows/codeql-create-issues.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
 
 permissions:
-    contents: read
-    security-events: read
-    issues: read
+  contents: read
+  security-events: read
+  issues: read
 
 jobs:
   codql-scan-job:

--- a/.github/workflows/codeql-create-issues.yml
+++ b/.github/workflows/codeql-create-issues.yml
@@ -6,8 +6,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
-  security-events: read
+  security-events: write
   issues: read
 
 jobs:

--- a/.github/workflows/codeql-create-issues.yml
+++ b/.github/workflows/codeql-create-issues.yml
@@ -5,6 +5,11 @@ name: "CodeQL Create Issues"
 on:  
   workflow_dispatch:
 
+# permissions:
+#     contents: read
+#     security-events: read
+#     issues: read
+
 jobs:
   codql-scan-job:
     uses: ./.github/workflows/codeql-scan-job.yml


### PR DESCRIPTION
Fixes #8580

### What changes did you make?
  - Add a default `permissions` block in `.github/workflows/codeql_create_issues.yml`:
  ```
  permissions:
    actions: read
    contents: read
    security-events: write
    issues: read
  ```
  - Tweak `permissions` block specified in original issue to resolve an error in testing. See testing log containing said error at the bottom of this PR.
    - Add `actions: read` and `security-events: write` permissions

### Why did you make the changes (we will use this info to test)?
  - Adding a default permissions block helps limit workflows to what is needed by minimizing unnecessary permissions, as per [GitHub security best practices](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token#modifying-the-permissions-for-the-github_token).
  - The `permissions` block specified in the original issue did not contain `actions: read` and `security-events: write`. As a result, the workflow would throw an error. After my conversation with Will, I added these two specifications in the original issue to resolve this.


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
- No visual changes to the website.
- I tested the CodeQL Create Issues workflow on my fork.
- In the following test logs, click `Workflow File` to see the updated `.yml` file
- [Test Log with error (before permissions block was updated)](https://github.com/castillios/website/actions/runs/26546018152)
- [Test Log with success (with final changes)](https://github.com/castillios/website/actions/runs/26598003975)
