### PR TITLE
Specified default permissions for move-closed-issues.yaml

### DIFF
--- a/.github/workflows/move-closed-issues.yaml
+++ b/.github/workflows/move-closed-issues.yaml
@@ -4,6 +4,9 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   Move-Closed-Issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #8584 

### What changes did you make?
  - Added a top-level ```permissions:``` block to the ```.github/workflows/move-closed-issues.yaml``` file
  - Set the default ```contents``` permission to ```read``` 

### Why did you make the changes (we will use this info to test)?
  - To align the workflow with GitHub security recommendations by explicitly defining minimum required permissions
  - To minimize unnecessary privileges by restricting default repository access


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

- No visual changes

### Test Log
- https://gist.github.com/egcuriel/edf606ea59d592e1bbca42756076fa70
