### PR TITLE
Specify default permissions for pr-verification.yml

### DIFF
--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+    contents: read
+
 jobs:
   Check-Team-Membership:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #8585

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - added top level permissions block according to the issue #8585 : `content: read`

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To align with GitHub security best practices, we want to specify the minimum required permissions for each workflow via a top-level permissions: block to ensure that workflows only have the access they need by default.

<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 
 - No visual changes to the website
 - I tested the workflow on my forked repo - [successfully ran test log](https://github.com/Tomomi-K1/website/actions/runs/32807136468/job/97681443279) 

I can confirmed now GITHUB_TOKEN has limited permissions in the test log.   
<img width="525" height="90" alt="image" src="https://github.com/user-attachments/assets/76b713a5-3875-4c09-8c41-6c42a9981970" />

before change I see these permissions under setup step of the log:
<img width="478" height="423" alt="image" src="https://github.com/user-attachments/assets/8ce48287-02ed-4f00-a833-cf3aeda8f30e" />


