### PR TITLE
Specify default, minimum permissions for "Issue Trigger" workflow

### DIFF
--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -3,6 +3,10 @@ on:
   issues:
     types: [opened, transferred, assigned, labeled, unlabeled]
 
+permissions:
+    contents: read
+    issues: write 
+
 jobs:
   # Adds missing labels to newly-created or transferred issues
   Add-Missing-Labels-To-Issues:


### PR DESCRIPTION
Fixes #8336 
### What changes did you make?
  - Added default, workflow-level permissions to `issue-trigger.yml` 

### Why did you make the changes (we will use this info to test)?
  - We want to limit the default `GITHUB_TOKEN` permissions to the minimum required access for this workflow, following GitHub Actions security best practices.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Test logs
- [Create issue](https://github.com/t-will-gillis/website/actions/runs/26721892460/job/78750345480)
- [Assign issue](https://github.com/t-will-gillis/website/actions/runs/26722198266/job/78751182329)
- [Feature branch](https://github.com/t-will-gillis/website/actions/runs/26722237354)
- [Test issue](https://github.com/t-will-gillis/website/issues/1316)

## If you want to review this
- See "Resources/Instructions" on #8336 to set up your environment
- Additionally, on `github-actions/trigger-issue/add-preliminary-comment/preliminary-update-comment.js`, change line 69 to `const isAdminOrMerge = true;`
- Whenever `github-actions/utils/query-issue-info.js` or `github-actions/utils/mutate-issue-status.js` runs, there will be an error. This can be addressed, but is probably more work than you need to do to review this. If you want to fix this, let me know and I can show you. Otherwise, ok to ignore it.


