### PR TITLE
Fix tool name inconsistency

### DIFF
--- a/_projects/open-community-survey.md
+++ b/_projects/open-community-survey.md
@@ -66,7 +66,7 @@ location:
   - Remote
 partner: 'LA Department of Neighborhood Empowerment (DONE), LA Neighborhood Councils (NCs), LA Department of Transportation (LADOT), LA City Planning Department (LACP)'
 tools:
-  - ArcGIS surveys
+  - ArcGIS Survey123
   - Figma
   - Google Docs
   - Zoom


### PR DESCRIPTION
Fixes #8573

### What changes did you make?
  - Updated `ArcGIS surveys` to `ArcGIS Survey123` under the `tools` variable.
 
### Why did you make the changes (we will use this info to test)?
  - To keep the tools information up-to-date for people who visit the HackforLA website.
  - To update the filter as well so visitors can filter based on specific tools.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)

<details>
<summary>Before Screenshot from Projects page with filter: ArcGIS surveys</summary>

<img width="1161" height="1315" alt="Screenshot 2026-08-24 at 6 07 43 PM" src="https://github.com/user-attachments/assets/3d467391-bd93-4b13-aed8-86eafd15078b" />

</details>

<details>
<summary>Before Screenshot from Open Community Survey Page</summary>


<img width="1161" height="1079" alt="Screenshot 2026-08-24 at 6 08 19 PM" src="https://github.com/user-attachments/assets/1bf3a2d5-05e8-416d-ab25-40025a7d85d1" />

</details>

<details>
<summary>After Screenshot from Projects page with filter: ArcGIS Survey123</summary>
  

<img width="1161" height="1313" alt="Screenshot 2026-08-24 at 6 10 05 PM" src="https://github.com/user-attachments/assets/3c0fa6a7-be81-4085-b4bb-60bb8d2b84af" />

</details>

<details>
<summary>After Screenshot from Open Community Survey Page</summary>
 
<img width="1161" height="1113" alt="Screenshot 2026-08-24 at 6 03 55 PM" src="https://github.com/user-attachments/assets/f84c25af-b326-45fe-9533-b4c04b2c44f0" />

</details>

