### PR TITLE
Refactor wins workflow for current project board

### DIFF
--- a/google-apps-scripts/gh-requests/Code.js
+++ b/google-apps-scripts/gh-requests/Code.js
@@ -157,7 +157,6 @@ function setToken_() {
   }
  
   const doc = DocumentApp.openById(id);
-  console.log(documentProperties.getProperty(`TOKEN`));
   documentProperties.setProperty('TOKEN', doc.getBody().getText());
 }
 

--- a/google-apps-scripts/gh-requests/Code.js
+++ b/google-apps-scripts/gh-requests/Code.js
@@ -7,7 +7,6 @@
 const documentProperties = PropertiesService.getDocumentProperties();
 const ACCEPT_HEADER = {
   "Repository": "application/vnd.github.v3+json",
-  "ProjectBoard": "application/vnd.github.inertia-preview+json"
 }
 
 /************************************************** FUNCTIONS USING THE FETCH REQUESTS ********************************************************************/
@@ -94,23 +93,54 @@ function createIssue() {
   return response;
 }
 
-// Adds an issue to a project board column
-function addIssueToProjectBoardColumn(issueID, columnID) {
-  const payload = {
-    "note": null,
-    "content_id": parseInt(issueID),
-    "content_type": "Issue", // new-win-submission
-  };
-  const url = `https://api.github.com/projects/columns/${columnID}/cards`;
-  const response = postRequest_(url, ACCEPT_HEADER.ProjectBoard, payload);
+// Adds an issue to a Projects v2 board and sets its Status field
+function addIssueToProjectV2(issueNodeId, projectId, statusFieldId, statusOptionId) {
+  const addItemMutation = `
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId })
+      {
+        item { id }
+      }
+    }`;
+  
+  const addItemData = graphqlRequest_(addItemMutation, {
+    projectId: projectId,
+    contentId: issueNodeId,
+  });
 
-    if (response === false ) {
-    console.log(`Adding issue to project board column failed.`)
+  if (addItemData === false) {
+    console.log("Adding issue to project board failed.");
     return false;
   }
 
-  console.log(`Adding issue to project board column succeeded. Project card ${response.body.id}`);
-  return response;
+  const itemId = addItemData.addProjectV2ItemById.item.id;
+
+  const updateStatusMutation = `
+    mutation($projectId: ID!, $fieldId: ID!, $itemId: ID!, $value: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId,
+        fieldId: $fieldId,
+        itemId: $itemId,
+        value: { singleSelectOptionId: $value }
+      }) {
+        projectV2Item { id }
+      }
+    }`;
+
+  const updateStatusData = graphqlRequest_(updateStatusMutation, {
+    projectId: projectId,
+    fieldId: statusFieldId,
+    itemId: itemId,
+    value: statusOptionId,
+  });
+
+  if (updateStatusData === false) {
+    console.log("Setting project Status field failed.");
+    return false;
+  }
+
+  console.log(`Issue added to project board. Project item ${itemId}`);
+  return updateStatusData;
 }
 
 /************************************************** TOKEN RETRIEVAL ********************************************************************/
@@ -125,10 +155,10 @@ function setToken_() {
       id = file.getId();
     }
   }
-  
+ 
   const doc = DocumentApp.openById(id);
+  console.log(documentProperties.getProperty(`TOKEN`));
   documentProperties.setProperty('TOKEN', doc.getBody().getText());
-  console.log(documentProperties.getProperty(`TOKEN`))
 }
 
 // Uses base64 to decode an input
@@ -194,7 +224,7 @@ function putRequest_(url, acceptHeader, payload) {
     console.log(`Error Status Code ${responseObject.status}: \n${JSON.stringify(responseObject.body)}`);
     return false;
   }
-  
+ 
 }
 
 // GitHub POST request
@@ -225,4 +255,33 @@ function postRequest_(url, acceptHeader, payload) {
     console.log(`Error Status Code ${responseObject.status}: \n${JSON.stringify(responseObject.body)}`);
     return false;
   }
+}
+
+const GRAPHQL_URL = "https://api.github.com/graphql";
+
+// GitHub GraphQL request
+function graphqlRequest_(query, variables) {
+  setToken_();
+  const options = {
+    method: "POST",
+    contentType: "application/json",
+    headers: {
+      Authorization: `Bearer ${decode(documentProperties.getProperty("TOKEN"))}`,
+    },
+    payload: JSON.stringify({ query, variables }),
+    muteHttpExceptions: true,
+  };
+
+  const response = UrlFetchApp.fetch(GRAPHQL_URL, options);
+  const body = JSON.parse(response.getContentText());
+
+  if (response.getResponseCode() === 200 && !body.errors) {
+    console.log("GraphQL request succeeded.\n");
+    return body.data
+  } 
+  else {
+    console.log(`GraphQL request failed (${response.getResponseCode()}):\n${JSON.stringify(body.errors || body)}`);
+    return false;
+  }
+
 }

