### PR TITLE
Fixed capitalization of GitHub in a comment

### DIFF
--- a/_sass/components/_guides.scss
+++ b/_sass/components/_guides.scss
@@ -246,7 +246,7 @@ img[src*='#examples'] {
 	opacity: 0.7;
 }
 
-/* Populates an empty div for Users with no Github Link */
+/* Populates an empty div for Users with no GitHub Link */
 .no-github {
 	padding: 10px;
 	margin: 15px;


### PR DESCRIPTION
Fixes #7419

### What changes did you make?
  - Replaced an instance of Github with GitHub in a comment.
 
### Why did you make the changes (we will use this info to test)?
  - To display the GitHub company name correctly.

 

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes Of The Website  (if any, please do not screenshot code changes)

Fixed GitHub casing. No visual changes to the website.

