### PR TITLE
Add minimum permissions to PR label workflows

### DIFF
--- a/.github/workflows/set-pr-labels.yaml
+++ b/.github/workflows/set-pr-labels.yaml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   issues: read
+  pull-requests: write
 
 jobs:
   generate-labels-artifact:

--- a/.github/workflows/set-pr-labels.yaml
+++ b/.github/workflows/set-pr-labels.yaml
@@ -7,6 +7,10 @@ on:
       - 'gh-pages'
       - 'feature-homepage-launch'
 
+permissions:
+  contents: read
+  issues: read
+
 jobs:
   generate-labels-artifact:
     runs-on: ubuntu-latest

--- a/.github/workflows/wr-set-pr-labels.yaml
+++ b/.github/workflows/wr-set-pr-labels.yaml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   actions: read
   issues: write
+  pull-requests: write
 
 jobs:
   on-failure:

--- a/.github/workflows/wr-set-pr-labels.yaml
+++ b/.github/workflows/wr-set-pr-labels.yaml
@@ -5,6 +5,11 @@ on:
     workflows: ['Set PR Labels']
     types: [completed]
 
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
 jobs:
   on-failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #8592

### What changes did you make?

Added explicit workflow-level permissions to the PR label workflows.

For `.github/workflows/set-pr-labels.yaml`:

* `contents: read`
* `issues: read`

For `.github/workflows/wr-set-pr-labels.yaml`:

* `contents: read`
* `actions: read`
* `issues: write`
* `pull-requests: write`

### Why did you make the changes?

This limits the default `GITHUB_TOKEN` permissions to the minimum required access for these workflows, following GitHub Actions security best practices.

`pull-requests: write` is included only in `.github/workflows/wr-set-pr-labels.yaml` because testing confirmed that this workflow needs write access to pull requests. It was removed from `.github/workflows/set-pr-labels.yaml` because that workflow does not write to pull requests.

### CodeQL Alerts

* [x] I have checked this PR for CodeQL alerts and none were found.
* [ ] I found CodeQL alert(s), and resolved or documented them.

### Screenshots of Proposed Changes To The Website

No visual changes to the website.

### Testing

Testing confirmed that `pull-requests: write` is required for `.github/workflows/wr-set-pr-labels.yaml`, but it is not needed for `.github/workflows/set-pr-labels.yaml`.

With these permissions, each workflow has the minimum permissions needed for its behavior.