--- a/google-apps-scripts/wins-form-responses/Code.js
+++ b/google-apps-scripts/wins-form-responses/Code.js
@@ -8,12 +8,11 @@
  *    - These are "On Form Submit" triggers which calls createIssue and insertLatestFormSubmitIntoReviewSheet
  * 
  * Resources:
- *    1. Ice Box                   = https://github.com/hackforla/website/projects/7#column-7198227
- *    2. Prioritized Backlog       = https://github.com/hackforla/website/projects/7#column-7198257
- *    3. In Progress               = https://github.com/hackforla/website/projects/7#column-7198228
- *    4. Links/Questions/In Review = https://github.com/hackforla/website/projects/7#column-8178690
- *    6. Link to "Review" sheet    = https://docs.google.com/spreadsheets/d/1tj6eQlVLFgmskoXouVt87POxYVwR1yWT2vOSQEPyDtg/edit#gid=1706218917
- *    7. Link to "Responses" sheet = https://docs.google.com/spreadsheets/d/1tj6eQlVLFgmskoXouVt87POxYVwR1yWT2vOSQEPyDtg/edit?resourcekey#gid=1106372497
+ *    1. Project board (Project 86) = https://github.com/orgs/hackforla/projects/86
+ *    2. Target status for new wins issues i.e. "Questions / In Review", replaces column keys from old projects board
+ *       (GraphQL IDs in PROJECT_V2: github-actions/utils/_data/status-field-ids.js)
+ *    3. Link to "Review" sheet    = https://docs.google.com/spreadsheets/d/1tj6eQlVLFgmskoXouVt87POxYVwR1yWT2vOSQEPyDtg/edit#gid=1706218917
+ *    4. Link to "Responses" sheet = https://docs.google.com/spreadsheets/d/1tj6eQlVLFgmskoXouVt87POxYVwR1yWT2vOSQEPyDtg/edit?resourcekey#gid=1106372497
  */
 
 
@@ -25,13 +24,17 @@ const ISSUE_TEMPLATE = {
   "labels": []
 }
 
-const COLUMN_KEYS = {
-  "IceBox": 7198227,
-  "NewIssueApproval": 15235217,
-  "PrioritizedBacklog": 7198257,
-  "InProgress": 7198228,
-  "InReview": 8178690
-}
+const PROJECT_V2 = {
+  PROJECT_ID: "PVT_kwDOALGKNs4Ajuck",
+  STATUS_FIELD_ID: "PVTSSF_lADOALGKNs4AjuckzgcCutQ",
+  STATUS: {
+    IceBox: "2b49cbab",
+    NewIssueApproval: "83187325",
+    PrioritizedBacklog: "434304a8",
+    InProgress: "9a878e9c",
+    InReview: "53b56f8d",
+  },
+};
 
 /************************************************** TRIGGER(Time Based) 1 SECTION ********************************************************************/
 /*
@@ -52,8 +55,13 @@ function main() {
     row.push(i + 1);
   });
 
-  // Filter out only the rows where display-column(colum 15) is set to true
-  const filteredRows = Array.from(allRows).filter(win => win[15] === true);
+  // Filter out only the rows where display-column (column 15) is set to true
+  const display = columnHeaders.indexOf("Display?");
+  if (display == -1) {
+    console.log("Ending script; Display column not found.");
+    return 1;
+  }
+  const filteredRows = Array.from(allRows).filter(win => win[display] === true);
 
   // Create an array of objects (key-value pair) based on the column headers and rows of values so the data does not need to be formatted later in GitHub
   const keyValueData = filteredRows.map(row => {
@@ -116,11 +124,21 @@ function main() {
 function createIssue(e) {
   const issueResponse = ghrequests.createIssue();
   if (issueResponse === false) {
-    console.log('Ending script...')
+    console.log('Ending script...');
     return 1;
   }
 
-  ghrequests.addIssueToProjectBoardColumn(issueResponse.body.id, COLUMN_KEYS["InReview"]);
+  const addToProjectResponse = ghrequests.addIssueToProjectV2(
+    issueResponse.body.node_id,
+    PROJECT_V2.PROJECT_ID,
+    PROJECT_V2.STATUS_FIELD_ID,
+    PROJECT_V2.STATUS.InReview
+  );
+
+  if (addToProjectResponse === false) {
+    console.log('Ending script...');
+    return 1;
+  }
 }
 
 /************************************************** TRIGGER("On Form Submit") 3 SECTION ********************************************************************/
