### PR TITLE
Adds "github-handle" to Ambareen Sultana's section.

### DIFF
--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -20,6 +20,7 @@ leadership:
       github: 'https://github.com/kalyaniraman'
     picture: https://avatars.githubusercontent.com/kalyaniraman
   - name: Ambareen Sultana
+    github-handle:
     role: Product Manager
     links:
       slack: 'https://hackforla.slack.com/team/U03FQ1BBGP4'


### PR DESCRIPTION
Fixes #7432 

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Added `github-handle` to Ambareen Sultana's section.

### Why did you make the changes (we will use this info to test)?
  - Building up to reduce redundancy in project data by eventually replacing existing `github` and `picture` variables.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
  - No visual changes to the website

