### PR TITLE
Added a single variable for the  github-handle

### DIFF
--- a/_projects/not-today.md
+++ b/_projects/not-today.md
@@ -7,6 +7,7 @@ alt: 'Not Today - Self-Defense Against Suicidal Thoughts'
 image-hero: /assets/images/projects/not-today-hero.png
 leadership:
   - name: Mya Stark
+    github-handle:
     role: Product Owner & SME
     links:
       slack: 'https://hackforla.slack.com/team/UMC7AJLDV'


### PR DESCRIPTION

Fixes #7781 

### What changes did you make? 
  - Added a `github-handle` variable for Mya Stark within the existing mapping
  - Used spaces to align the `github-handle` variable under the variable  `name`
  - The value of the `github-handle` variable is `null`

### Why did you make the changes (we will use this info to test)?
  - The added `github-handle` variable will eventually replace both `github` and `picture` variables
  - The main goal of this refactor preparation is to reduce redundancy in the project file

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
 - Added a variable with the value `null` to an existing mapping. No visual changes to the website.