@@ -204,7 +222,7 @@ function insertLatestFormSubmitIntoReviewSheet(formSubmitEvent){
   
   // Set the column 'Q'  for new row created in the 'Responses' sheet by form submission to be mapped to the new row created in the 'review' sheet
   responsesSheet.getRange(formDataInsertedAt.rowStart, formDataInsertedAt.columnEnd + 2).setFormula("=Review!B2");
-  }
+}
 
 /***************************************************************** DEBUGGING (run manually) *************************************************/
 /**
@@ -329,6 +347,3 @@ function compareResponsesAndReview() {
   }
 
 }
-
-  
-


### PR DESCRIPTION
Fixes #8701 

### What changes did you make?
  - gh-requests/Code.js:
    - Replace `addIssueToProjectBoardColumn` function with `addIssueToProjectV2` to post issues to the current project board using a GraphQL API call 
    - Create a `graphqlRequest_ ` helper function to build an API call. It mirrors the existing `postRequest_ ` function
    - Remove any console output of GitHub PAT to avoid leaking sensitive keys
  - wins-form-responses/Code.js:
    - Update docs comment to point to `github-actions/utils/_data/status-field-ids.js` for accuracy
    - Replace outdated `COLUMN_KEYS` with `PROJECT_V2` object literal, which connects to current project board
    - Update previously hardcoded display-column filter in order to maintain PR creation 
    - In `createIssue` replace `addIssueToProjectBoardColumn` with call to `addIssueToProjectV2`
 

### Why did you make the changes (we will use this info to test)?
  - To keep the Wins workflow up to date by notifying the team of any new Wins submissions via automated issue and PR creation
  - Why shift to GraphQL?: GitHub previously used REST for any Project Board API calls. However, they rolled out a new Projects v2 feature that requires GraphQL. Hack for LA uses a Projects v2 board, and because the older flow relied [on deprecated Projects classic code,](https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/) the automated notification workflow stopped working.
  - As for why the change to the hardcoded display-column filter was made, Danielle proposed the change and why [in the original issue](https://github.com/hackforla/website/issues/8701#issuecomment-5562960566).

### Testing Setup/Strategy
 - Following the [Wins Google Apps Script Development Guide](https://docs.google.com/document/d/12ARuJ3S6MTS11-sMEZZTEweJB43-4tL6EU0IrMsWuM4/edit?usp=drivesdk), I created copies of the Wins responses Sheet & gh-requests Apps Scripts
 - In order to test the Wins workflow, I replaced any points that touch Hack for LA's project boards and the `elizabethhonest` account with my fork's project board IDs and my own GitHub handle respectively
 - This was the following testing flow I used ([as per section `8. Testing` of the guide](https://docs.google.com/document/d/12ARuJ3S6MTS11-sMEZZTEweJB43-4tL6EU0IrMsWuM4/edit?tab=t.0#heading=h.xo6k7xjhe2gk)):
   - On my fork, create an `update-wins-data` branch to receive Wins submissions / data from Google Apps Script.
   - Then create a `test-wins` branch to act as the base for PRs in place of `gh-pages`
   - Submit a Win via my copy of the Wins Google Form
   - Ensure for every Wins submission, an issue is created in my fork, for example: https://github.com/castillios/website/issues/35 
   - Run main() on `wins-form-response/Code.js` via Google Apps Script to create a PR on my fork: (https://github.com/castillios/website/pull/36).
- Then, I merged the test PR into `test-wins` and viewed the website to ensure that test Wins populate the page as intended (screenshot attached below)


<h3>CodeQL Alerts</h3>


After the PR has been submitted and the resulting GitHub actions/checks have been completed, developers should check the PR for CodeQL alert annotations.


<details><summary>Check the PR's comments. If present on your PR, the CodeQL alert looks similar as shown</summary>
  
![Screenshot 2024-10-28 154514](https://github.com/user-attachments/assets/ea66c586-c14c-45fd-8705-1c116224e704)


</details>

Please let us know that you have checked for CodeQL alerts. **Please do not dismiss alerts.**
- [x] I have checked this PR for CodeQL alerts and none were found.
- [ ] I found CodeQL alert(s), and (select one):
   - [ ] I have resolved the CodeQL alert(s) as noted
   - [ ] I believe the CodeQL alert(s) is a false positive (Merge Team will evaluate)
   - [ ] I have followed the Instructions below, but I am still stuck (Merge Team will evaluate)

<details><summary>Instructions for resolving CodeQL alerts</summary>

If CodeQL alert/annotations appear, refer to [How to Resolve CodeQL alerts](https://github.com/hackforla/website/issues/6463#issuecomment-2002573270).  

In general, CodeQL alerts should be resolved prior to PR reviews and merging

</details>

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
Note: These are NOT current changes to the website, rather the screenshots below are examples of what the changes WOULD look like after the refactor using test Wins.

<details>
<summary>Example of Wins Page</summary>
<img width="1440" height="776" alt="image" src="https://github.com/user-attachments/assets/54a44a1b-3301-4e6f-83ec-e0136e2a477a" />
</details>

<details>
<summary>Wins test submissions via Google Sheets</summary>
I've highlighted the Wins overview to emphasize these are the same submissions displayed in the example above:
<img width="886" height="391" alt="image" src="https://github.com/user-attachments/assets/8f36f8b6-2a79-458f-9c69-cc91df5da8bc" />
</details>
